### PR TITLE
fix: P0 bugs (#82 #83) + serverApiConfig fail-fast (上线前清债)

### DIFF
--- a/backend/src/pdf/Invoice.pug
+++ b/backend/src/pdf/Invoice.pug
@@ -372,8 +372,9 @@ html
           .info-column.company
             p.strong #{settings.company_name || 'Your Company Name'}
             if settings.company_website
-              p 
-                a(href=settings.company_website) #{settings.company_website}
+              - const companyWebsiteUrl = settings.company_website.startsWith('http') ? settings.company_website : 'https://' + settings.company_website
+              p
+                a(href=companyWebsiteUrl target='_blank') #{settings.company_website}
             if settings.company_address
               p #{settings.company_address}
             if settings.company_phone

--- a/backend/src/pdf/Quote.pug
+++ b/backend/src/pdf/Quote.pug
@@ -342,8 +342,9 @@ html
           .info-column.company
             p.strong #{settings.company_name || 'Your Company Name'}
             if settings.company_website
-              p 
-                a(href=settings.company_website) #{settings.company_website}
+              - const companyWebsiteUrl = settings.company_website.startsWith('http') ? settings.company_website : 'https://' + settings.company_website
+              p
+                a(href=companyWebsiteUrl target='_blank') #{settings.company_website}
             if settings.company_address
               p #{settings.company_address}
             if settings.company_phone

--- a/frontend/src/config/serverApiConfig.js
+++ b/frontend/src/config/serverApiConfig.js
@@ -1,50 +1,18 @@
-// Get API URL from environment or use default
-const getApiBaseUrl = () => {
-  if (import.meta.env.VITE_APP_API_URL) {
-    return import.meta.env.VITE_APP_API_URL;
-  }
-  // 确保API路径正确
-  return 'http://localhost:8888/api/';
-};
+const BACKEND_SERVER = import.meta.env.VITE_BACKEND_SERVER;
 
-// API URL 配置
-export const API_BASE_URL = import.meta.env.VITE_APP_API_URL 
-  ? import.meta.env.VITE_APP_API_URL  // 使用环境变量
-  : 'http://localhost:8888/api/';     // 本地开发默认值
+if (!BACKEND_SERVER) {
+  throw new Error(
+    '[serverApiConfig] VITE_BACKEND_SERVER is required. ' +
+      'Set it in frontend/.env for dev (e.g. http://localhost:8888/) ' +
+      'or pass as docker build ARG for prod (e.g. https://app.olajob.cn/).'
+  );
+}
 
-// 添加调试日志
-console.warn('API_BASE_URL is set to:', API_BASE_URL);
+export const BASE_URL = BACKEND_SERVER;
+export const API_BASE_URL = import.meta.env.VITE_APP_API_URL || BACKEND_SERVER + 'api/';
+export const DOWNLOAD_BASE_URL = BACKEND_SERVER + 'download/';
+export const EXCEL_EXPORT_BASE_URL = BACKEND_SERVER + 'export/excel/';
+export const FILE_BASE_URL = import.meta.env.VITE_FILE_BASE_URL || BACKEND_SERVER;
+export const WEBSITE_URL = import.meta.env.VITE_WEBSITE_URL || '';
 
-export const BASE_URL =
-  import.meta.env.PROD || import.meta.env.VITE_DEV_REMOTE
-    ? import.meta.env.VITE_BACKEND_SERVER || 'http://localhost:8888/'
-    : 'http://localhost:8888/';
-
-export const WEBSITE_URL = import.meta.env.PROD
-  ? import.meta.env.VITE_WEBSITE_URL || 'http://localhost:3000/'
-  : 'http://localhost:3000/';
-  
-export const DOWNLOAD_BASE_URL =
-  import.meta.env.PROD || import.meta.env.VITE_DEV_REMOTE
-    ? (import.meta.env.VITE_BACKEND_SERVER || 'http://localhost:8888/') + 'download/'
-    : 'http://localhost:8888/download/';
-
-// Excel导出URL配置
-export const EXCEL_EXPORT_BASE_URL =
-  import.meta.env.PROD || import.meta.env.VITE_DEV_REMOTE
-    ? (import.meta.env.VITE_BACKEND_SERVER || 'http://localhost:8888/') + 'export/excel/'
-    : 'http://localhost:8888/export/excel/';
-    
 export const ACCESS_TOKEN_NAME = 'x-auth-token';
-
-export const FILE_BASE_URL = import.meta.env.VITE_FILE_BASE_URL || 'http://localhost:8888/';
-
-// For debugging
-console.log('API_BASE_URL:', API_BASE_URL);
-console.log('BASE_URL:', BASE_URL);
-console.log('FILE_BASE_URL:', FILE_BASE_URL);
-console.log('EXCEL_EXPORT_BASE_URL:', EXCEL_EXPORT_BASE_URL);
-
-//  console.log(
-//    '🚀 Welcome to Ola ERP CRM!'
-//  );

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import { Form, Input, Select, Button, Steps, message } from 'antd';
 import {
   UserOutlined,
@@ -23,6 +24,7 @@ export default function Onboarding() {
   const [form] = Form.useForm();
   const { current: currentUser } = useSelector(selectAuth);
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const steps = [
     { title: 'About You', icon: <UserOutlined /> },
@@ -57,7 +59,6 @@ export default function Onboarding() {
       if (response.success) {
         message.success('Welcome to Ola! 🎉');
 
-        // 更新 localStorage
         const auth_state = {
           current: response.result,
           isLoggedIn: true,
@@ -66,7 +67,7 @@ export default function Onboarding() {
         };
         window.localStorage.setItem('auth', JSON.stringify(auth_state));
 
-        // 更新 Redux store — OlaOs 三层路由会自动切换到 DefaultApp
+        navigate('/', { replace: true });
         dispatch({ type: actionTypes.REQUEST_SUCCESS, payload: response.result });
       } else {
         setLoading(false);

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,5 +1,6 @@
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import useLanguage from '@/locale/useLanguage';
 import { Form, Button, Typography } from 'antd';
@@ -14,17 +15,18 @@ const { Text } = Typography;
 
 const RegisterPage = () => {
   const translate = useLanguage();
-  const { isLoading } = useSelector(selectAuth);
+  const { isLoading, isSuccess } = useSelector(selectAuth);
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const onFinish = (values) => {
-    // 剔除 confirmPassword，后端 API 需要 name, surname, email, password
     const { confirmPassword, ...registerData } = values;
     dispatch(register({ registerData }));
   };
 
-  // 注册成功后 Redux 自动设为 isLoggedIn=true（auto-login），
-  // OlaOs 会检测 onboarded===false 并显示上车表单。无需手动 navigate。
+  useEffect(() => {
+    if (isSuccess) navigate('/', { replace: true });
+  }, [isSuccess]);
 
   const FormContainer = () => {
     return (


### PR DESCRIPTION
明天部署前清掉 3 项必修。PR #84 merge 时这 3 个 commit 还没追上，单独走一个 PR。

## 内容

- **`fddc8e0` fix(auth) closes #83** — Register/Onboarding 完成后 `navigate('/', replace)`。
  Bug 根因：URL 停在 `/register`，OlaOs flip 到 DefaultApp 后 AppRouter 没有 `/register` → NotFound。
- **`a12c7e9` fix(pdf) closes #82** — `a(href=settings.company_website)` 当无 `https://` 前缀时被当相对路径，加 `https://` 前缀 + `target=_blank`。Quote 和 Invoice 同步修。
- **`fe419ce` refactor(config)** — `serverApiConfig.js` 移除所有 `http://localhost:8888` fallback 默认值。`VITE_BACKEND_SERVER` 缺失时立刻抛错。明天 docker build 忘传 ARG 不会再静默连本地。本地 dev 不受影响（`frontend/.env` 已配）。Vite build 验证通过。

## Test plan

- [x] D1 端到端 Lead-to-Quote 闭环（zyd 已手测通过）
- [x] Vite build 通过
- [ ] CI claude-review 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)