### PR TITLE
fix(auth): P0 cookie 丢失 — 移除 Partitioned + 错误的 domain

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/authUser.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/authUser.js
@@ -34,10 +34,15 @@ const authUser = async (req, res, { user, databasePassword, password, UserPasswo
         maxAge: req.body.remember ? 365 * 24 * 60 * 60 * 1000 : null,
         sameSite: 'Lax',
         httpOnly: true,
-        secure: false,
-        domain: req.hostname,
+        secure: false,  // CF Flexible：CF→origin 是 HTTP，必须 false
         path: '/',
-        Partitioned: true,
+        // 不设 domain —— 浏览器走 host-only cookie，自动 scope 到当前域
+        //   设 domain 反而会踩坑：domain=app.olatech.ai 登录后切到 app.olajob.cn
+        //   浏览器不会带这个 cookie（预期行为），但更重要的是 req.hostname
+        //   在 CF 反代后未必可靠
+        // 不设 Partitioned —— 新 CHIPS attribute 要求配 secure=true + SameSite=None，
+        //   我们是 secure=false + SameSite=Lax，Partitioned 会让 Chrome 直接丢弃
+        //   整个 cookie —— 登录后下次请求没 cookie → 401 "No authentication token"
       })
       .json({
         success: true,

--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/register.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/register.js
@@ -110,10 +110,9 @@ const register = async (req, res, { userModel }) => {
       maxAge: 24 * 60 * 60 * 1000,
       sameSite: 'Lax',
       httpOnly: true,
-      secure: false,
-      domain: req.hostname,
+      secure: false,  // CF Flexible：CF→origin HTTP
       path: '/',
-      Partitioned: true,
+      // 不设 domain / Partitioned，原因见 authUser.js 注释
     })
     .json({
       success: true,

--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/resetPassword.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/resetPassword.js
@@ -116,10 +116,9 @@ const resetPassword = async (req, res, { userModel }) => {
         maxAge: 24 * 60 * 60 * 1000,
         sameSite: 'Lax',
         httpOnly: true,
-        secure: false,
-        domain: req.hostname,
+        secure: false,  // CF Flexible：CF→origin HTTP
         path: '/',
-        Partitioned: true,
+        // 不设 domain / Partitioned，原因见 authUser.js 注释
       })
       .json({
         success: true,


### PR DESCRIPTION
## 紧急修复

PR #115 刚刚部署到生产，发现登录 app.olatech.ai 后**所有 API 请求报 401 \"No authentication token\"** —— 浏览器没写入 cookie。

## Root cause

三个 set-cookie 处（authUser/register/resetPassword）都有：
\`\`\`js
{
  Partitioned: true,   // ← 罪魁
  secure: false,
  sameSite: 'Lax',
  domain: req.hostname,
}
\`\`\`

Chrome/现代浏览器规定：\`Partitioned\` 必须配 \`Secure=true\` + \`SameSite=None\`。我们是 \`secure: false\` + \`SameSite=Lax\`（CF Flexible：CF→origin HTTP，必须 secure=false），Partitioned 让浏览器**静默拒绝整个 cookie**。

## Fix

三个文件同步：
- 移除 \`Partitioned: true\`
- 移除 \`domain: req.hostname\` (改走 host-only cookie，更安全；之前 req.hostname 在 CF 反代后可能不可靠)
- 保留 \`sameSite: Lax\` + \`httpOnly\` + \`secure: false\` + \`path: /\`

## Test plan

- [ ] 部署后登录 app.olatech.ai → 成功 → dashboard 首屏加载数据（不再 401）
- [ ] 登录 app.olajob.cn → 同样成功（两个域各自独立 cookie，共存）
- [ ] logout → 无残留

🤖 Generated with [Claude Code](https://claude.com/claude-code)