### PR TITLE
feat: quality polish — quote.create warnings[] + Joi 错误中文化 (#56 #58)

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/schemaValidate.js
+++ b/backend/src/controllers/appControllers/invoiceController/schemaValidate.js
@@ -1,39 +1,193 @@
 const Joi = require('joi');
+
+// 错误信息中文化 — 同 quoteController/schemaValidate.js 的设计理念：
+// 不暴露 Joi path 语法（notes[0] / items[0].price），面向用户而非开发者。
 const schema = Joi.object({
-  client: Joi.alternatives().try(Joi.string(), Joi.object()).required(),
-  number: Joi.alternatives().try(Joi.string(), Joi.number()).required(),
-  year: Joi.number().required(),
-  status: Joi.string().required(),
-  notes: Joi.array().items(Joi.string()).default([]),
-  termsOfDelivery: Joi.array().items(Joi.string()).default([]),
-  shippingMark: Joi.array().items(Joi.string()).default([]),
-  paymentTerms: Joi.array().items(Joi.string()).default([]),
-  bankDetails: Joi.string().allow('').default(''),
-  packaging: Joi.array().items(Joi.string()).default([]),
-  shipmentDocuments: Joi.array().items(Joi.string()).default([]),
-  expiredDate: Joi.date().required(),
-  date: Joi.date().required(),
-  currency: Joi.string().allow(''),
-  relatedPurchaseOrders: Joi.array().items(Joi.string()).optional(),
-  freight: Joi.number().default(0),
-  discount: Joi.number().default(0),
-  // array cannot be empty
+  client: Joi.alternatives()
+    .try(Joi.string(), Joi.object())
+    .required()
+    .messages({
+      'any.required': '请选择客户',
+      'alternatives.match': '客户字段格式不正确',
+    }),
+  number: Joi.alternatives()
+    .try(Joi.string(), Joi.number())
+    .required()
+    .messages({
+      'any.required': '请填写发票编号',
+      'alternatives.match': '发票编号格式不正确',
+    }),
+  year: Joi.number()
+    .required()
+    .messages({
+      'any.required': '请填写年份',
+      'number.base': '年份必须是数字',
+    }),
+  status: Joi.string()
+    .required()
+    .messages({
+      'any.required': '请选择发票状态',
+      'string.base': '发票状态必须是文字',
+      'string.empty': '请选择发票状态',
+    }),
+  notes: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '备注项必须是文字',
+        'string.empty': '请填写备注内容或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '备注必须是数组',
+    }),
+  termsOfDelivery: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '交付条款项必须是文字',
+        'string.empty': '请填写交付条款或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '交付条款必须是数组',
+    }),
+  shippingMark: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '唛头项必须是文字',
+        'string.empty': '请填写唛头或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '唛头必须是数组',
+    }),
+  paymentTerms: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '付款条款项必须是文字',
+        'string.empty': '请填写付款条款或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '付款条款必须是数组',
+    }),
+  bankDetails: Joi.string()
+    .allow('')
+    .default('')
+    .messages({
+      'string.base': '银行账户信息必须是文字',
+    }),
+  packaging: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '包装说明项必须是文字',
+        'string.empty': '请填写包装说明或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '包装说明必须是数组',
+    }),
+  shipmentDocuments: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '出货单据项必须是文字',
+        'string.empty': '请填写出货单据或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '出货单据必须是数组',
+    }),
+  expiredDate: Joi.date()
+    .required()
+    .messages({
+      'any.required': '请填写有效期',
+      'date.base': '有效期必须是有效的日期',
+    }),
+  date: Joi.date()
+    .required()
+    .messages({
+      'any.required': '请填写发票日期',
+      'date.base': '发票日期必须是有效的日期',
+    }),
+  currency: Joi.string()
+    .allow('')
+    .messages({
+      'string.base': '币种必须是文字',
+    }),
+  relatedPurchaseOrders: Joi.array()
+    .items(Joi.string())
+    .optional()
+    .messages({
+      'array.base': '关联采购单必须是数组',
+    }),
+  freight: Joi.number()
+    .default(0)
+    .messages({
+      'number.base': '运费必须是数字',
+    }),
+  discount: Joi.number()
+    .default(0)
+    .messages({
+      'number.base': '折扣必须是数字',
+    }),
   items: Joi.array()
     .items(
       Joi.object({
         _id: Joi.string().allow('').optional(),
-        itemName: Joi.string().required(),
+        itemName: Joi.string()
+          .required()
+          .messages({
+            'any.required': '产品 SKU / 编号为必填',
+            'string.empty': '产品 SKU / 编号不能为空',
+            'string.base': '产品 SKU / 编号必须是文字',
+          }),
         description: Joi.string().allow(''),
         laser: Joi.string().allow(''),
-        quantity: Joi.number().required(),
-        price: Joi.number().required(),
-        total: Joi.number().required(),
+        quantity: Joi.number()
+          .required()
+          .messages({
+            'any.required': '产品数量为必填',
+            'number.base': '产品数量必须是数字',
+          }),
+        price: Joi.number()
+          .required()
+          .messages({
+            'any.required': '产品单价为必填',
+            'number.base': '产品单价必须是数字',
+          }),
+        total: Joi.number()
+          .required()
+          .messages({
+            'any.required': '产品小计为必填',
+            'number.base': '产品小计必须是数字',
+          }),
         unit_en: Joi.string().allow(''),
         unit_cn: Joi.string().allow(''),
-      }).required()
+      })
+        .required()
+        .messages({
+          'object.base': '产品项格式不正确',
+        }),
     )
-    .required(),
-  taxRate: Joi.alternatives().try(Joi.number(), Joi.string()).default(0),
+    .min(1)
+    .required()
+    .messages({
+      'any.required': '发票必须至少包含一个产品',
+      'array.min': '发票必须至少包含一个产品',
+      'array.base': '产品列表格式不正确',
+      'array.includesRequiredUnknowns': '发票必须至少包含一个产品',
+    }),
+  taxRate: Joi.alternatives()
+    .try(Joi.number(), Joi.string())
+    .default(0)
+    .messages({
+      'alternatives.match': '税率格式不正确',
+    }),
 });
 
 module.exports = schema;

--- a/backend/src/controllers/appControllers/quoteController/schemaValidate.js
+++ b/backend/src/controllers/appControllers/quoteController/schemaValidate.js
@@ -1,35 +1,161 @@
 const Joi = require('joi');
+
+// 所有 Joi 错误信息强制中文输出：
+// - 避免把 path 语法（如 "notes[0]" / "items[0].price"）暴露给非技术用户
+// - 前端 Form.List / Form.Item 的 rules 是第一道防线；此处是兜底
+// - 单条消息尽量自带字段语义（哪一项出错、期望什么）
 const schema = Joi.object({
-  client: Joi.alternatives().try(Joi.string(), Joi.object()).required(),
-  number: Joi.alternatives().try(Joi.string(), Joi.number()).required(),
-  year: Joi.number().required(),
-  status: Joi.string().required(),
-  notes: Joi.array().items(Joi.string()).default([]),
-  termsOfDelivery: Joi.array().items(Joi.string()).default([]),
-  paymentTerms: Joi.array().items(Joi.string()).default([]),
-  expiredDate: Joi.date().required(),
-  date: Joi.date().required(),
-  currency: Joi.string().valid('USD', 'CNY').required(),
-  exchangeRate: Joi.number().positive().default(1),
-  freight: Joi.number().default(0),
-  discount: Joi.number().default(0),
-  // array cannot be empty
+  client: Joi.alternatives()
+    .try(Joi.string(), Joi.object())
+    .required()
+    .messages({
+      'any.required': '请选择客户',
+      'alternatives.match': '客户字段格式不正确',
+    }),
+  number: Joi.alternatives()
+    .try(Joi.string(), Joi.number())
+    .required()
+    .messages({
+      'any.required': '请填写报价单编号',
+      'alternatives.match': '报价单编号格式不正确',
+    }),
+  year: Joi.number()
+    .required()
+    .messages({
+      'any.required': '请填写年份',
+      'number.base': '年份必须是数字',
+    }),
+  status: Joi.string()
+    .required()
+    .messages({
+      'any.required': '请选择报价状态',
+      'string.base': '报价状态必须是文字',
+      'string.empty': '请选择报价状态',
+    }),
+  notes: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '备注项必须是文字',
+        'string.empty': '请填写备注内容或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '备注必须是数组',
+    }),
+  termsOfDelivery: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '交付条款项必须是文字',
+        'string.empty': '请填写交付条款或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '交付条款必须是数组',
+    }),
+  paymentTerms: Joi.array()
+    .items(
+      Joi.string().messages({
+        'string.base': '付款条款项必须是文字',
+        'string.empty': '请填写付款条款或删除该项',
+      }),
+    )
+    .default([])
+    .messages({
+      'array.base': '付款条款必须是数组',
+    }),
+  expiredDate: Joi.date()
+    .required()
+    .messages({
+      'any.required': '请填写有效期',
+      'date.base': '有效期必须是有效的日期',
+    }),
+  date: Joi.date()
+    .required()
+    .messages({
+      'any.required': '请填写报价日期',
+      'date.base': '报价日期必须是有效的日期',
+    }),
+  currency: Joi.string()
+    .valid('USD', 'CNY')
+    .required()
+    .messages({
+      'any.required': '请选择币种',
+      'any.only': '币种只能是 USD 或 CNY',
+      'string.base': '币种必须是文字',
+      'string.empty': '请选择币种',
+    }),
+  exchangeRate: Joi.number()
+    .positive()
+    .default(1)
+    .messages({
+      'number.base': '汇率必须是数字',
+      'number.positive': '汇率必须大于 0',
+    }),
+  freight: Joi.number()
+    .default(0)
+    .messages({
+      'number.base': '运费必须是数字',
+    }),
+  discount: Joi.number()
+    .default(0)
+    .messages({
+      'number.base': '折扣必须是数字',
+    }),
   items: Joi.array()
     .items(
       Joi.object({
         _id: Joi.string().allow('').optional(),
-        itemName: Joi.string().required(),
+        itemName: Joi.string()
+          .required()
+          .messages({
+            'any.required': '产品 SKU / 编号为必填',
+            'string.empty': '产品 SKU / 编号不能为空',
+            'string.base': '产品 SKU / 编号必须是文字',
+          }),
         description: Joi.string().allow(''),
         laser: Joi.string().allow(''),
-        quantity: Joi.number().required(),
-        price: Joi.number().required(),
-        total: Joi.number().required(),
+        quantity: Joi.number()
+          .required()
+          .messages({
+            'any.required': '产品数量为必填',
+            'number.base': '产品数量必须是数字',
+          }),
+        price: Joi.number()
+          .required()
+          .messages({
+            'any.required': '产品单价为必填',
+            'number.base': '产品单价必须是数字',
+          }),
+        total: Joi.number()
+          .required()
+          .messages({
+            'any.required': '产品小计为必填',
+            'number.base': '产品小计必须是数字',
+          }),
         unit_en: Joi.string().allow(''),
         unit_cn: Joi.string().allow(''),
-      }).required()
+      })
+        .required()
+        .messages({
+          'object.base': '产品项格式不正确',
+        }),
     )
-    .required(),
-  taxRate: Joi.alternatives().try(Joi.number(), Joi.string()).default(0),
+    .min(1)
+    .required()
+    .messages({
+      'any.required': '报价单必须至少包含一个产品',
+      'array.min': '报价单必须至少包含一个产品',
+      'array.base': '产品列表格式不正确',
+      'array.includesRequiredUnknowns': '报价单必须至少包含一个产品',
+    }),
+  taxRate: Joi.alternatives()
+    .try(Joi.number(), Joi.string())
+    .default(0)
+    .messages({
+      'alternatives.match': '税率格式不正确',
+    }),
 });
 
-module.exports = schema; 
+module.exports = schema;

--- a/backend/src/mcp/tools/crud/quote.js
+++ b/backend/src/mcp/tools/crud/quote.js
@@ -31,23 +31,50 @@ const { getSystemAdmin } = require('../../bootstrap');
 // CN preferred, falls back to EN. Items where the Agent already provided
 // a description are left untouched. Items whose itemName doesn't match
 // any Merch are also left untouched (no silent failure, no fabrication).
+//
+// Returns `{items, warnings}`. `warnings[]` is non-empty whenever an item
+// ended up with a blank description that the salesperson will have to
+// back-fill manually — either because the serialNumber wasn't found or
+// because the Merch record itself has no description. The caller surfaces
+// these into the MCP envelope so the Agent can read them verbatim to the
+// salesperson (per SOUL.md). Never silent — see issue #58.
 async function enrichItemDescriptions(items) {
   const Merch = mongoose.model('Merch');
-  const serialNumbers = items
+  const warnings = [];
+
+  const serialNumbersToLookUp = items
     .filter((it) => !it.description && it.itemName)
     .map((it) => it.itemName);
-  if (serialNumbers.length === 0) return items;
+
+  if (serialNumbersToLookUp.length === 0) {
+    return { items, warnings };
+  }
+
   const merchDocs = await Merch.find({
-    serialNumber: { $in: serialNumbers },
+    serialNumber: { $in: serialNumbersToLookUp },
     removed: false,
   }).lean();
   const bySerial = new Map(merchDocs.map((m) => [m.serialNumber, m]));
-  return items.map((it) => {
+
+  const enriched = items.map((it) => {
     if (it.description) return it;
     const m = bySerial.get(it.itemName);
-    if (!m) return it;
-    return { ...it, description: m.description_cn || m.description_en || '' };
+    if (!m) {
+      warnings.push(
+        `${it.itemName}: 未在 Merch 中匹配到 serialNumber — 描述和单位均留空`,
+      );
+      return it;
+    }
+    const description = m.description_cn || m.description_en || '';
+    if (!description) {
+      warnings.push(
+        `${it.itemName}: 在 Merch 中找到，但 description_cn / description_en 均为空 — 描述字段留空`,
+      );
+    }
+    return { ...it, description };
   });
+
+  return { items: enriched, warnings };
 }
 
 async function call(method, input) {
@@ -132,7 +159,9 @@ const create = {
       unit_en: it.unit_en || '',
       unit_cn: it.unit_cn || '',
     }));
-    items = await enrichItemDescriptions(items);
+    const enrichResult = await enrichItemDescriptions(items);
+    items = enrichResult.items;
+    const warnings = enrichResult.warnings;
 
     const now = new Date();
     const body = {
@@ -152,7 +181,11 @@ const create = {
     };
     if (input.exchangeRate !== undefined) body.exchangeRate = input.exchangeRate;
 
-    return call(quoteController.create, { body });
+    const result = await call(quoteController.create, { body });
+    if (result.ok && warnings.length > 0) {
+      return { ...result, warnings };
+    }
+    return result;
   },
 };
 
@@ -194,7 +227,9 @@ const update = {
       unit_en: it.unit_en || '',
       unit_cn: it.unit_cn || '',
     }));
-    items = await enrichItemDescriptions(items);
+    const enrichResult = await enrichItemDescriptions(items);
+    items = enrichResult.items;
+    const warnings = enrichResult.warnings;
     const now = new Date();
     const body = {
       client: rest.client,
@@ -212,7 +247,11 @@ const update = {
       discount: rest.discount ?? 0,
     };
     if (rest.exchangeRate !== undefined) body.exchangeRate = rest.exchangeRate;
-    return call(quoteController.update, { params: { id }, body });
+    const result = await call(quoteController.update, { params: { id }, body });
+    if (result.ok && warnings.length > 0) {
+      return { ...result, warnings };
+    }
+    return result;
   },
 };
 

--- a/frontend/src/modules/QuoteModule/Forms/QuoteForm.jsx
+++ b/frontend/src/modules/QuoteModule/Forms/QuoteForm.jsx
@@ -355,7 +355,17 @@ function LoadQuoteForm({ subTotal = 0, current = null }) {
                     {fields.map((field, index) => (
                       <Row key={field.key} style={{ marginBottom: '8px' }}>
                         <Col span={22}>
-                          <Form.Item {...field} noStyle>
+                          <Form.Item
+                            {...field}
+                            rules={[
+                              {
+                                required: true,
+                                whitespace: true,
+                                message: '请填写交付条款或删除该行',
+                              },
+                            ]}
+                            style={{ marginBottom: 0 }}
+                          >
                             <Input
                               placeholder={`${translate('Terms of Delivery')} #${index + 1}`}
                               style={{ width: '100%' }}
@@ -399,7 +409,17 @@ function LoadQuoteForm({ subTotal = 0, current = null }) {
                     {fields.map((field, index) => (
                       <Row key={field.key} style={{ marginBottom: '8px' }}>
                         <Col span={22}>
-                          <Form.Item {...field} noStyle>
+                          <Form.Item
+                            {...field}
+                            rules={[
+                              {
+                                required: true,
+                                whitespace: true,
+                                message: '请填写付款条款或删除该行',
+                              },
+                            ]}
+                            style={{ marginBottom: 0 }}
+                          >
                             <Input
                               placeholder={`${translate('Payment Term')} #${index + 1}`}
                               style={{ width: '100%' }}
@@ -444,7 +464,17 @@ function LoadQuoteForm({ subTotal = 0, current = null }) {
                     {fields.map((field, index) => (
                       <Row key={field.key} style={{ marginBottom: '8px' }}>
                         <Col span={22}>
-                          <Form.Item {...field} noStyle>
+                          <Form.Item
+                            {...field}
+                            rules={[
+                              {
+                                required: true,
+                                whitespace: true,
+                                message: '请填写备注内容或删除该行',
+                              },
+                            ]}
+                            style={{ marginBottom: 0 }}
+                          >
                             <Input
                               placeholder={`${translate('Condition')} #${index + 1}`}
                               style={{ width: '100%' }}

--- a/ola/nanobot-workspace/SOUL.md
+++ b/ola/nanobot-workspace/SOUL.md
@@ -98,6 +98,13 @@ instinct in this document.
   the salesperson to **review and save** in the Quotes page. Example:
   > "已生成 draft Q-2026XXXX，total ¥XX,XXX。请到 Quotes 页面 review，
   > 补全空白价格后保存。"
+- **Warnings handling.** If the `quote.create` or `quote.update` response
+  includes a non-empty `warnings[]` array, I read every warning verbatim
+  to the salesperson prefixed with "注意：", **before** the standard
+  review-and-save closing. Never silently swallow warnings. Example:
+  > "已生成 draft Q-2026XXXX，total ¥39,408。
+  > 注意：A-1517 在 Merch 中找到但描述字段为空；PHM-260 未在 Merch 中匹配到，描述和单位都留空。
+  > 请到 Quotes 页面 review，补全这些字段后保存。"
 - The only verbs I use are **review / 检查**, **save / 保存**,
   **edit / 修改**. Never **send / 发送 / 发出 / 发给客户**.
 


### PR DESCRIPTION
两个小优化，#78 merge 后的打磨批次。

## Closes

- #58 `quote.create` warnings[]
- #56 Joi 错误信息对用户不友好

## Commit 1 · `b5d7a22` — `quote.create` warnings[]（#58）

**问题**：agent 传一个没在 Merch 里的 serialNumber 时，quote 照样建出来但 description / unit 列空白，销售完全不知道哪一项匹配失败。

**改动**：
- `backend/src/mcp/tools/crud/quote.js`: `enrichItemDescriptions` 从 `items` 改返 `{items, warnings}`；`quote.create` 和 `quote.update` handler 在 ok 路径下把非空 warnings 合进 MCP 响应 envelope 的 top-level（空数组省略，happy path 无感知）
- `ola/nanobot-workspace/SOUL.md`: "After the quote is created" 小节加 "Warnings handling" rule — 非空时以 "注意：" 前缀逐条读给销售员，不 silent

**两种 warning**：
- `"<SN>: 未在 Merch 中匹配到 serialNumber — 描述和单位均留空"`
- `"<SN>: 在 Merch 中找到，但 description_cn / description_en 均为空 — 描述字段留空"`

**已知限制**：SOUL.md 是 vendored 在 `ola/nanobot-workspace/`；已 provision 过的机器要看到新 rule 得 `rm ~/.nanobot/workspace/SOUL.md && bash start-dev.sh`（SETUP.md 现有 troubleshooting 覆盖了这点）。

## Commit 2 · `62bebce` — Joi 错误中文化（#56）

**问题**：Quote 表单加一行空 note 提交 → 用户看到 `"notes[0]" must be a string`（Joi 原文 + path 语法）。

**改动**：两层防线
- **前端**（`frontend/src/modules/QuoteModule/Forms/QuoteForm.jsx`）: 3 个 Form.List（termsOfDelivery / paymentTerms / notes）内嵌 Input 从 `noStyle` 改成带 `rules: [{required:true, whitespace:true, message:'...'}]` 的正常 Form.Item；空行根本不发请求
- **后端兜底**（`quoteController/schemaValidate.js` + `invoiceController/schemaValidate.js`）: 每字段 `.messages({...})` 全中文，覆盖常见 Joi key：`any.required` / `string.base` / `string.empty` / `number.base` / `array.base` / `array.min` / `array.includesRequiredUnknowns` / `alternatives.match` / `date.base` / `any.only` / `object.base`

**Out of scope**（issue body 里提过但不在本 PR）：
- `register.js` / `onboarding.js` 的同模式属于 auth 流，不同 i18n 语境
- `paymentController` 根本没有 schemaValidate
- 双语 i18n layer — 产品当前纯中文，双语 framework 留后

## 验证

**F1**:
- [x] `node --check backend/src/mcp/tools/crud/quote.js` 通过
- [x] 手读 create + update handler 两处集成点一致
- [ ] 实机端到端待 zyd 测（第二台 mac 需 `rm ~/.nanobot/workspace/SOUL.md && bash start-dev.sh` 才能加载新 SOUL）

**F2**:
- [x] backend 两个 schema `node --check` 通过
- [x] 7 个 case 手测全部中文 + 无 path 泄漏（empty body / currency:'EUR' / items:[] / items:[null] / quantity:'x' / notes:[''] / happy）
- [x] `npx vite build` 2.66s 通过
- [ ] 浏览器实操待 zyd 测（Quote 表单加空 note → 前端红字）

## 风险

- F2 后端 schema 文件改得多（+370 行），若有字段遗漏 `.messages()` 会 fallback 到英文 + path 语法；好在所有 **用户主动填写**的字段都已覆盖（client / items / currency / notes 类）
- F1 MCP envelope 多了 top-level `warnings` key；下游如果有代码假设只有 `{ok, data, message}` 三个 key 可能需要兼容——我扫过 nanobot 侧没这种假设