### PR TITLE
style(layout): implement global edge-to-edge layout for CRUD & ERP modules while insulating Dashboard and AskOla with distinct legacy metrics

### DIFF
--- a/frontend/src/apps/ErpApp.jsx
+++ b/frontend/src/apps/ErpApp.jsx
@@ -60,10 +60,10 @@ export default function ErpCrmApp() {
             <HeaderContent />
             <Content
               style={{
-                margin: '40px auto 30px',
+                margin: '0 auto',
                 overflow: 'initial',
                 width: '100%',
-                padding: '0 25px',
+                padding: '0 10px',
                 maxWidth: 'none',
               }}
             >
@@ -80,11 +80,11 @@ export default function ErpCrmApp() {
             <HeaderContent />
             <Content
               style={{
-                margin: '40px auto 30px',
+                margin: '0 auto',
                 overflow: 'initial',
                 width: '100%',
-                padding: '0 40px',
-                maxWidth: 1200,
+                padding: '0 10px',
+                maxWidth: 'none',
               }}
             >
               <AppRouter />

--- a/frontend/src/layout/CrudLayout/index.jsx
+++ b/frontend/src/layout/CrudLayout/index.jsx
@@ -38,12 +38,14 @@ const ContentBox = ({ children }) => {
   // }, [isNavMenuClose]);
   return (
     <Content
-      className="whiteBox shadow layoutPadding"
+      className="whiteBox"
       style={{
-        margin: '24px auto',
+        margin: '0 auto',
+        padding: '0 10px',
         width: '100%',
         maxWidth: '100%',
         flex: 'none',
+        borderRadius: 0,
       }}
     >
       {children}

--- a/frontend/src/layout/ErpLayout/index.jsx
+++ b/frontend/src/layout/ErpLayout/index.jsx
@@ -9,12 +9,14 @@ export default function ErpLayout({ children }) {
   return (
     <ErpContextProvider>
       <Content
-        className="whiteBox shadow layoutPadding"
+        className="whiteBox"
         style={{
-          margin: '30px auto',
+          margin: '0 auto',
+          padding: '0 10px',
           width: '100%',
-          maxWidth: '1100px',
+          maxWidth: 'none',
           minHeight: '600px',
+          borderRadius: 0,
         }}
       >
         {children}

--- a/frontend/src/pages/AskOla.jsx
+++ b/frontend/src/pages/AskOla.jsx
@@ -45,7 +45,15 @@ export default function AskOla() {
   }, [plusMenuOpen]);
 
   return (
-    <div className="askola-chat-page">
+    <div
+      style={{
+        margin: '40px auto 30px',
+        padding: '0 40px',
+        maxWidth: 1200,
+        width: '100%',
+      }}
+    >
+      <div className="askola-chat-page">
       {/* Center greeting */}
       <div className="askola-chat-center">
         <h1 className="askola-chat-greeting">What's on the agenda today?</h1>
@@ -93,6 +101,7 @@ export default function AskOla() {
           </button>
         </div>
       </div>
+    </div>
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,4 +1,15 @@
 import DashboardModule from '@/modules/DashboardModule';
 export default function Dashboard() {
-  return <DashboardModule />;
+  return (
+    <div
+      style={{
+        margin: '40px auto 30px',
+        padding: '0 40px',
+        maxWidth: 1200,
+        width: '100%',
+      }}
+    >
+      <DashboardModule />
+    </div>
+  );
 }


### PR DESCRIPTION
## 改动内容
- 解除了 ErpApp 和 CrudLayout 的 40px 内外边框束缚，让 Invoice、Quote、Purchase Orders、Payment 及 Merchandise 等全业务模块实现了“无界全面屏”填充效果（边距缩小至仅 1cm 防文字贴边）。
- 对 Dashboard 和 AskOla 界面做特殊的 Padding 包裹解耦隔离，使其不受全屏化影响，原生保留了舒适、剧中的 1200px 及安全边距设计。

## 验证
- [x] 本地视觉审查无误
- [x] 不破坏原有的业务及状态保留