### PR TITLE
fix(security+ux+infra): IDOR P0 + Merch 必填收敛 + nginx stale DNS

### DIFF
--- a/backend/src/controllers/appControllers/comparisonController/fullComparison.js
+++ b/backend/src/controllers/appControllers/comparisonController/fullComparison.js
@@ -22,8 +22,12 @@ const fullComparison = async (req, res) => {
       });
     }
 
-    // 查询发票及其关联的采购订单
-    const invoice = await Invoice.findById(invoiceId)
+    // 查询发票及其关联的采购订单（严格限定为当前用户所有）
+    const invoice = await Invoice.findOne({
+      _id: invoiceId,
+      removed: false,
+      createdBy: req.admin._id,
+    })
       .populate({
         path: 'relatedPurchaseOrders',
         match: { removed: false, createdBy: req.admin._id }

--- a/backend/src/controllers/appControllers/comparisonController/fullComparison.js
+++ b/backend/src/controllers/appControllers/comparisonController/fullComparison.js
@@ -1,8 +1,6 @@
 const mongoose = require('mongoose');
 const Invoice = mongoose.model('Invoice');
-const Client = mongoose.model('Client');
 const Merch = mongoose.model('Merch');
-const PurchaseOrder = mongoose.model('PurchaseOrder');
 
 /**
  * 全面比较功能
@@ -85,6 +83,8 @@ const fullComparison = async (req, res) => {
       
       // 遍历关联的采购订单
       for (const po of invoice.relatedPurchaseOrders || []) {
+        // populate({ match }) 对不匹配的引用会留 null 而非移除 slot，必须 guard
+        if (!po) continue;
         // 查找采购订单中匹配的商品（只取第一个）
         const poItem = po.items.find(poItem => poItem.itemName === itemName);
         if (poItem) {
@@ -100,7 +100,8 @@ const fullComparison = async (req, res) => {
       
       // 如果找到采购信息并且有商品VAT/ETR信息
       if (purchaseInfo && merchInfo) {
-        const { VAT, ETR } = merchInfo;
+        // VAT/ETR 在 Merch 上为可选（#90），缺失时用默认值兜底避免 NaN
+        const { VAT = 1.13, ETR = 0.13 } = merchInfo;
         itemResult.purchasePrice = purchaseInfo.price;
         itemResult.purchaseOrderNumber = purchaseInfo.poNumber;
         itemResult.purchaseQuantity = purchaseInfo.quantity;

--- a/backend/src/controllers/appControllers/comparisonController/getPurchasePrice.js
+++ b/backend/src/controllers/appControllers/comparisonController/getPurchasePrice.js
@@ -86,8 +86,12 @@ const getPurchasePrice = async (req, res) => {
 
     // CASE 2: Check region history if no direct client history
     if (!purchasePrice) {
-      // Get current client's country
-      const client = await Client.findById(clientId);
+      // Get current client's country (严格限定为当前用户所有)
+      const client = await Client.findOne({
+        _id: clientId,
+        removed: false,
+        createdBy: req.admin._id,
+      });
       if (!client || !client.country) {
         return res.status(400).json({
           success: false,

--- a/backend/src/controllers/appControllers/invoiceController/copy.js
+++ b/backend/src/controllers/appControllers/invoiceController/copy.js
@@ -5,9 +5,13 @@ const copy = async (req, res) => {
   try {
     const { id } = req.params;
 
-    // 查找要复制的发票
-    const sourceInvoice = await Invoice.findById(id);
-    
+    // 查找要复制的发票（严格限定为当前用户所有）
+    const sourceInvoice = await Invoice.findOne({
+      _id: id,
+      removed: false,
+      createdBy: req.admin._id,
+    });
+
     if (!sourceInvoice) {
       return res.status(404).json({
         success: false,

--- a/backend/src/controllers/appControllers/purchaseOrderController/copy.js
+++ b/backend/src/controllers/appControllers/purchaseOrderController/copy.js
@@ -5,9 +5,13 @@ const copy = async (req, res) => {
   try {
     const { id } = req.params;
 
-    // 查找要复制的采购订单
-    const sourcePurchaseOrder = await PurchaseOrder.findById(id);
-    
+    // 查找要复制的采购订单（严格限定为当前用户所有）
+    const sourcePurchaseOrder = await PurchaseOrder.findOne({
+      _id: id,
+      removed: false,
+      createdBy: req.admin._id,
+    });
+
     if (!sourcePurchaseOrder) {
       return res.status(404).json({
         success: false,

--- a/backend/src/controllers/appControllers/quoteController/copy.js
+++ b/backend/src/controllers/appControllers/quoteController/copy.js
@@ -5,9 +5,13 @@ const copy = async (req, res) => {
   try {
     const { id } = req.params;
 
-    // 查找要复制的报价单
-    const sourceQuote = await Quote.findById(id);
-    
+    // 查找要复制的报价单（严格限定为当前用户所有）
+    const sourceQuote = await Quote.findOne({
+      _id: id,
+      removed: false,
+      createdBy: req.admin._id,
+    });
+
     if (!sourceQuote) {
       return res.status(404).json({
         success: false,

--- a/backend/src/handlers/errorHandlers.js
+++ b/backend/src/handlers/errorHandlers.js
@@ -10,18 +10,22 @@ exports.catchErrors = (fn) => {
   return function (req, res, next) {
     return fn(req, res, next).catch((error) => {
       if (error.name == 'ValidationError') {
-        
+        // 从 mongoose ValidationError 提取字段名和具体原因，生成对用户友好的消息
+        const fieldIssues = Object.entries(error.errors || {}).map(([field, err]) => {
+          // kind: 'required' / 'Number' / 'enum' / ...；err.message 是 mongoose 原文
+          const kind = err.kind || err.name || 'invalid';
+          return `${field} (${kind})`;
+        });
+        const message = fieldIssues.length
+          ? `Missing or invalid fields: ${fieldIssues.join(', ')}`
+          : 'Validation failed';
+
         return res.status(400).json({
           success: false,
           result: null,
-          message: 'Required fields are not supplied hey',
+          message,
           controller: fn.name,
           error: error,
-          requestInfo:{
-            body:req.body,
-            params:req.params,
-            admin:req.admin
-          }
         });
       } else {
         // Server Error

--- a/backend/src/handlers/errorHandlers.js
+++ b/backend/src/handlers/errorHandlers.js
@@ -24,19 +24,15 @@ exports.catchErrors = (fn) => {
           success: false,
           result: null,
           message,
-          controller: fn.name,
-          error: error,
         });
       } else {
-        // Server Error
+        // Server Error — 仅在服务器侧记录详细信息，不回显给客户端
         console.log('Server Error in controller:', fn.name);
         console.log('Error details:', error);
         return res.status(500).json({
           success: false,
           result: null,
           message: error.message,
-          controller: fn.name,
-          error: error,
         });
       }
     });

--- a/backend/src/models/appModels/Merch.js
+++ b/backend/src/models/appModels/Merch.js
@@ -13,8 +13,7 @@ const schema = new mongoose.Schema({
     key: true
   },
   serialNumberLong: {
-    type: String, 
-    required: true
+    type: String
   },
   description_en: {
     type: String,
@@ -24,24 +23,20 @@ const schema = new mongoose.Schema({
     type: String
   },
   weight: {
-    type: Number,
-    required: true
+    type: Number
   },
   VAT: {
-    type: Number,
-    required: true
+    type: Number
   },
   ETR: {
-    type: Number,
-    required: true
+    type: Number
   },
   unit_en: {
     type: String,
     required: true
   },
   unit_cn: {
-    type: String,
-    required: true
+    type: String
   }
 });
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -27,6 +27,12 @@ COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
 # 设计：本 nginx 始终部署在 TLS 反代（Caddy/CF）之后，client→Caddy(HTTPS)→nginx(HTTP)→backend
 # 所以 X-Forwarded-Proto 硬编码 https（$scheme 在 nginx 这一跳永远是 http，传上去会误导 backend）
 RUN cat > /etc/nginx/conf.d/default.conf <<'NGINX'
+# Docker 内嵌 DNS (127.0.0.11) 用于运行时解析 service name "backend"。
+# 没有 resolver + variable，nginx 会在启动时一次性解析 backend 的 IP 并永久缓存：
+# 一旦 backend 容器 recreate（IP 变化），nginx 继续打旧 IP 返 502。加了这个 nginx
+# 每 10s 重新解析，backend 可以独立重启而 frontend 无感。
+resolver 127.0.0.11 valid=10s ipv6=off;
+
 server {
     listen 80;
     root /usr/share/nginx/html;
@@ -35,7 +41,8 @@ server {
     # /api/ola/* 走 NanoBot → Gemini，长链路 LLM 请求允许 3 分钟
     # 必须放在 /api/ 之前 —— nginx 最长前缀匹配优先
     location /api/ola/ {
-        proxy_pass http://backend:8888/api/ola/;
+        set $upstream_backend backend:8888;
+        proxy_pass http://$upstream_backend/api/ola/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -48,7 +55,8 @@ server {
 
     # 后端 API 反代（docker-compose 网络内用 service name "backend"）
     location /api/ {
-        proxy_pass http://backend:8888/api/;
+        set $upstream_backend backend:8888;
+        proxy_pass http://$upstream_backend/api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -59,7 +67,8 @@ server {
     }
 
     location /download/ {
-        proxy_pass http://backend:8888/download/;
+        set $upstream_backend backend:8888;
+        proxy_pass http://$upstream_backend/download/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -69,7 +78,8 @@ server {
     }
 
     location /export/ {
-        proxy_pass http://backend:8888/export/;
+        set $upstream_backend backend:8888;
+        proxy_pass http://$upstream_backend/export/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -79,7 +89,8 @@ server {
     }
 
     location /public/ {
-        proxy_pass http://backend:8888/public/;
+        set $upstream_backend backend:8888;
+        proxy_pass http://$upstream_backend/public/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -88,7 +99,8 @@ server {
     }
 
     location /health {
-        proxy_pass http://backend:8888/health;
+        set $upstream_backend backend:8888;
+        proxy_pass http://$upstream_backend/health;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Proto https;

--- a/frontend/src/pages/Merchandise/config.js
+++ b/frontend/src/pages/Merchandise/config.js
@@ -1,16 +1,18 @@
 export const fields = {
   serialNumber: {
     type: 'string',
+    required: true,
   },
   serialNumberLong: {
     type: 'string',
   },
   description_en: {
     type: 'string',
+    required: true,
   },
   description_cn: {
     type: 'string',
-  },    
+  },
   weight: {
     type: 'number',
   },
@@ -22,10 +24,9 @@ export const fields = {
   },
   unit_en: {
     type: 'string',
-    required: true
+    required: true,
   },
   unit_cn: {
     type: 'string',
-    required: true
-  }
+  },
 };


### PR DESCRIPTION
## Summary

一次性处理 3 个 issue，每个 commit 独立。

### #107 — 跨租户 IDOR P0 安全修复（[2e4b2ee](https://github.com/SeekMi-Technologies/Ola/commit/2e4b2ee)）

5 处 \`findById(id)\` 无 \`createdBy\` 过滤，任何登录用户可凭 \`_id\` 读/复制他人数据：

| 文件 | 影响 |
|---|---|
| \`quoteController/copy.js\` | copy 他人 quote（连带 client 引用到自己账号） |
| \`invoiceController/copy.js\` | 同上 |
| \`purchaseOrderController/copy.js\` | 同上 |
| \`comparisonController/fullComparison.js\` | read-only 他人 invoice 数据 |
| \`comparisonController/getPurchasePrice.js\` | 凭他人 clientId 走后续查询 |

修法：\`findById\` → \`findOne({ _id, removed: false, createdBy: req.admin._id })\`。

### #90 — Merch UX + 统一 ValidationError 文案（[090d5ae](https://github.com/SeekMi-Technologies/Ola/commit/090d5ae)）

- Merch 必填从 8 个 → 3 个：\`serialNumber\`, \`description_en\`, \`unit_en\`（其他全可选，Lead-to-Quote MVP 不需要）
- \`frontend/src/pages/Merchandise/config.js\` 对齐同步 required
- \`handlers/errorHandlers.js\` 从 mongoose \`error.errors\` 提取字段名，改报 \`Missing or invalid fields: foo (required), bar (Number)\`，取代过去 generic \`Required fields are not supplied hey\`
- Side-fix：删掉错误响应里回显的 requestInfo（含 body/params/admin 敏感字段）

### #108-a — nginx stale DNS 永久修复（[bf4551d](https://github.com/SeekMi-Technologies/Ola/commit/bf4551d)）

**确认根因同时解释了 #108 NanoBot 昨晚挂的事故**。

原 \`proxy_pass http://backend:8888\` 用 docker service name，nginx 启动时一次解析永久缓存；backend recreate 后 IP 变了，nginx 仍打旧 IP 返 502。

加了 \`resolver 127.0.0.11 valid=10s ipv6=off;\` + 每个 location \`set \$upstream_backend\` + \`proxy_pass \$var\`，强制按 TTL 重解析。backend 可独立重启，frontend 10s 内恢复。

⚠️ **部署注意**：需重建 frontend 镜像 → \`docker compose up -d --build frontend\`

## Test plan

- [ ] #107：test@test.com 和另一账号互相用对方 \`_id\` copy quote/invoice/PO → 必须返 404
- [ ] #107：用另一账号的 invoiceId 调 \`/comparison/fullComparison\` → 必须返 404
- [ ] #90：新建 Merch 只填 serialNumber + description_en + unit_en → 成功
- [ ] #90：漏填 serialNumber → 报错消息含 \`serialNumber (required)\`
- [ ] #108-a：部署后 \`docker compose up -d --force-recreate backend\`（不重启 frontend）→ 等 12s → \`curl /api/setting/listAll\` 返 401 而不是 502

## Not in this PR

剩余 item 另起 PR：107-b (Atlas orphan cleanup)、107-c/d (frontend persist + e2e regression)、108-b (.env cron backup)、109 (olatech.ai 域名切换)、登录慢诊断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)