### PR TITLE
feat(askola): replace Ask Ola button with History and Settings on Ask Ola page

### DIFF
--- a/frontend/src/apps/Header/HeaderContainer.jsx
+++ b/frontend/src/apps/Header/HeaderContainer.jsx
@@ -26,6 +26,8 @@ import {
   SettingOutlined,
   UserOutlined,
   CheckSquareOutlined,
+  HistoryOutlined,
+  EllipsisOutlined,
 } from '@ant-design/icons';
 
 const PAGE_MAP = {
@@ -89,14 +91,32 @@ export default function HeaderContent() {
       </div>
 
       <div className="header-right-actions">
-        <button className="header-action-btn">
-          <QuestionCircleOutlined />
-          <span>Help</span>
-        </button>
-        <button className="header-action-btn header-action-btn--ola">
-          <SmileOutlined />
-          <span>Ask Ola</span>
-        </button>
+        {location.pathname === '/askola' ? (
+          <>
+            <button className="header-action-btn">
+              <QuestionCircleOutlined />
+              <span>Help</span>
+            </button>
+            <button className="header-action-btn header-action-btn--ola">
+              <HistoryOutlined />
+              <span>History</span>
+            </button>
+            <button className="header-action-btn" style={{ padding: '0 8px', minWidth: 'auto', border: 'none', background: 'transparent', boxShadow: 'none' }}>
+              <EllipsisOutlined rotate={90} style={{ fontSize: '18px', color: '#8c8c8c' }} />
+            </button>
+          </>
+        ) : (
+          <>
+            <button className="header-action-btn">
+              <QuestionCircleOutlined />
+              <span>Help</span>
+            </button>
+            <button className="header-action-btn header-action-btn--ola">
+              <SmileOutlined />
+              <span>Ask Ola</span>
+            </button>
+          </>
+        )}
       </div>
     </Header>
   );


### PR DESCRIPTION
## 改动内容

- 在 Ask Ola 页面将右上角的 Ask Ola 按钮替换为 History 按钮并保留原有样式
- 增加了靠右并排的 Settings 按钮

## 验证

- [x] 本地测试通过
- [x] 不破坏现有功能