### PR TITLE
fix(auth): P0 — axios baseURL 双前缀 bug (/api/api/login)

### DIFF
--- a/frontend/src/auth/auth.service.js
+++ b/frontend/src/auth/auth.service.js
@@ -1,19 +1,18 @@
-import { API_BASE_URL } from '@/config/serverApiConfig';
-
 import axios from 'axios';
 import errorHandler from '@/request/errorHandler';
 import successHandler from '@/request/successHandler';
 
-// Debug log to check API_BASE_URL
-console.log('Debug - API_BASE_URL value:', API_BASE_URL);
+// 注意：这里所有请求用相对路径（不加 API_BASE_URL 前缀）。request.js 已经
+// 设置了 axios.defaults.baseURL = API_BASE_URL。再拼前缀会触发 axios 的
+// URL 合并 bug —— 形如 `${API_BASE_URL}login` = `/api/login`，axios 只把
+// 带 `://` 的字符串视为绝对，所以会把 `/api/` + `/api/login` 拼成
+// `/api/api/login`，backend 404 → fall-through → 401 "No auth token"。
+// 之前 API_BASE_URL 是 `https://app.olajob.cn/api/` 因为含 `://` 绝对模式被
+// 跳过 baseURL 合并才偶然能跑通；换 same-origin 相对路径后才暴露。
 
 export const login = async ({ loginData }) => {
   try {
-    const url = `${API_BASE_URL}login?timestamp=${new Date().getTime()}`;
-    // Debug log to check constructed URL
-    console.log('Debug - Login URL:', url);
-    
-    const response = await axios.post(url, loginData);
+    const response = await axios.post(`login?timestamp=${Date.now()}`, loginData);
 
     const { status, data } = response;
 
@@ -33,7 +32,7 @@ export const login = async ({ loginData }) => {
 
 export const register = async ({ registerData }) => {
   try {
-    const response = await axios.post(`${API_BASE_URL}register`, registerData);
+    const response = await axios.post('register', registerData);
 
     const { status, data } = response;
 
@@ -52,7 +51,7 @@ export const register = async ({ registerData }) => {
 
 export const verify = async ({ userId, emailToken }) => {
   try {
-    const response = await axios.get(`${API_BASE_URL}verify/${userId}/${emailToken}`);
+    const response = await axios.get(`verify/${userId}/${emailToken}`);
 
     const { status, data } = response;
 
@@ -71,7 +70,7 @@ export const verify = async ({ userId, emailToken }) => {
 
 export const resetPassword = async ({ resetPasswordData }) => {
   try {
-    const response = await axios.post(`${API_BASE_URL}resetpassword`, resetPasswordData);
+    const response = await axios.post('resetpassword', resetPasswordData);
 
     const { status, data } = response;
 
@@ -91,7 +90,7 @@ export const logout = async () => {
   axios.defaults.withCredentials = true;
   try {
     // window.localStorage.clear();
-    const response = await axios.post(`${API_BASE_URL}logout?timestamp=${new Date().getTime()}`);
+    const response = await axios.post(`logout?timestamp=${Date.now()}`);
     const { status, data } = response;
 
     successHandler(

--- a/frontend/src/modules/SettingModule/components/CompanyLogoField.jsx
+++ b/frontend/src/modules/SettingModule/components/CompanyLogoField.jsx
@@ -6,7 +6,7 @@ import axios from 'axios';
 
 import { settingsAction } from '@/redux/settings/actions';
 import { selectSettings } from '@/redux/settings/selectors';
-import { API_BASE_URL, FILE_BASE_URL } from '@/config/serverApiConfig';
+import { FILE_BASE_URL } from '@/config/serverApiConfig';
 import useLanguage from '@/locale/useLanguage';
 
 export default function CompanyLogoField() {
@@ -38,8 +38,9 @@ export default function CompanyLogoField() {
     try {
       const formData = new FormData();
       formData.append('file', file);
+      // 用相对路径避免 axios baseURL 双前缀 bug（详见 auth.service.js 注释）
       const response = await axios.patch(
-        `${API_BASE_URL}setting/upload/company_logo`,
+        'setting/upload/company_logo',
         formData,
         {
           headers: { 'Content-Type': 'multipart/form-data' },

--- a/frontend/src/modules/SettingModule/components/UpdateSettingForm.jsx
+++ b/frontend/src/modules/SettingModule/components/UpdateSettingForm.jsx
@@ -8,7 +8,6 @@ import { Button, Form, message } from 'antd';
 import Loading from '@/components/Loading';
 import useLanguage from '@/locale/useLanguage';
 import axios from 'axios';
-import { API_BASE_URL } from '@/config/serverApiConfig';
 
 export default function UpdateSettingForm({ config, children, withUpload, uploadSettingKey }) {
   let { entity, settingsCategory } = config;
@@ -27,8 +26,9 @@ export default function UpdateSettingForm({ config, children, withUpload, upload
           const formData = new FormData();
           formData.append('file', fieldsValue.file[0].originFileObj);
 
+          // 用相对路径避免 axios baseURL 双前缀 bug（详见 auth.service.js 注释）
           const response = await axios.patch(
-            `${API_BASE_URL}setting/upload/${uploadSettingKey}`,
+            `setting/upload/${uploadSettingKey}`,
             formData,
             {
               headers: { 'Content-Type': 'multipart/form-data' },


### PR DESCRIPTION
## P0 — 根因彻底定位

用户反馈两台电脑 + 手机无痕都登录不上，报 \"No authentication token\"。curl 直打 \`/api/login\` 成功，但浏览器通过 axios 挂。

## Root cause

\`auth.service.js\` 手拼 URL：
\`\`\`js
const url = \`\${API_BASE_URL}login\`;   // = "/api/login"
axios.post(url, loginData);
\`\`\`

**axios 的 URL 合并只认 \`://\` 为 absolute**，\`/api/login\` 以 \`/\` 开头仍算 relative。axios 会 \`baseURL (=/api/) + /api/login\` → 发到 **\`/api/api/login\`**。

Backend 看 \`/api/api/login\`：
- \`app.use('/api', coreAuthRouter)\` 剥前缀 → 剩 \`/api/login\`
- coreAuthRouter 里只定义了 \`/login\` 不是 \`/api/login\` → 不匹配
- fall through → \`isValidAuthToken\` → 401 \"No auth token\"

**curl 直打 \`/api/login\` 成功是因为我的 curl 自己写的 URL，不经过 axios。** 这是我 smoke 漏过的最致命一层 —— 没用 browser/真正的 axios client 过一遍。

**验证**：\`curl https://app.olatech.ai/api/api/login\` → 返 401 \"No auth token\"，和用户 browser 完全一致。

## Why didn't this break before?

之前 \`API_BASE_URL = 'https://app.olajob.cn/api/'\` 含 \`://\` 被 axios 识别为 absolute URL，跳过 baseURL 合并，直接打 \`https://app.olajob.cn/api/login\` OK。PR #114 换成 same-origin 相对路径 \`/api/\` 后暴露。

## Fix

7 处（5 auth.service + 2 setting upload）改相对 path，让 \`axios.defaults.baseURL\` 自然 prepend：

\`\`\`diff
- \${API_BASE_URL}login        →   login
- \${API_BASE_URL}register     →   register
- \${API_BASE_URL}verify/\$id   →   verify/\$id
- \${API_BASE_URL}resetpassword →   resetpassword
- \${API_BASE_URL}logout       →   logout
- \${API_BASE_URL}setting/upload/company_logo  →  setting/upload/company_logo
- \${API_BASE_URL}setting/upload/\$key          →  setting/upload/\$key
\`\`\`

## Codebase audit

- \`DOWNLOAD_BASE_URL\` / \`EXCEL_EXPORT_BASE_URL\`：只在 \`window.open()\` 用，浏览器直接导航非 axios，同源路径正常 ✓
- \`FILE_BASE_URL\`：只在 \`<img src>\` 用，同源解析正常 ✓
- \`checkImage.js\`：dead code（无 caller），不改 ✓
- \`request.js\`：用 \`axios.post(entity + '/create')\` 等真相对路径（无前导 /），axios 正确 prepend baseURL，正常 ✓

## Test plan

- [x] 本地 \`vite build\` 验证 dist JS 里无 \`/api/{login,register,...}\` 绝对路径字符串
- [ ] 部署后浏览器真登录（curl 在此场景误导性大，必须浏览器）
- [ ] 部署后 curl E2E 3-check 也要跑（memory 规则）

## 自检反思

我今天的 debug 流程缺了这关键一环：**不能只 curl，必须真用浏览器/真用 axios client 模拟**。curl 是最外层工具，但前端的 axios client 有它自己的 URL 合并逻辑，只有真客户端能复现。我在 memory 规则里的 "3 条 curl" 要补一条 "用 headless browser 或 axios client fetch 一次"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)