### PR TITLE
fix(auth): JWT signature 503→401 + jwtExpired (issue #110)

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js
@@ -28,15 +28,9 @@ const isValidAuthToken = async (req, res, next, { userModel, jwtSecret = 'JWT_SE
         jwtExpired: true,
       });
 
+    // jwt.verify 要么返回解码的 payload，要么抛错；不存在返 falsy 的路径，所以老代码里
+    // if (!verified) 分支一直是 dead code，删掉
     const verified = jwt.verify(token, process.env[jwtSecret]);
-
-    if (!verified)
-      return res.status(401).json({
-        success: false,
-        result: null,
-        message: 'Token verification failed, authorization denied.',
-        jwtExpired: true,
-      });
 
     const userPasswordPromise = UserPassword.findOne({ user: verified.id, removed: false });
     const userPromise = User.findOne({ _id: verified.id, removed: false });
@@ -48,6 +42,16 @@ const isValidAuthToken = async (req, res, next, { userModel, jwtSecret = 'JWT_SE
         success: false,
         result: null,
         message: "User doesn't Exist, authorization denied.",
+        jwtExpired: true,
+      });
+
+    // Edge case: User 存在但 UserPassword 被删（数据异常）→ 直接当作 session 失效，
+    // 否则下一行解构 null 会抛 TypeError 被 catch 成 503
+    if (!userPassword)
+      return res.status(401).json({
+        success: false,
+        result: null,
+        message: 'Session credentials missing, please log in again.',
         jwtExpired: true,
       });
 

--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js
@@ -65,13 +65,29 @@ const isValidAuthToken = async (req, res, next, { userModel, jwtSecret = 'JWT_SE
       next();
     }
   } catch (error) {
-    console.error('Auth error:', error);
+    // JWT lib 抛的错都是认证失败（invalid signature / expired / malformed），
+    // 返 401 + jwtExpired 让前端清 cookie 走登出流程；
+    // 503 会被 errorHandler 识别为 "Cannot connect to server" 假象，导致用户陷在
+    // "登录报 Invalid Signature" 而无法登录（issue #110 根因：JWT_SECRET 换过或
+    // 本地/生产环境不同，浏览器残留旧 cookie 签名验不过，永久卡住）。
+    if (
+      error.name === 'JsonWebTokenError' ||
+      error.name === 'TokenExpiredError' ||
+      error.name === 'NotBeforeError'
+    ) {
+      return res.status(401).json({
+        success: false,
+        result: null,
+        message: 'Authentication token invalid or expired. Please log in again.',
+        jwtExpired: true,
+      });
+    }
+    // 其他才是真 server error（DB 挂等）
+    console.error('Auth middleware error:', error);
     return res.status(503).json({
       success: false,
       result: null,
       message: error.message,
-      error: error,
-      controller: 'isValidAuthToken',
     });
   }
 };


### PR DESCRIPTION
Closes #110

## Summary

修复用户在正常浏览器窗口登录报 \`503 Invalid Signature\`（匿名窗口可以）的问题。

## Root cause

浏览器残留的旧 JWT cookie（JWT_SECRET 换过 / 本地切生产），后端 [isValidAuthToken.js](backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js) catch 块对 \`jwt.verify\` 抛的任何错（包括 \`JsonWebTokenError: invalid signature\`）都返 **503**。前端 errorHandler 看到 503 → 弹 "Cannot connect to server"，且**不清 cookie**，用户永久卡住。

## Fix

把 JWT lib 抛的 \`JsonWebTokenError / TokenExpiredError / NotBeforeError\` 识别为认证失败，返 \`401 + jwtExpired: true\`。前端代码已有这条路径 ([errorHandler.js:41](frontend/src/request/errorHandler.js#L41))：清 cookie + 跳 \`/logout\`。只有真 server error（DB down 等）才保留 503。

顺带：503 响应去掉 \`error\`/\`controller\` 字段，与 PR #111 的 errorHandlers.js 同步防信息泄露。

## Test plan

本地已验证 3 个 case：
- Invalid signature → 401 + jwtExpired=true ✓
- Expired token → 401 + jwtExpired=true ✓
- No token (已有行为) → 401 ✓

部署后验证：
- [ ] 之前卡在 503 Invalid Signature 的正常浏览器窗口，刷新后自动清 cookie 跳转 /login 而不是卡死
- [ ] 清 cookie 后正常登录流程无影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)