### PR TITLE
fix(askola): plus menu popup opens upward to avoid bottom clipping

### DIFF
--- a/frontend/src/style/partials/askola.css
+++ b/frontend/src/style/partials/askola.css
@@ -454,10 +454,10 @@
   flex-shrink: 0;
 }
 
-/* Popup menu */
+/* Popup menu — opens upward so it isn't clipped at page bottom */
 .askola-plus-menu {
   position: absolute;
-  top: calc(100% + 10px);
+  bottom: calc(100% + 10px);
   left: 0;
   min-width: 220px;
   background: #ffffff;


### PR DESCRIPTION
## 改动内容

- **文件**: `frontend/src/style/partials/askola.css`
- **问题**: Ask Ola 对话页面底部的 "+" 按钮弹出菜单（Upload photos & files）向下展开时被页面底部遮挡，无法正常显示
- **修复**: 将 `.askola-plus-menu` 的定位从 `top: calc(100% + 10px)` 改为 `bottom: calc(100% + 10px)`，使弹窗向上展开

## 验证

- [x] 仅修改 CSS 样式，不影响任何组件逻辑
- [x] 改动范围：1 个文件，2 行变更
- [x] 不破坏现有功能