### PR TITLE
fix(deploy): MCP_BIND_ADDR fail-fast + 项目根 .env 进 git

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,15 @@
+# 项目根 .env —— 仅给 docker-compose.yml 做变量插值用（compose 自动读取）
+# **不要在这里放任何密钥**。密钥（DATABASE / JWT_SECRET / GEMINI_API_KEY /
+# MCP_SERVICE_TOKEN / RESEND_API 等）一律放 backend/.env，那个不进 git。
+#
+# 这个文件 commit 到仓库，是因为 docker-compose.yml 需要 MCP_BIND_ADDR 才能启动
+# （之前用 ${MCP_BIND_ADDR:-127.0.0.1} 默认值导致重启时 shell env 丢失会静默退化
+# 到 loopback，nanobot 跨机连不到 MCP；改用 ${MCP_BIND_ADDR:?...} fail-fast 后
+# 必须保证这个变量始终可读，所以放进 git 跟随项目走）。
+#
+# 不同部署环境覆盖方法：
+#   - 本地 dev：项目根再放一个 .env.local 覆盖（compose 优先读 .env.local）
+#   - 生产 Box1：直接用本文件的值（100.109.220.126 是 Box1 的 Tailscale IP）
+
+# Box1 的 Tailscale IP，nanobot (Box2) 走 100.109.220.126:8889 连过来调 MCP tools
+MCP_BIND_ADDR=100.109.220.126

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ npm-debug.log
 .env.production
 *.env
 
+# 例外：项目根 .env 仅含 docker-compose 编排所需的非敏感变量（如 MCP_BIND_ADDR）。
+# 真正的密钥（DATABASE / JWT_SECRET / GEMINI_API_KEY / MCP_SERVICE_TOKEN 等）
+# 仍只放在 backend/.env，不进 git。
+!/.env
+
 # Build files
 build/
 dist/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,13 @@
 # Tailscale 跨机：Box2 nanobot → Box1 mcp (100.109.220.126:8889) → backend (MongoDB)
 # 使用: 在 Box1 上 cd 到项目目录，配置 backend/.env 后执行 docker compose up -d --build
 #
-# 环境变量（可选）：
-#   MCP_BIND_ADDR — MCP 对外暴露绑定地址。默认 127.0.0.1（本地只允许 loopback）。
-#                    分机部署必须设为 Box1 Tailscale IP，如 MCP_BIND_ADDR=100.109.220.126
-#                    可放 .env 文件（compose 自动读取）或 shell 环境变量
+# 环境变量（必填）：
+#   MCP_BIND_ADDR — MCP 对外暴露绑定地址。**必须在项目根 .env 里设置**。
+#                    单机本地 dev：MCP_BIND_ADDR=127.0.0.1
+#                    生产分机部署：MCP_BIND_ADDR=<Box1 Tailscale IP>，如 100.109.220.126
+#                    没设这个变量 docker compose up 直接报错退出，不允许静默 fallback —
+#                    历史教训：之前用 ${MCP_BIND_ADDR:-127.0.0.1} 默认值，重启时 shell
+#                    env 丢失就会悄悄退化到 loopback，nanobot 跨机连不到 MCP。
 
 services:
   backend:
@@ -36,11 +39,12 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     command: node src/mcp/server.js
-    # 绑定地址通过 MCP_BIND_ADDR 控制：
-    # - 本地 dev：默认 127.0.0.1（只 loopback，不跨机）
-    # - 生产分机：shell 或 .env 设 MCP_BIND_ADDR=<Box1 Tailscale IP>
+    # 绑定地址通过 MCP_BIND_ADDR 控制（必须显式设置，无默认值）：
+    # - 本地 dev：项目根 .env 里 MCP_BIND_ADDR=127.0.0.1（只 loopback）
+    # - 生产分机：项目根 .env 里 MCP_BIND_ADDR=<Box1 Tailscale IP>
+    # ${VAR:?msg} 语法：如果没设 VAR，docker compose up 立刻报错退出（fail-fast）
     ports:
-      - "${MCP_BIND_ADDR:-127.0.0.1}:8889:8889"
+      - "${MCP_BIND_ADDR:?MCP_BIND_ADDR must be set in /app/crm/.env (e.g. 100.109.220.126 for prod, 127.0.0.1 for local dev)}:8889:8889"
     env_file:
       - ./backend/.env
     environment:
@@ -72,4 +76,5 @@ volumes:
 #   Box3: docker run -d --name gotenberg --restart unless-stopped -p 3000:3000 gotenberg/gotenberg:8
 # - backend/.env 必须包含 GOTENBERG_URL / NANOBOT_HOST / NANOBOT_PORT / MCP_SERVICE_TOKEN / GEMINI_API_KEY 等
 # - ALLOWED_ORIGINS / PUBLIC_SERVER_FILE 等也从 backend/.env 读取
-# - 分机部署时 shell 必须 export MCP_BIND_ADDR=<Box1 Tailscale IP>（例 100.109.220.126）否则 nanobot 连不上
+# - 分机部署时 项目根 .env 必须有 MCP_BIND_ADDR=<Box1 Tailscale IP>（例 100.109.220.126），
+#   .env 已 commit 到仓库（不含密钥），git pull 后无需手工 export


### PR DESCRIPTION
## 背景 / 根因

之前 [docker-compose.yml](docker-compose.yml) 用 \`\${MCP_BIND_ADDR:-127.0.0.1}\` 提供默认值，依赖手工在 shell 里 \`export MCP_BIND_ADDR=100.109.220.126\`。一旦在新 SSH 会话里跑 \`docker compose up -d\`（shell env 丢失），MCP 容器会**悄悄绑回 loopback**，Box2 nanobot 跨机连不到 MCP server。

**症状极隐蔽**：
- backend 主 API 完全正常，CRM 网页能登录、能聊天
- 只有 nanobot 触发 tool call 时才挂（socket hangup）
- 普通登录冒烟根本测不出来

今天就因为这个吃了亏，nanobot tool call 全挂。

## 改动

1. **\`docker-compose.yml\`** — \`\${MCP_BIND_ADDR:?...}\` 强制要求显式设置：
   \`\`\`yaml
   - "\${MCP_BIND_ADDR:?MCP_BIND_ADDR must be set in /app/crm/.env (e.g. 100.109.220.126 for prod, 127.0.0.1 for local dev)}:8889:8889"
   \`\`\`
   缺了变量 \`docker compose up\` **直接报错退出**，杜绝静默退化。

2. **\`.gitignore\`** 加 \`!/.env\` 例外 —— 项目根 \`.env\` 进 git，但 \`backend/.env\`（含密钥）继续不进 git。

3. **\`/.env\`** 新增（已 commit）：
   \`\`\`
   MCP_BIND_ADDR=100.109.220.126
   \`\`\`
   只含 docker-compose 编排所需的非敏感变量。git pull 即可用，不再依赖任何手工 export。

## 部署后验证

合到 dev → main 部署到 Box1 后，从任意非 Box1 节点（Box2/本机 Tailscale）跑：
\`\`\`bash
curl -sS -m 5 -w "\nHTTP %{http_code}\n" -X POST http://100.109.220.126:8889/mcp \\
  -H "Authorization: Bearer \$MCP_SERVICE_TOKEN" \\
  -H 'Content-Type: application/json' \\
  -H 'Accept: application/json, text/event-stream' \\
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
\`\`\`
预期 200 + SSE 流（15 个 v1 tools）。

然后从 \`app.olajob.cn\` 和 \`app.olatech.ai\` 各跑一次需要 tool call 的 chat（如"查一下客户列表"），都应能调通工具。

## Test plan

- [ ] dev 合并后部署 Box1 → \`docker compose up -d\` 不报错
- [ ] 故意 \`mv .env .env.bak\` 后 \`docker compose up\` → 应报 "MCP_BIND_ADDR must be set..." 并退出
- [ ] Box2 curl MCP → 200 + tools 列表
- [ ] olajob.cn 和 olatech.ai 各跑一次 tool-call chat → 都成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)