### PR TITLE
fix(deploy): frontend host:80 for CF proxy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -69,13 +69,13 @@ else
 fi
 
 echo "🌐 [5/5] 接口连通性检查..."
-FRONTEND_CODE=$(ssh "$SERVER" "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3000" || echo "000")
+FRONTEND_CODE=$(ssh "$SERVER" "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:80" || echo "000")
 BACKEND_CODE=$(ssh "$SERVER" "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8888/health" || echo "000")
 
 if [ "$FRONTEND_CODE" = "200" ]; then
-    echo "   ✅ 前端 3000: HTTP $FRONTEND_CODE"
+    echo "   ✅ 前端 :80: HTTP $FRONTEND_CODE"
 else
-    echo "   ⚠️ 前端 3000: HTTP $FRONTEND_CODE (预期 200)"
+    echo "   ⚠️ 前端 :80: HTTP $FRONTEND_CODE (预期 200)"
 fi
 if [ "$BACKEND_CODE" = "200" ]; then
     echo "   ✅ 后端 8888/health: HTTP $BACKEND_CODE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,10 @@ services:
       args:
         VITE_BACKEND_SERVER: "https://app.olajob.cn/"
         VITE_APP_API_URL: "https://app.olajob.cn/api/"
+    # Cloudflare proxy 只支持标准端口（80/443/8080/...），自定义 3000 不被代理
+    # 所以 host 端口直接用 80，CF → Box1:80 → nginx-in-frontend → backend:8888
     ports:
-      - "3000:80"
+      - "80:80"
     depends_on:
       - backend
     restart: unless-stopped

--- a/ola/DEPLOY_RUNBOOK.md
+++ b/ola/DEPLOY_RUNBOOK.md
@@ -210,46 +210,31 @@ OPENAI_API_KEY=<key>
 
 ---
 
-## Phase 6 — 公网入口：Aliyun DNS + Caddy + Let's Encrypt（Duke + Claude，~20 min）
+## Phase 6 — 公网入口：Cloudflare Proxy（Duke + Claude，~10 min）
 
-**方案决策**：olajob.cn 目前托管在 Aliyun。迁到 CF 需要改 NS 等 1-24h 传播，赶不上明天 demo。本次用 Aliyun DNS + Box1 Caddy + LE 最简方案，CF Tunnel 迁移放 T+1 周 backlog（和 OSS 迁移一起做）。
+**方案决策**：olajob.cn 已迁到 Cloudflare（NS = elaine/gerald.ns.cloudflare.com，已全球传播）。用 CF 直接代理 Box1:80，不在 Box1 跑 caddy / LE。CF 终结 HTTPS，origin 走 HTTP。
 
 ### Duke 操作
 
-1. Aliyun 控制台 → 域名 → olajob.cn → DNS 解析：
-   - 添加 A 记录：`app` → `47.77.239.237`（Box1 IP），TTL 10min
-2. ECS 安全组确认 Box1 开放 443 和 80（安全组规则）
-3. 告诉 Claude：DNS 已配
+1. CF Dashboard → `olajob.cn` → DNS：
+   - A 记录 `app` → `47.77.239.237`，代理状态 = **橙云 (Proxied)**
+2. CF Dashboard → `olajob.cn` → SSL/TLS → Overview → Encryption mode = **Flexible**
+   - Box1 没跑 TLS，必须 Flexible（CF→origin 明文），Full/Full strict 会 526
+3. Aliyun ECS Box1 安全组入方向放开 TCP 80 源 `0.0.0.0/0`（CF 访问用）
+4. 告诉 Claude 配置完成
 
-### Claude 操作（SSH Box1 装 Caddy）
-
-```bash
-# Caddy 会自动申请 Let's Encrypt 证书、自动续期
-apt update && apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
-apt update && apt install -y caddy
-
-# 写 Caddyfile
-cat > /etc/caddy/Caddyfile <<'CADDY'
-app.olajob.cn {
-    reverse_proxy localhost:3000
-}
-CADDY
-
-systemctl reload caddy
-```
-
-Caddy 第一次启动会自动走 ACME challenge 申请证书（要求 DNS 已传播）。
-
-### 校验
+### 校验（Claude）
 
 ```bash
 curl -sI https://app.olajob.cn                    # 200
 curl -sI https://app.olajob.cn/api/setting/listAll # 401（说明 /api proxy 生效）
 ```
 
-### CF 迁移（T+1 周 backlog，不在今晚 scope）
+### 旧的 Caddy + LE 方案（不再使用）
+
+如需紧急切回直连：1) CF app 记录切灰云 2) Box1 装 caddy 3) Caddyfile 写 `app.olajob.cn { reverse_proxy localhost:80 }` 4) systemctl start caddy。
+
+### 未来升级：CF Tunnel
 
 届时：registrar 改 NS → CF → 建 Tunnel → 关 Caddy → DNS 切到 CF。老 Caddy 配置保留作为 fallback 文档。
 


### PR DESCRIPTION
被 PR #92 落下的单个 commit — 我 push 它之前 PR #92 已经 merge。

**内容**：docker-compose.yml frontend 端口 3000:80 → 80:80 + deploy.sh health check 端口同步 + runbook Phase 6 改 CF Proxy Flexible

**为什么必需**：Cloudflare proxy 只代理标准端口（80/443/8080/...），3000 端口 CF 连不上 origin。

**风险**：无，纯配置改。本地已 cherry-pick 到主分支并开始部署，PR 用于保持 main git 历史干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)