### PR TITLE
feat(skills): add Claude Code skills for team workflow (#139)

### DIFF
--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -19,8 +19,7 @@ description: Identify the Ola CRM operator (Yuandong / Ziyue / Will / Angel), re
 | 殷子越 / Ziyue / 子越 | 🟢 全栈对等（**无 trivial 豁免**） | `ZIYUE_FEAT` | `/spec` 必走，任何改动都要 PLAN→APPROVE |
 | 王梓珩 / Will / Ziheng / wzh | 🟣 UI/UX | `WZH_UI` | `/ui-tweak` 微调；超出 UI 范围转 Yuandong |
 | 文怡力 / Yili / Angel | 🟣 UI/UX | `YILI_UI` | `/ui-tweak`；超出 UI 范围转 Yuandong |
-
-
+| 刘致远 / Zack / lzy / 致远 | 🔵 体验/反馈 | — (无 branch) | 不写代码、不动文件；把想法整理成一句话告诉 Yuandong / Ziyue |
 
 ## 2. 跑 repo 状态 — 报告给用户
 
@@ -74,7 +73,8 @@ gh issue list --repo SeekMi-Technologies/Ola --state open --limit 10
 - **Yuandong** 加新功能 / 改后端 → `/spec` 走 6 phase。trivial single-line fix → 直接动手（Phase 5 EXECUTE + Phase 6 TEST 仍要走，永不豁免）
 - **Ziyue** 任何改动（包括单行 typo）→ `/spec` 必走完 PLAN→APPROVE 才动手。**没有 trivial 豁免**，这是 zyd 明确给 Ziyue 的纪律
 - **Will / Angel** 想改 UI 颜色 / 文字 / 间距 / AntD props → `/ui-tweak` 一步步带。想改业务逻辑 / 加字段 / 动 state → 不能做，转 Yuandong 或 Ziyue
-- **改完、验证通过、想提交** → 任何身份都用 `/ship`
+- **lzy / Zack** 不写代码 — 听他描述需求 / bug，整理成一句话发给 Yuandong 或 Ziyue。**不要带他走 `/spec` 或 `/ui-tweak`**
+- **改完、验证通过、想提交** → 写代码的身份都用 `/ship`
 
 ## 6. 项目速查（用得上时引用）
 

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: onboard
+description: Identify the Ola CRM operator (Yuandong / Ziyue / Will / Angel), report current git branch + task.md state + open GitHub issues, and route to /spec for code work or /ui-tweak for UI tweaks. Use at the start of every fresh Ola CRM session, when the user identifies themselves, asks "what should we do?", or types /onboard.
+---
+
+# Onboard — Ola CRM 上车
+
+> **用户什么语言, 你就用什么语言.** User writes Chinese → reply Chinese. User writes English → reply English. Mixed → mirror dominant. Code identifiers stay English regardless.
+
+## 1. 问身份 — 第一件事
+
+> 你好，我是 Ola CRM 的 AI 开发伙伴。在开始之前，请问你是谁？
+
+匹配下面这张表才能继续。**绝不假设是谁**，即使上次对话是 zyd。
+
+| 名字 / 别名 | 模式 | Branch | 默认下一步 |
+|---|---|---|---|
+| 张元东 / Yuandong / zyd / Duke / 元东 | 🟢 全栈对等 | `ZYD_FEAT` | `/spec` 走流程；trivial typo/单行 fix 可直接动手 |
+| 殷子越 / Ziyue / 子越 | 🟢 全栈对等（**无 trivial 豁免**） | `ZIYUE_FEAT` | `/spec` 必走，任何改动都要 PLAN→APPROVE |
+| 王梓珩 / Will / Ziheng / wzh | 🟣 UI/UX | `WZH_UI` | `/ui-tweak` 微调；超出 UI 范围转 Yuandong |
+| 文怡力 / Yili / Angel | 🟣 UI/UX | `YILI_UI` | `/ui-tweak`；超出 UI 范围转 Yuandong |
+
+
+
+## 2. 跑 repo 状态 — 报告给用户
+
+并行执行这些，给一句话总结：
+
+```bash
+git branch --show-current
+git status --short
+git log origin/dev..HEAD --oneline           # 未推 commits
+git log HEAD..origin/dev --oneline           # 落后于 dev → 提示 rebase
+gh issue list --repo SeekMi-Technologies/Ola --state open --limit 10
+```
+
+读 [task.md](task.md)（在 repo root，gitignored）— 上次工作到哪了？哪些 `[/]` 还在进行？
+
+向用户报告（一句话，不要超过两句）：
+> 当前 [branch]，[N] 个未推 commit，task.md 上还有 [items]，GitHub 有 [M] 个 open issue。今天做什么？
+
+**Branch 检查：操作者的 branch 必须等于身份表里写的那个。** 不一致立刻指出（不要让 Yuandong 在 ZIYUE_FEAT 上写代码、不要让 Angel 在 main 上写）。
+
+## 3. 红线 — 永远生效
+
+不管在做什么任务，这些不能触：
+
+- ❌ **Silent error** — 任何失败必须有明确错误信息。没有 `catch(e){}` 空处理。
+- ❌ **`setTimeout` 替代异步** — 用真正的 async/await 或 Promise。
+- ❌ **`// @ts-ignore` / `// eslint-disable` 绕 bug** — 修根因，不绕。
+- ❌ **Agent 编造产品价格** — 价格永远留空给销售填。
+- ❌ **Silent-error on missing Merch** — 必须明确告诉用户「未找到 [产品名]，请在 Merchandise 添加」。
+- ❌ **删 Mongo collection / index** — zyd 手动做，Agent 不碰。
+- ❌ **改 [docker-compose.yml](docker-compose.yml) 端口或 [.env](backend/.env.example) 内容** — 告诉用户加什么，不自己改。
+- ❌ **Hardcode secrets** — 走环境变量。
+- ❌ **`eval()` / `exec()` / 动态代码执行**。
+- ✅ **Soft delete** 用 `removed: true`，不物理删。
+- ✅ **钱算用 `helpers.calculate.multiply/add/sub`** — 不用原生 `+ - *`（浮点精度）。
+- ✅ **Migration 必须幂等** — 重复执行不出错。
+- ✅ **接口走 `adminAuth.isValidAuthToken`**（已在 [app.js](backend/src/app.js) 全局挂上）。
+- ✅ **Channel 字段不 hardcode `whatsapp`** — WeChat / Email 后面要加。
+
+## 4. 我未经允许不会做
+
+- `git push`（必须先问「可以 push 了吗?」等明确 OK；这是 zyd 的硬协议，不是建议）
+- 合并 PR 到 dev 或 main
+- 改 [docker-compose.yml](docker-compose.yml)、`.env*` 文件
+- SSH 上生产服务器改 `.env.production`（zyd 手动）
+- 删 commit / `git push --force` dev 或 main / `git reset --hard`
+- 引入新 npm 依赖（要先说理由 + 等同意）
+
+## 5. 路由 — 按身份决定下一步
+
+- **Yuandong** 加新功能 / 改后端 → `/spec` 走 6 phase。trivial single-line fix → 直接动手（Phase 5 EXECUTE + Phase 6 TEST 仍要走，永不豁免）
+- **Ziyue** 任何改动（包括单行 typo）→ `/spec` 必走完 PLAN→APPROVE 才动手。**没有 trivial 豁免**，这是 zyd 明确给 Ziyue 的纪律
+- **Will / Angel** 想改 UI 颜色 / 文字 / 间距 / AntD props → `/ui-tweak` 一步步带。想改业务逻辑 / 加字段 / 动 state → 不能做，转 Yuandong 或 Ziyue
+- **改完、验证通过、想提交** → 任何身份都用 `/ship`
+
+## 6. 项目速查（用得上时引用）
+
+- **产品**：Ola = AI 原生外贸 ERP/CRM。MVP = Lead-to-Quote 闭环（WhatsApp 询盘 → Agent 提取产品 → 匹配 [Merch](backend/src/models/appModels/Merch.js) → 协助创建 Quote draft）
+- **栈**：Backend Node 20 + Express + MongoDB Atlas；Frontend React 18 + AntD + Vite + Redux Toolkit；AI 走 sibling [`../nanobot/`](../nanobot/)（Python，MCP 协议接 [backend/src/mcp/](backend/src/mcp/)）
+- **生产 URL**：https://app.olatech.ai（主）；https://app.olajob.cn（过渡，T+2 周下架）
+- **测试账号**：`admin@admin.com / admin123`
+- **本地启动**：`bash start-dev.sh`（一键起 backend 8888 + MCP 8889 + nanobot 8900 + frontend 3000）
+
+## 7. 真理源（重要）
+
+- **本 skill 是 Claude Code 工作流的真理源。** 同类 4 个 skill 在 [.claude/skills/](.claude/skills/) 下：`onboard`（本文）/ `spec` / `ship` / `ui-tweak`
+- **`.agents/workflows/*.md` 是给 Antigravity 的指针**，不要在运行时读它们的内容（已 outdated 风险高）
+- **要更深的产品/技术背景**：人读 [.agents/context/understanding.md](.agents/context/understanding.md) 和 [.agents/context/code_conventions.md](.agents/context/code_conventions.md)。Skill 不依赖它们
+- **想看真实的代码模板** → 直接读 codebase（如 [backend/src/controllers/appControllers/quoteController/](backend/src/controllers/appControllers/quoteController/) 是 controller pattern 的活样本）
+
+## 8. 完成 onboard 后
+
+报告完 repo 状态 → 等用户说今天做什么 → 按 §5 路由到 `/spec` 或 `/ui-tweak`。**onboard 本身不写代码、不动文件**，只识别 + 报告 + 路由。

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: ship
+description: Atomic commit + push + PR for Ola CRM. Auto-detects operator's branch (Yuandong→ZYD_FEAT / Ziyue→ZIYUE_FEAT / Will→WZH_UI / Angel→YILI_UI), runs pre-commit code review, asks for explicit push authorization, pushes to the operator's feature branch, and creates a PR to dev (never main). Use after a backlog item passes Phase 6 verification (or after a /ui-tweak change is approved). Never push without asking first — this is a hard zyd protocol.
+---
+
+# Ship — 原子提交 + PR 到 dev
+
+> **用户什么语言, 你就用什么语言.** Code identifiers stay English regardless.
+>
+> **Push 协议是硬的：** 在执行 `git push` 之前**必须**显式问操作者「可以 push 了吗?」并等明确 OK。这条不是建议，是 zyd 的规则。
+
+## 1. Pre-flight — branch 校验 + 与 dev 同步
+
+```bash
+git branch --show-current
+git fetch origin
+git status --short
+```
+
+操作者的 branch **必须**等于身份表里写的那个：
+
+| 操作者 | Branch |
+|---|---|
+| Yuandong | `ZYD_FEAT` |
+| Ziyue | `ZIYUE_FEAT` |
+| Will | `WZH_UI` |
+| Angel | `YILI_UI` |
+
+- 在 `main` 或 `dev` → ❌ 立刻停。让用户切到正确 branch
+- 不在自己的 branch → ❌ 停。提醒"你应该在 X 上而不是 Y"
+- 在正确 branch → ✅ 继续
+
+```bash
+git log HEAD..origin/dev --oneline    # 落后于 dev 的 commits
+```
+
+有输出 → 提醒用户先 rebase：
+
+```bash
+git rebase origin/dev
+# 如有冲突 → 解决后 git rebase --continue
+```
+
+## 2. Atomicity — 一次 push = 一件事
+
+```bash
+git status
+git diff --stat
+```
+
+**原子化原则：一次推送只包含一个 backlog item / 一个功能 / 一个修复。**
+
+如果 `git status` 显示的改动跨多个不相关 concern，强制拆分：
+```bash
+git add <file1> <file2>            # 只暂存当前 item 相关的文件
+# 其余文件留到下一次 commit
+```
+
+违反原子化的反例：
+- ❌ 同 commit 里既修了 Quote bug 又给 Merch 加新字段
+- ❌ 功能代码和无关的格式化/重命名混在一起
+- ✅ 一个 commit = 一个 Quote 导出功能的完整实现（即使跨 5 文件，function-level atomic OK）
+
+## 3. Pre-commit code review — 走一遍 checklist
+
+```bash
+git diff --staged
+```
+
+逐文件过这些（不通过就修，不要"算了下次再说"）：
+
+**通用：**
+- [ ] `console.log` 已清理（`console.error/warn` 可保留）
+- [ ] 没有 hardcoded secrets / API key / Token
+- [ ] TODO 都有 owner + 日期：`// TODO(zyd): desc, by 2026-MM-DD`
+- [ ] 没引入新 npm 依赖（如果有，必须先和 zyd 沟通且 `package.json` 已更新）
+- [ ] 没破坏已有功能（grep 改动函数的 caller 确认）
+
+**后端改动：**
+- [ ] 响应 shape `{ success, result, message }` 一致（成功失败都是）
+- [ ] 错误码分类正确（400/404/409/500，不是所有都 500）
+- [ ] Joi schemaValidate 在 controller 入口
+- [ ] 每个 catch 块都返回明确错误，没有 `catch(e){}` 空处理
+- [ ] 新 Schema 有 `removed/enabled/createdBy/created/updated` 五字段
+- [ ] 钱算用 `helpers.calculate.*`
+
+**前端改动：**
+- [ ] API 走 `request/` 封装（不直接 `fetch`）
+- [ ] 只用 AntD（无 Material UI / Chakra / Tailwind）
+- [ ] Redux 走 `crud` slice 标准 action
+- [ ] 组件 PascalCase
+- [ ] `cd frontend && npx vite build` 必过
+
+**完整模板对照** → [/spec](../spec/SKILL.md) §2 + 直接读 codebase ([backend/src/controllers/appControllers/quoteController/](../../../backend/src/controllers/appControllers/quoteController/) 是 controller pattern 活样本)。
+
+## 4. Commit message — type(scope): desc
+
+格式：`type(scope): 简明描述`
+
+| type | 用途 | 示例 |
+|---|---|---|
+| `feat` | 新功能 | `feat(quote): add freight calculation` |
+| `fix` | bug fix | `fix(merch): handle null unit_cn when missing` |
+| `refactor` | 重构（不改功能） | `refactor(controller): extract validation` |
+| `docs` | 文档 | `docs(skills): add ship workflow` |
+| `chore` | 杂务（依赖、配置） | `chore(deps): add @modelcontextprotocol/sdk` |
+| `style` | 样式 / 格式 | `style(quote): adjust column width` |
+| `test` | 测试 | `test(quote): add curl assertions for create` |
+
+**scope** = 被改动的模块名：`quote / merch / invoice / client / comparison / auth / agents / mcp / nanobot / deps / deploy / skills / ola`
+
+多行描述（推荐用 heredoc）：
+```bash
+git commit -m "$(cat <<'EOF'
+feat(quote): add freight + discount fields
+
+- Quote schema 加 freight + discount Number 字段
+- create controller 算 total = subtotal + freight - discount
+- QuoteForm 加对应输入框
+- Unit 自动从 Merch 填
+EOF
+)"
+```
+
+**Agent 草拟 commit message → 给用户看 → 用户确认后执行。**
+
+## 5. PUSH PROTOCOL — 硬规则
+
+**在 `git push` 之前必须显式问：**
+
+> 我现在要 push 到 [BRANCH] 了，可以吗？
+
+等用户明确说「可以 / OK / push 吧 / 行」之后才执行。
+
+**不允许的反模式：**
+- ❌ 默认用户同意，直接 push
+- ❌ 用户说「commit 一下」就理解为「也 push」
+- ❌ 在 PR 流程里隐含 push 已批
+
+push 命令：
+```bash
+git push origin $(git branch --show-current)
+```
+
+**绝不直接 `git push origin main` 或 `git push origin dev`。**
+**绝不 `git push --force` 到 dev / main**（feature branch 上 rebase 后 force-push 自己的 branch 是 OK 的）。
+
+push 后确认：
+```bash
+git log -1 --oneline
+git log origin/$(git branch --show-current) -1 --oneline   # remote 同步了
+```
+
+## 6. PR 创建 — `--base dev`，永远不是 main
+
+如果当前 backlog item 是这次工作的最后一个（task.md 全 `[x]`），创建 PR：
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+gh pr create \
+  --base dev \
+  --head "$CURRENT_BRANCH" \
+  --title "type(scope): 简明描述" \
+  --body "$(cat <<'EOF'
+## 改动内容
+
+- 改动点 1
+- 改动点 2
+
+## 验证
+
+- [x] 后端 _verify.js / curl 通过
+- [x] 前端 vite build 通过
+- [ ] (如适用) curl E2E 3 断言通过
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- `--base dev` 固定（**绝不 main**；dev → main 由 Yuandong 手动在 GitHub 操作）
+- title 复用最近一批 commit 的整体描述
+- body 列实际改动 + 勾验证项
+- 关联 GitHub issues 用 `Closes #N` / `Refs #N`
+
+```bash
+gh pr list --state open --head "$CURRENT_BRANCH"
+```
+
+告诉用户 PR URL，让他去 GitHub review/merge。
+
+## 7. 冲突处理
+
+PR 有冲突 → 本地解决：
+```bash
+git fetch origin
+git rebase origin/dev
+# 解冲突 → git add → git rebase --continue
+git push origin "$(git branch --show-current)" --force-with-lease
+```
+
+`--force-with-lease`（不是裸 `--force`）：保护远端被别人推过的情况。
+**永远不 force-push 到 dev / main。**
+
+## 8. Infra-change variant
+
+如果 commit 触到 [/spec](../spec/SKILL.md) §3 列的 infra 文件，push 后**强制**多走一步：部署完成后**立即** curl E2E 3 断言（每个生产 domain 独立验证）：
+
+1. `curl -sS https://<domain>/health` → 200 + `{ status: 'ok' }`
+2. `curl -sS https://<domain>/api/setting/listAll` → **401**（未带 cookie）
+3. 完整 login flow → 200 + 真数据
+
+任一断言失败 → **立即回滚**，不在生产 debug。这条断言跑通之前，task.md 的 `[/]` 不能标 `[x]`。
+
+参考 [feedback_infra_change_curl_e2e](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_infra_change_curl_e2e.md) 和 [feedback_production_rigor_2026_04_21](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_production_rigor_2026_04_21.md)。

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -212,4 +212,4 @@ git push origin "$(git branch --show-current)" --force-with-lease
 
 任一断言失败 → **立即回滚**，不在生产 debug。这条断言跑通之前，task.md 的 `[/]` 不能标 `[x]`。
 
-参考 [feedback_infra_change_curl_e2e](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_infra_change_curl_e2e.md) 和 [feedback_production_rigor_2026_04_21](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_production_rigor_2026_04_21.md)。
+历史教训：PR #111 的 nginx 截断 bug 就是缺这步 E2E 才漏到生产。

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: spec
+description: Spec-Driven Development loop for Ola CRM — runs the 6-phase cycle (PLAN → REVISE → APPROVE → BACKLOG → EXECUTE → TEST) for any non-trivial code change. Enforces the APPROVE gate, task.md discipline, robustness red lines, and Ola's verification pattern (temp _verify.js + curl 3-assertion E2E). Use when starting any backend or full-stack feature, any frontend work beyond pure CSS micro-tweaks, or any infra-touching change. Required for Ziyue on every change (no trivial 豁免). Yuandong gets a single-file trivial bypass; Will/Angel use /ui-tweak for small UI changes.
+---
+
+# Spec — Ola CRM Spec-Driven Development
+
+> **用户什么语言, 你就用什么语言.** User Chinese → reply Chinese. Code identifiers stay English.
+>
+> **Robust over Fancy.** 永远选稳定可维护可测试，不是炫技。
+
+## 0. 谁能 trivial 豁免
+
+| 操作者 | trivial 豁免（跳 Phase 1-3） | 何时算 trivial |
+|---|---|---|
+| Yuandong | ✅ 允许 | 单文件 + 单一关心点 + 零业务逻辑变化（CSS 数值、变量重命名、注释修正、单行 typo） |
+| Ziyue | ❌ **从不允许** | zyd 的明确决定。任何改动都走完 PLAN→APPROVE 才动手 |
+| Will / Angel | UI 微调走 [/ui-tweak](../ui-tweak/SKILL.md)；组件重构 / 改 state / 改 props 接口来这里走完整 6 phase |
+
+碰多于 1 个文件、碰任何 controller / model / Redux slice / API → 不 trivial。
+**Phase 5（EXECUTE）+ Phase 6（TEST）永远不可豁免，对所有人。**
+
+## 1. 6 Phase 循环
+
+```
+用户需求 → PLAN → REVISE → APPROVE → BACKLOG → [EXECUTE → TEST → /ship] × N
+```
+
+### Phase 1: PLAN
+
+不写代码。复述用户的理解 → 列要改/新建的文件路径 → 每个文件的 import/require 依赖（谁 import 它，谁 call 它）→ 列方案文字描述 → 列验收标准。涉及多于 3 个不相关文件 → 建议拆分。多方案时给 pros/cons。
+
+### Phase 2: REVISE
+
+用户改方案，来回多次。按反馈修方案，不抢着写代码。直到用户满意。
+
+### Phase 3: APPROVE — 硬门
+
+用户**明确说**「approved / 开始 / 可以 / 没问题 / 干 / 上」之后才进 Phase 4。
+
+- ❌「行吧」「嗯」「ok」**不算** — 再问一次「我开始？」
+- ❌「我先快速试一下」**不算** — 试就是 EXECUTE，没 APPROVE 不能
+- ❌ 隐含同意（用户没说不就是默许）**绝对不算**
+- ✅ 仅限 Yuandong：「直接改」算（trivial 豁免范围内）
+
+### Phase 4: BACKLOG
+
+拆成 [task.md](../../../task.md) 里的独立 backlog item。task.md 是 gitignored 工作文档，永不 commit。
+
+每个 item:
+- **独立可验证** — 完成后能立刻测试
+- **Atomic = function-level，不是 file-level** — 一个 function-level 改动跨 5 文件也归一个 item（schema + validate + controller 一起改的话不能拆，否则中间状态不一致）。`≤3 文件` 是软目标
+- **明确验收** — 具体到能 curl / grep / vite build 验
+- 状态：`[ ]` todo · `[/]` in-progress · `[x]` done · `[!]` blocked
+
+### Phase 5: EXECUTE — 一次只做一件事
+
+从 task.md 取第一个 `[ ]` → 标 `[/]` → **只做这一个 item**，不顺手修别的。逐文件实现，每个文件改完一句话说明动机。
+
+发现 out-of-scope 问题 → 加到 task.md 「Discovered tech debt」段，**不当场修**。这一条违反就是漂移的开始。
+
+### Phase 6: TEST — 永不豁免
+
+按 item 验收标准验证。Ola 没有 jest/vitest 配置（这是有意决定，见 [feedback_verification_pattern](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_verification_pattern.md)）。验证方式：
+
+- **后端逻辑：** 临时 `_verify.js` 紧挨改的文件，autoload 所有 model：
+  ```javascript
+  require('module-alias/register');
+  require('@/models/utils');  // 关键：autoload 所有 Mongoose model
+  // ... 断言 ...
+  ```
+  跑完 `rm` 掉。永远不 commit `_verify.js`。
+- **HTTP 接口：** curl **至少 3 条断言**（[feedback_acceptance_criteria_depth](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_acceptance_criteria_depth.md)）：
+  1. Happy path → `success: true` + 期望的 result shape
+  2. Negative case → 400 / 404 / 409 + 具体中文 message
+  3. **Protocol 入口之后的第二次调用** — 不是只测第一步就完事
+- **前端：** `cd frontend && npx vite build` 必过（eslint 配置经常坏，可跳）
+- **infra 改动**（见 §4）→ curl E2E 3 条强制
+
+通过 → 问用户「可以 push 了吗?」→ 等明确 OK → [/ship](../ship/SKILL.md) → 标 `[x]` → 回 Phase 5。
+失败 → 修到通过，**不跳下一个**。
+
+## 2. 横切红线（写代码时这些是底线）
+
+[/onboard](../onboard/SKILL.md) §3 列了完整红线。写代码时这些必须过：
+
+- **后端：**
+  - 响应 shape 必须 `{ success, result, message }`（成功失败都是）
+  - 错误码分类正确：400 输入错 / 404 不存在 / 409 冲突 / 500 系统错。**不是所有错都返 500**
+  - 输入用 Joi schema 校验（在 controller 入口）
+  - 新 Mongoose Schema 必须含 `removed / enabled / createdBy / created / updated` 五字段
+  - 钱算用 [`helpers.calculate.multiply/add/sub`](../../../backend/src/helpers/index.js) — 永远不用原生 `+ - *`
+  - 所有 controller 方法被 `catchErrors()` 包装（在 [handlers/errorHandlers.js](../../../backend/src/handlers/errorHandlers.js)）
+  - Soft delete via `removed: true`，不物理删
+- **前端：**
+  - API 必须走 [request/](../../../frontend/src/request/) 封装，不直接 `fetch()` / `XMLHttpRequest`
+  - 只用 AntD，不引 Material UI / Chakra / Tailwind
+  - Redux 走 `crud` slice 标准 action（`crud.create / read / update / delete / list`）
+  - 组件 PascalCase，文件名和组件名一致
+- **通用：**
+  - No silent catch — 每个 catch 块返回具体错误
+  - No `setTimeout` 假装异步 — 用真 async/await
+  - No `// @ts-ignore` / `// eslint-disable` 绕 bug
+  - TODO 格式 `// TODO(owner): desc, by 2026-MM-DD`
+  - 不引入新 npm 依赖（要先说理由 + 等同意）
+
+**模板就在 codebase 里，不要凭记忆写：**
+- Controller 模式（createCRUDController + 覆盖）→ [quoteController/index.js](../../../backend/src/controllers/appControllers/quoteController/index.js)
+- 自定义 create with Joi + 业务校验 → [quoteController/create.js](../../../backend/src/controllers/appControllers/quoteController/create.js) + [quoteController/schemaValidate.js](../../../backend/src/controllers/appControllers/quoteController/schemaValidate.js)
+- Mongoose Schema 五字段 → 任一 [models/appModels/](../../../backend/src/models/appModels/)
+- 前端 ErpPanelModule 用法 → [pages/Quote/](../../../frontend/src/pages/Quote/)
+- request 封装 → [request/request.js](../../../frontend/src/request/request.js)
+
+## 3. Infra-change 升级路径 — 触到立刻停
+
+碰下面任意一个，**停止 EXECUTE，明确告诉 Yuandong 这是 infra 改动，等显式 go-ahead**：
+
+- [createCRUDController](../../../backend/src/controllers/middlewaresControllers/createCRUDController/)
+- [errorHandlers](../../../backend/src/handlers/errorHandlers.js)
+- [appApi.js auto-route registration](../../../backend/src/routes/appRoutes/appApi.js)
+- nginx 配置 / Cloudflare 设置
+- [docker-compose.yml](../../../docker-compose.yml)
+- auth middleware
+- 任何 `.env*` 文件
+- `.env.production` 在 Box1 上（永远 SSH 改，不本地改）
+
+部署后**必须**立刻 curl E2E（每个生产 domain 独立验证），3 条断言：
+1. `curl -sS https://<domain>/health` → 200 + `{ status: 'ok' }`
+2. `curl -sS https://<domain>/api/setting/listAll` → **401**（未带 cookie）
+3. 完整 login + cookie + 受保护接口 → 200 + 真数据
+
+任一断言失败 → **立即回滚**，不在生产 debug。参考 [feedback_infra_change_curl_e2e](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_infra_change_curl_e2e.md) 和 [feedback_production_rigor_2026_04_21](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_production_rigor_2026_04_21.md)（PR #111 nginx 截断 bug 就是这条缺失导致的）。
+
+## 4. 出口
+
+- 当前 item Phase 6 通过 → 问「可以 push 了吗?」→ Yuandong/Ziyue/Will/Angel 明确 OK → [/ship](../ship/SKILL.md) → 标 `[x]` → 回 Phase 5 拿下一个 `[ ]`
+- task.md 所有 item `[x]` → [/ship](../ship/SKILL.md) 创建 PR 到 dev（**不是 main**）
+- 中途遇 §3 infra 触发 → 停 → 等 Yuandong 明确批 → 走 §3 流程

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -61,7 +61,7 @@ description: Spec-Driven Development loop for Ola CRM — runs the 6-phase cycle
 
 ### Phase 6: TEST — 永不豁免
 
-按 item 验收标准验证。Ola 没有 jest/vitest 配置（这是有意决定，见 [feedback_verification_pattern](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_verification_pattern.md)）。验证方式：
+按 item 验收标准验证。Ola 没配 `npm test` 脚本（有意决定）— jest 和 vitest 已装在 `backend/package.json` 和 `frontend/package.json`，需要时用 `npx jest` / `npx vitest` 直接跑。日常验证方式：
 
 - **后端逻辑：** 临时 `_verify.js` 紧挨改的文件，autoload 所有 model：
   ```javascript
@@ -70,7 +70,7 @@ description: Spec-Driven Development loop for Ola CRM — runs the 6-phase cycle
   // ... 断言 ...
   ```
   跑完 `rm` 掉。永远不 commit `_verify.js`。
-- **HTTP 接口：** curl **至少 3 条断言**（[feedback_acceptance_criteria_depth](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_acceptance_criteria_depth.md)）：
+- **HTTP 接口：** curl **至少 3 条断言**（不接受"endpoint 不 500 就算过"）：
   1. Happy path → `success: true` + 期望的 result shape
   2. Negative case → 400 / 404 / 409 + 具体中文 message
   3. **Protocol 入口之后的第二次调用** — 不是只测第一步就完事
@@ -129,7 +129,7 @@ description: Spec-Driven Development loop for Ola CRM — runs the 6-phase cycle
 2. `curl -sS https://<domain>/api/setting/listAll` → **401**（未带 cookie）
 3. 完整 login + cookie + 受保护接口 → 200 + 真数据
 
-任一断言失败 → **立即回滚**，不在生产 debug。参考 [feedback_infra_change_curl_e2e](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_infra_change_curl_e2e.md) 和 [feedback_production_rigor_2026_04_21](../../../../../.claude/projects/-Users-duke-Documents-GitHub-crm/memory/feedback_production_rigor_2026_04_21.md)（PR #111 nginx 截断 bug 就是这条缺失导致的）。
+任一断言失败 → **立即回滚**，不在生产 debug。历史教训：PR #111 的 nginx 截断 bug 就是缺这步 E2E 才漏到生产。
 
 ## 4. 出口
 

--- a/.claude/skills/ui-tweak/SKILL.md
+++ b/.claude/skills/ui-tweak/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: ui-tweak
+description: Foolproof guided UI micro-edit for Will and Angel (Ola UI/UX teammates) — change a button color, copy text, AntD prop, layout className, spacing, or font. Walks the user through plain-language intake → locate the file → preview the change → verify with vite build → hand off to /ship. Hard-walled scope: only CSS / .less / .scss / className / 文案 / AntD props. Refuses anything that needs business logic, state, Redux, request, or backend changes — those route to Yuandong or Ziyue. Use when a UI/UX teammate wants a small visual change.
+---
+
+# UI Tweak — 给 Will / Angel 的傻瓜版前端微调
+
+> **用户什么语言, 你就用什么语言.** Will/Angel 默认中文 — 你也用中文。无术语，多举例，每一步都让用户看见你在做什么。
+>
+> **核心承诺**：你不用懂代码。你描述要改什么，我帮你找到文件、改、给你看效果、push 到你的 branch。
+
+## 1. 听你想改什么 — 用大白话
+
+第一步**永远是问**，不要猜：
+
+> 你好！我帮你改 UI。先告诉我，你想改的是哪一种？
+>
+> 1. **颜色** — 比如某个按钮变绿、背景变浅
+> 2. **文字** — 比如把"新建"改成"添加新报价单"
+> 3. **大小** — 字大一点、按钮小一点、卡片宽一点
+> 4. **位置** — 把这个挪到右边、上下颠倒
+> 5. **AntD 组件 prop** — 比如让 input 变成大号、加个 placeholder
+> 6. **别的** — 描述一下你想要什么效果
+
+听用户回答。如果用户描述模糊（"那个看起来怪怪的"），追问到具体：
+- 哪个页面？（"Quote 列表页" / "Ask Ola" / "登录页"）
+- 哪个元素？（"右上角的按钮" / "输入框旁边的提示文字"）
+- 怎么改？（"颜色变浅一点" — 多浅？"# 颜色 + 形容词" 都行，我会试）
+
+## 2. 帮你找到文件 — 你不用搜
+
+用户说完后，**你（Claude）**去 codebase 找：
+
+```bash
+# 如果是文字改动 — 直接 grep 字符串
+grep -rn "新建" frontend/src/                 # 找「新建」按钮
+grep -rn "新建报价单" frontend/src/
+
+# 如果是颜色 / 样式 — 找页面
+ls frontend/src/pages/Quote/                  # Quote 相关页面
+ls frontend/src/modules/QuoteModule/          # Quote 模块（包含 forms）
+ls frontend/src/forms/                        # 各种表单
+
+# 如果是 AntD 组件配置 — 找 component 文件
+grep -rn "Button" frontend/src/pages/Quote/   # Quote 页所有 Button
+```
+
+找到候选位置后，**给用户看 + 确认**：
+
+> 我找到了，应该是这里：
+>
+> [QuoteList.jsx 第 42 行](frontend/src/pages/Quote/QuoteList.jsx#L42)
+>
+> ```jsx
+> <Button type="primary" onClick={handleNew}>新建</Button>
+> ```
+>
+> 这是 Quote 列表页右上角的"新建"按钮，点了会跳转到新建报价单页面。
+>
+> 是这一个吗？
+
+**不要直接改，等用户说"对，就是这个"再动手。** 如果用户说"不是"，再问"那是哪个？" 或继续搜。
+
+## 3. 你能改 / 不能改 — 硬墙
+
+**✅ 可以改：**
+- `.css`、`.less`、`.scss` 文件里所有内容
+- JSX 里的 `className="..."`
+- JSX 里的中文 / 英文文案字符串（按钮文字、placeholder、tooltip 文案、错误提示文案）
+- AntD 组件的 props：`type`、`size`、`shape`、`placeholder`、`title`、`tooltip`、`style={{ ... }}`、`disabled` 静态值
+- 布局结构调整（`<Row>` `<Col>` 的 `gutter`、`span`，`<Space>` 的 `size` 和 `direction`，`<Card>` 的 `bordered`、`hoverable`）
+- 图标替换（AntD `<Icon>` 换名字）
+- 图片 `<img src="..." />` 路径
+
+**❌ 不能改（碰到任何一个，立刻停 + 转 Yuandong/Ziyue）：**
+- `useState`、`useEffect`、`useMemo` 等任何 React Hook
+- `dispatch(...)` 任何 Redux action
+- `request.create / read / update / delete / list` 任何 API 调用
+- 任何 `props` 接口定义 / TypeScript type / PropTypes
+- 任何 `if/else`、`map`、`filter`、`reduce` 控制流
+- `backend/` 下任何文件（**完全不能碰**）
+- `frontend/src/redux/`、`frontend/src/request/`、`frontend/src/router/` 下任何文件
+- `package.json`、`vite.config.js`、`.env*`
+- 加新的 `import` 语句（除了 import 一个新的 AntD 组件名 — 这个 OK）
+
+**判断不确定时：默认拒绝 + 问 Yuandong。** 错杀好过越界。
+
+**当用户的需求超出"可以改"范围**，话术：
+
+> 你想要的这个改动需要改业务逻辑（不只是 UI），我不能直接做。
+>
+> 我转给 Yuandong / Ziyue 处理 — 你可以这样跟他说：
+> "[在 Quote 列表页] 我想 [加一个状态字段]"
+>
+> 我帮你把要点列出来，他看到就懂。
+
+不要找借口绕过这堵墙。
+
+## 4. 改之前先给你看 diff
+
+确认了文件 + 用户说要改 → **不要直接改**。先给用户看你打算改成什么：
+
+> 我准备这样改：
+>
+> **改前：**
+> ```jsx
+> <Button type="primary">新建</Button>
+> ```
+>
+> **改后：**
+> ```jsx
+> <Button type="primary" size="large">添加新报价单</Button>
+> ```
+>
+> 也就是把按钮文字从"新建"改成"添加新报价单"，并且把按钮变大。
+>
+> 看着对吗？我现在改？
+
+等用户说「对 / OK / 改吧」再 Edit 文件。
+
+## 5. 改完跑 vite build + 让你眼看
+
+改完后，**两步验证**：
+
+**第一步：build 不能挂**
+```bash
+cd frontend && npx vite build 2>&1 | tail -20
+```
+- build 通过 → 继续下一步
+- build 失败 → 立刻 revert（`git checkout -- <file>`），告诉用户"改完页面 build 不过，我把改动还原了。错误是：[错误内容]"
+
+**第二步：眼看效果**
+
+启动 dev server（如果还没起）：
+```bash
+# 如果后端也在本地：
+cd frontend && npm run dev
+# 如果后端不在本地（推荐 Will/Angel 用这个，不用配后端）：
+cd frontend && npm run dev:remote
+```
+
+告诉用户：
+
+> dev server 起好了，浏览器打开 http://localhost:3000
+> 跳到 [Quote 列表页]（点左边导航的"报价单"）
+> 看一下按钮是不是你想要的样子？
+>
+> 我等你确认。
+
+**等用户回复**。Will/Angel 说「好」/「没问题」之前不要往下走。
+
+如果用户说「不对，颜色再深一点」/「字再大一点」→ 回到 §4，再调一轮，再让看。可以来回多次，这是正常的。
+
+## 6. 用户满意 → 交给 /ship
+
+用户确认好了：
+
+> 改好了 ✅ 我现在准备 push 到你的 branch（[WZH_UI / YILI_UI]），可以吗？
+
+等用户说「可以」→ 调用 [/ship](../ship/SKILL.md) 流程，但只跑前端 checklist：
+
+- ✅ vite build 已通过
+- ✅ 没碰 backend/
+- ✅ 没引入新依赖
+- ✅ 改动只在 css / className / 文案 / AntD props 范围
+
+commit message 用 `style(scope): desc` 格式，比如：
+```
+style(quote): 「新建」按钮文字改为「添加新报价单」+ 改成大号
+```
+
+push 到操作者的 branch（Will → `WZH_UI` / Angel → `YILI_UI`）。**绝不 push 到 main / dev**。
+
+## 7. 失败模式 → 转给 Yuandong
+
+下面这些情况，**立刻转 Yuandong**，不要硬撑：
+
+- 🚫 用户描述的元素你找不到对应文件（搜 3 次还没头绪）
+- 🚫 改完 vite build 挂了，revert 后告诉用户但用户还是想要这个改动
+- 🚫 用户说"我想加一个新字段 / 新按钮 / 新页面" — 这是新功能，不是 tweak
+- 🚫 用户说"那个数据不对" — 是后端 / 数据问题，不是 UI
+- 🚫 用户说"我想让点击之后跳到 X" — 是路由 / state 改动，不是 UI
+
+转的话术：
+
+> 这个改动超出我的范围，需要 Yuandong / Ziyue 处理（涉及 [业务逻辑 / 数据 / 路由]）。
+>
+> 你可以这样跟他说：
+> "[页面/位置] 我想 [需求]"
+>
+> 比如："Quote 列表页我想加一个'状态'筛选下拉框"
+>
+> 等他做完你再来 /ui-tweak 我帮你调样式。
+
+## 8. 别忘了
+
+- **每改一个文件之前先给用户看 diff**，不要默默改
+- **每改完一次都让用户眼看**，不要默默 commit
+- **一次只做一件事** — 用户同时说「按钮变大 + 卡片变宽 + 文字加粗」→ 拆开，一次一个，每个都过 §4-§5
+- **耐心** — Will/Angel 不写代码，他们的判断标准是"看着对不对"，不是"代码对不对"。你的任务是让"看着对"成立

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,39 +2,62 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## ⚠️ Read this first — `.agents/` is the source of truth
+## ⚠️ Read this first — Dual workflow source
 
-Before doing any work, read these files in order. They are not optional — they define identity-gated permissions, the SDD development discipline, and the exact code patterns to use.
+Ola maintains **two parallel workflow doc sets** (as of 2026-04-26):
 
-1. `.agents/workflows/onboard.md` — entry-point ruleset, run every new conversation
-2. `.agents/context/understanding.md` — company / product / data model / tech decisions (the only authoritative source for product facts)
-3. `.agents/context/code_conventions.md` — controller/model/response templates, frontend rules
-4. `.agents/context/develop.md` — the SDD 6-phase loop (PLAN → REVISE → APPROVE → BACKLOG → EXECUTE → TEST), always-on
+| Tool | Source of truth | How loaded |
+|---|---|---|
+| **Claude Code** (Yuandong / Ziyue / Angel) | [`.claude/skills/`](.claude/skills/) — 4 skills: `onboard`, `spec`, `ship`, `ui-tweak` | Auto-loaded via skill `description` matching; or invoke explicitly: `/onboard` `/spec` `/ship` `/ui-tweak` |
+| **Antigravity** (Will, currently) | `.agents/workflows/*.md` + `.agents/context/*.md` | Antigravity reads `.agents/` directly |
+
+**Claude Code users — start here:**
+
+1. **`/onboard`** — identity gate (Yuandong / Ziyue / Will / Angel) + git/issue/task.md state report + routing
+2. **`/spec`** — for any non-trivial code work (6-phase SDD loop). Required for Ziyue on every change (no trivial 豁免)
+3. **`/ship`** — atomic commit + push (always asks first) + PR to dev (never main)
+4. **`/ui-tweak`** — for Will / Angel making small UI changes (color, copy, AntD prop, layout)
+
+**Skills are self-contained — they do NOT read `.agents/` at runtime.** All rules and identity tables are embedded in skill bodies, with pointers to live codebase for templates (e.g. `quoteController/index.js` is the canonical Controller pattern).
+
+**Maintenance discipline:** workflow changes that apply to all team members must be edited in BOTH the relevant skill AND the matching `.agents/` file (until Will migrates off Antigravity, at which point `.agents/workflows/*.md` collapse to pure pointers — deferred Phase J5/J6 in `task.md`).
+
+**Antigravity users (Will):** the legacy `.agents/` doc set is still canonical for you. Read in this order:
+
+1. `.agents/workflows/onboard.md` — entry-point ruleset
+2. `.agents/context/understanding.md` — company / product / data model
+3. `.agents/context/code_conventions.md` — controller/model/response templates
+4. `.agents/context/develop.md` — SDD 6-phase loop
 5. `.agents/workflows/{push,pr,start}.md` — invoked as `/push`, `/pr`, `/start`
 
 ### Identity gating (ask "你是谁?" at the start of a new conversation)
 
-| User | Mode | Allowed |
-|---|---|---|
-| **zyd / 张元东 / yuandong** | 🟢 peer | full-stack; trivial single-file fixes may skip Phase 1–3 |
-| **wzh / 王梓珩 / Will** | 🟡 protected | **frontend UI/style only** — `.css/.less/.scss`, JSX className/文案/layout, AntD props. ❌ Forbidden: anything in `backend/`, `models/`, API routes, `docker-compose.yml`, `.env`, `request/` config. Must walk all phases. |
-| **lzy / 刘致远 / zhiyuan** | 🔵 experience | no code; collect feedback for zyd |
+| User | Branch | Mode | Allowed |
+|---|---|---|---|
+| **Yuandong / 张元东 / zyd / Duke** | `ZYD_FEAT` | 🟢 peer | Full-stack; trivial single-file fixes may skip Phase 1–3 |
+| **Ziyue / 殷子越** | `ZIYUE_FEAT` | 🟢 peer (no trivial 豁免) | Full-stack; **must walk all 6 phases regardless of change size** (zyd's explicit decision) |
+| **Will / 王梓珩 / Ziheng / wzh** | `WZH_UI` | 🟣 UI/UX | `.css/.less/.scss`, JSX className/文案/layout, AntD props. ❌ Forbidden: `backend/`, `models/`, API routes, `docker-compose.yml`, `.env`, `request/` config |
+| **Angel / 文怡力 / Yili** | `YILI_UI` | 🟣 UI/UX | Same as Will. UT Dallas HCI PhD, UI/UX 专家 |
+| **lzy / 刘致远 / Zack / Zhiyuan** | — | 🔵 experience | No code; collects product feedback for Yuandong. Not in code-skill identity gates |
 
 ### SDD discipline (always-on after onboard)
 
 - **One backlog item at a time.** Track in `task.md`. Mark `[/]` in-progress, `[x]` done.
 - **No code before APPROVE.** Restate the plan, list affected files + their import/require deps, and wait for explicit "approved / 开始 / 可以".
 - **Test before advancing.** A failed item is fixed in place, never deferred. Out-of-scope discoveries → new backlog item, not an in-line fix.
-- **Done = pushed.** Each finished item → `/push` → mark `[x]` → next item. All items done → `/pr`.
-- **Trivial exemption (zyd only):** single-line typo / CSS / rename / unambiguous single-file fix may skip 1–3. Phase 5–6 are never skippable.
+- **Done = pushed.** Each finished item → `/ship` (Claude Code) or `/push` (Antigravity) → mark `[x]` → next item. All items done → `/pr` or `/ship`-PR.
+- **Trivial exemption (Yuandong only):** single-line typo / CSS / rename / unambiguous single-file fix may skip 1–3. **Ziyue does NOT get this exemption** — must walk all 6 phases. Phase 5–6 are never skippable for anyone.
+- **Push protocol:** before any `git push`, ask "可以 push 了吗?" and wait for explicit OK.
 
 ### Branch policy
 
 | User | Dev branch | Merge target |
 |---|---|---|
-| zyd | `ZYD_FEAT` | PR → `dev` |
-| wzh | `WZH_UI` | PR → `dev` |
-| — | `dev` → `main` | zyd-only, manually on GitHub |
+| Yuandong | `ZYD_FEAT` | PR → `dev` |
+| Ziyue | `ZIYUE_FEAT` | PR → `dev` |
+| Will (wzh) | `WZH_UI` | PR → `dev` |
+| Angel (Yili) | `YILI_UI` | PR → `dev` |
+| — | `dev` → `main` | Yuandong-only, manually on GitHub |
 
 Never commit on `main` or `dev`. PRs target **`dev`**, not `main`. Before pushing, rebase on `origin/dev`.
 


### PR DESCRIPTION
## 改动内容

新增 4 个项目级 Claude Code skills 在 `.claude/skills/`，统一团队的 Claude Code 工作流：

- **`onboard`** (96 行) — 身份门控 (Yuandong / Ziyue / Will / Angel)，repo 状态报告，路由到 `/spec` 或 `/ui-tweak`
- **`spec`** (138 行) — 6-phase SDD 闭环，APPROVE 硬门，`_verify.js` + curl 3 断言验证模式，trivial 豁免分割（Yuandong YES，Ziyue NO）
- **`ship`** (215 行) — branch 自动检测，原子提交，**ASK-FIRST push 协议**，PR 到 dev (永不 main)，infra-change curl E2E
- **`ui-tweak`** (200 行) — 给 Will/Angel 的傻瓜版前端微调，硬墙限制在 CSS / className / AntD props，业务逻辑改动转 Yuandong

Skills self-contained：**runtime 不读 `.agents/`**。模板指向 live codebase（如 [`quoteController/index.js`](backend/src/controllers/appControllers/quoteController/index.js)）。Description 都 < 1536 字符上限以保证 auto-invocation 触发。

## CLAUDE.md 更新

加双源说明：
- `.claude/skills/` for Claude Code (Yuandong / Ziyue / Angel)
- `.agents/` 保留 for Antigravity (Will，仍在用)

两边并行维护直到 Will 迁移到 Claude Code。`.agents/workflows/*.md` 收敛到 pure pointers 是 deferred work（task.md 里 J5/J6 标 `[~]`）。

身份表更新：5 行（含 Ziyue, Angel, lzy/Zack 仍在团队但不开发）。Branch 策略表加 `ZIYUE_FEAT` + `YILI_UI`。

## 配套

- ✅ `YILI_UI` branch 已从 `origin/dev` 创建（commit `37a7dd5`），Angel 可以直接 push
- ✅ Memory 5 条同步：team_roster (5 人) / skill_inversion (双源) / ziyue_no_trivial / 修正 user_zyd 和 ola_overview 和 sdd_discipline

## 验证

- [x] 自动：4 个 SKILL.md 都有合法 YAML frontmatter
- [x] 自动：description 全部 < 1536 字符（最长 spec 583）
- [x] 自动：line count 全部 < 500 行软上限（最多 ship 215）
- [x] 自动：`grep "Read.*\.agents/"` 空 — 无运行时 `.agents/` 依赖
- [x] 自动：YILI_UI branch 在 remote (`git ls-remote origin YILI_UI` 返 SHA)
- [x] 手测：onboard 路由（zyd 已确认 E2E 1 通过）
- [ ] 手测：spec APPROVE gate / Ziyue no-trivial 分支
- [ ] 手测：ship ASK-FIRST 协议（**本 PR 的 push 流程本身是测试结果 — 通过**）
- [ ] 手测：ui-tweak 硬墙（请 Angel 试一次"加新字段"应被拒）

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)