### PR TITLE
fix(crud): default paginatedList sort to created desc (closes #163)

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/test/**/*.test.js'],
+  setupFiles: ['<rootDir>/test/jest.setup.js'],
+  testTimeout: 60000,
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "setup": "node src/setup/setup.js",
     "add-admin": "node src/setup/addAdmin.js",
     "reset": "node src/setup/reset.js",
-    "mcp:dev": "node src/mcp/server.js"
+    "mcp:dev": "node src/mcp/server.js",
+    "test": "jest"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.509.0",

--- a/backend/src/controllers/appControllers/invoiceController/paginatedList.js
+++ b/backend/src/controllers/appControllers/invoiceController/paginatedList.js
@@ -7,7 +7,8 @@ const paginatedList = async (req, res) => {
   const limit = parseInt(req.query.items) || 10;
   const skip = page * limit - limit;
 
-  const { sortBy = 'enabled', sortValue = -1, filter, equal } = req.query;
+  const { sortBy, sortValue = -1, filter, equal } = req.query;
+  const sortSpec = sortBy ? { [sortBy]: Number(sortValue) } : { created: -1, _id: -1 };
 
   const fieldsArray = req.query.fields ? req.query.fields.split(',') : [];
 
@@ -28,7 +29,7 @@ const paginatedList = async (req, res) => {
   })
     .skip(skip)
     .limit(limit)
-    .sort({ [sortBy]: sortValue })
+    .sort(sortSpec)
     .populate('createdBy', 'name')
     .exec();
 

--- a/backend/src/controllers/appControllers/purchaseOrderController/paginatedList.js
+++ b/backend/src/controllers/appControllers/purchaseOrderController/paginatedList.js
@@ -8,7 +8,8 @@ const paginatedList = async (req, res) => {
   const skip = page * limit - limit;
 
   //  Query the database for a list of all results
-  const { sortBy = 'enabled', sortValue = -1, filter, equal } = req.query;
+  const { sortBy, sortValue = -1, filter, equal } = req.query;
+  const sortSpec = sortBy ? { [sortBy]: Number(sortValue) } : { created: -1, _id: -1 };
 
   const fieldsArray = req.query.fields ? req.query.fields.split(',') : [];
 
@@ -29,7 +30,7 @@ const paginatedList = async (req, res) => {
   })
     .skip(skip)
     .limit(limit)
-    .sort({ [sortBy]: sortValue })
+    .sort(sortSpec)
     .populate('createdBy', 'name')
     .exec();
 

--- a/backend/src/controllers/appControllers/quoteController/paginatedList.js
+++ b/backend/src/controllers/appControllers/quoteController/paginatedList.js
@@ -8,7 +8,8 @@ const paginatedList = async (req, res) => {
   const skip = page * limit - limit;
 
   //  Query the database for a list of all results
-  const { sortBy = 'enabled', sortValue = -1, filter, equal } = req.query;
+  const { sortBy, sortValue = -1, filter, equal } = req.query;
+  const sortSpec = sortBy ? { [sortBy]: Number(sortValue) } : { created: -1, _id: -1 };
 
   const fieldsArray = req.query.fields ? req.query.fields.split(',') : [];
 
@@ -30,7 +31,7 @@ const paginatedList = async (req, res) => {
   })
     .skip(skip)
     .limit(limit)
-    .sort({ [sortBy]: sortValue })
+    .sort(sortSpec)
     .populate('createdBy', 'name')
     .exec();
 

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
@@ -3,7 +3,8 @@ const paginatedList = async (Model, req, res) => {
   const limit = parseInt(req.query.items) || 10;
   const skip = page * limit - limit;
 
-  const { sortBy = 'enabled', sortValue = -1, filter, equal } = req.query;
+  const { sortBy, sortValue = -1, filter, equal } = req.query;
+  const sortSpec = sortBy ? { [sortBy]: Number(sortValue) } : { created: -1, _id: -1 };
 
   const fieldsArray = req.query.fields ? req.query.fields.split(',') : [];
 
@@ -25,7 +26,7 @@ const paginatedList = async (Model, req, res) => {
   })
     .skip(skip)
     .limit(limit)
-    .sort({ [sortBy]: sortValue })
+    .sort(sortSpec)
     .populate()
     .exec();
 

--- a/backend/test/jest.setup.js
+++ b/backend/test/jest.setup.js
@@ -1,0 +1,4 @@
+require('module-alias/register');
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
+process.env.NODE_ENV = 'test';

--- a/backend/test/paginatedList.test.js
+++ b/backend/test/paginatedList.test.js
@@ -1,0 +1,265 @@
+/**
+ * Regression test for issue #163 — paginatedList default sort.
+ *
+ * Bug history: the generic and per-entity paginatedList controllers defaulted
+ * `sortBy='enabled'`, a field that does not exist on Quote / Invoice /
+ * PurchaseOrder / Payment / Merch / Factory schemas. Mongo silently fell back
+ * to natural order, so newly inserted documents did not reliably appear on
+ * page 1 of the list. Fix: use `{ created: -1, _id: -1 }` as the default
+ * sort spec — semantic for entities with `created`, deterministic via _id
+ * tiebreaker for entities without it (Merch, Factory) and across same-second
+ * inserts.
+ */
+
+const path = require('path');
+const { globSync } = require('glob');
+const express = require('express');
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+const adminId = new mongoose.Types.ObjectId();
+
+let mongo;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  for (const name of ['Quote', 'Invoice', 'PurchaseOrder', 'Payment', 'Merch', 'Factory', 'Client']) {
+    if (mongoose.models[name]) {
+      await mongoose.models[name].deleteMany({});
+    }
+  }
+});
+
+function buildEntityApp(controllerRelPath) {
+  const controller = require(path.join(BACKEND_ROOT, controllerRelPath));
+  const app = express();
+  app.use((req, _res, next) => {
+    req.admin = { _id: adminId };
+    next();
+  });
+  app.get('/list', (req, res) => controller(req, res));
+  return app;
+}
+
+function buildGenericApp(Model) {
+  const generic = require(
+    path.join(BACKEND_ROOT, 'src/controllers/middlewaresControllers/createCRUDController/paginatedList')
+  );
+  const app = express();
+  app.use((req, _res, next) => {
+    req.admin = { _id: adminId };
+    next();
+  });
+  app.get('/list', (req, res) => generic(Model, req, res));
+  return app;
+}
+
+async function seedClient() {
+  return mongoose.model('Client').create({
+    name: 'Test Client',
+    country: 'CN',
+    createdBy: adminId,
+  });
+}
+
+function quoteFixture(overrides) {
+  return {
+    number: 'Q-DEFAULT',
+    year: 2026,
+    date: new Date('2026-01-01'),
+    expiredDate: new Date('2026-02-01'),
+    createdBy: adminId,
+    items: [{ itemName: 'X', quantity: 1, price: 1, total: 1 }],
+    total: 1,
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+describe('paginatedList default sort — issue #163 regression', () => {
+  describe('Quote (per-entity override)', () => {
+    test('returns newest-first by created desc when sortBy is not provided', async () => {
+      const client = await seedClient();
+      const Quote = mongoose.model('Quote');
+      await Quote.create([
+        quoteFixture({ number: 'Q-OLD', client: client._id, created: new Date('2025-01-01') }),
+        quoteFixture({ number: 'Q-MID', client: client._id, created: new Date('2025-06-01') }),
+        quoteFixture({ number: 'Q-NEW', client: client._id, created: new Date('2026-04-27') }),
+      ]);
+
+      const app = buildEntityApp('src/controllers/appControllers/quoteController/paginatedList');
+      const res = await request(app).get('/list?page=1&items=10');
+
+      expect(res.status).toBe(200);
+      expect(res.body.result.map((q) => q.number)).toEqual(['Q-NEW', 'Q-MID', 'Q-OLD']);
+    });
+
+    test('is stable across consecutive calls and produces no page-1/page-2 overlap when many docs share the same `created`', async () => {
+      const client = await seedClient();
+      const Quote = mongoose.model('Quote');
+      const sameTime = new Date('2026-01-01T00:00:00Z');
+      await Quote.insertMany(
+        Array.from({ length: 25 }, (_, i) =>
+          quoteFixture({
+            number: `Q-${String(i).padStart(3, '0')}`,
+            client: client._id,
+            created: sameTime,
+          })
+        )
+      );
+
+      const app = buildEntityApp('src/controllers/appControllers/quoteController/paginatedList');
+      const [r1a, r1b, r2a, r2b] = await Promise.all([
+        request(app).get('/list?page=1&items=10'),
+        request(app).get('/list?page=1&items=10'),
+        request(app).get('/list?page=2&items=10'),
+        request(app).get('/list?page=2&items=10'),
+      ]);
+
+      const numbers = (r) => r.body.result.map((q) => q.number);
+      expect(numbers(r1a)).toEqual(numbers(r1b));
+      expect(numbers(r2a)).toEqual(numbers(r2b));
+
+      const page1Set = new Set(numbers(r1a));
+      const overlap = numbers(r2a).filter((n) => page1Set.has(n));
+      expect(overlap).toEqual([]);
+    });
+
+    test('honors caller-supplied sortBy', async () => {
+      const client = await seedClient();
+      const Quote = mongoose.model('Quote');
+      await Quote.create([
+        quoteFixture({ number: 'Q-A', client: client._id, total: 100 }),
+        quoteFixture({ number: 'Q-B', client: client._id, total: 50 }),
+        quoteFixture({ number: 'Q-C', client: client._id, total: 200 }),
+      ]);
+
+      const app = buildEntityApp('src/controllers/appControllers/quoteController/paginatedList');
+      const res = await request(app).get('/list?page=1&items=10&sortBy=total&sortValue=1');
+
+      expect(res.status).toBe(200);
+      expect(res.body.result.map((q) => q.total)).toEqual([50, 100, 200]);
+    });
+  });
+
+  describe('Invoice (per-entity override)', () => {
+    test('returns newest-first by created desc when sortBy is not provided', async () => {
+      const client = await seedClient();
+      const Invoice = mongoose.model('Invoice');
+      const baseDoc = (overrides) => ({
+        number: 'INV-DEFAULT',
+        year: 2026,
+        date: new Date(),
+        expiredDate: new Date(),
+        client: client._id,
+        createdBy: adminId,
+        items: [{ itemName: 'X', quantity: 1, price: 1, total: 1 }],
+        total: 1,
+        currency: 'USD',
+        ...overrides,
+      });
+      await Invoice.create([
+        baseDoc({ number: 'INV-OLD', created: new Date('2025-01-01') }),
+        baseDoc({ number: 'INV-NEW', created: new Date('2026-04-27') }),
+      ]);
+
+      const app = buildEntityApp('src/controllers/appControllers/invoiceController/paginatedList');
+      const res = await request(app).get('/list?page=1&items=10');
+
+      expect(res.status).toBe(200);
+      expect(res.body.result.map((i) => i.number)).toEqual(['INV-NEW', 'INV-OLD']);
+    });
+  });
+
+  describe('Generic CRUD (used by Merch / Payment / Factory / etc.)', () => {
+    test('Merch — no `created` field, falls back to _id desc tiebreaker', async () => {
+      const Merch = mongoose.model('Merch');
+      await Merch.create({
+        serialNumber: 'A-001',
+        description_en: 'first',
+        unit_en: 'PC',
+        createdBy: adminId,
+      });
+      await Merch.create({
+        serialNumber: 'A-002',
+        description_en: 'second',
+        unit_en: 'PC',
+        createdBy: adminId,
+      });
+      await Merch.create({
+        serialNumber: 'A-003',
+        description_en: 'third',
+        unit_en: 'PC',
+        createdBy: adminId,
+      });
+
+      const app = buildGenericApp(Merch);
+      const res = await request(app).get('/list?page=1&items=10');
+
+      expect(res.status).toBe(200);
+      expect(res.body.result.map((m) => m.serialNumber)).toEqual(['A-003', 'A-002', 'A-001']);
+    });
+
+    test('Payment — has `created` field, returns newest-first', async () => {
+      const client = await seedClient();
+      const Invoice = mongoose.model('Invoice');
+      const PaymentMode = mongoose.model('PaymentMode');
+      const Payment = mongoose.model('Payment');
+
+      const invoice = await Invoice.create({
+        number: 'INV-1',
+        year: 2026,
+        date: new Date(),
+        expiredDate: new Date(),
+        client: client._id,
+        createdBy: adminId,
+        items: [{ itemName: 'X', quantity: 1, price: 1, total: 1 }],
+        total: 1,
+        currency: 'USD',
+      });
+      const mode = await PaymentMode.create({
+        name: 'cash',
+        description: 'cash payment',
+        createdBy: adminId,
+      });
+
+      const baseDoc = (overrides) => ({
+        number: 1,
+        date: new Date(),
+        amount: 1,
+        client: client._id,
+        invoice: invoice._id,
+        paymentMode: mode._id,
+        createdBy: adminId,
+        currency: 'USD',
+        ...overrides,
+      });
+
+      await Payment.create([
+        baseDoc({ number: 1, created: new Date('2025-01-01') }),
+        baseDoc({ number: 2, created: new Date('2026-01-01') }),
+        baseDoc({ number: 3, created: new Date('2026-04-01') }),
+      ]);
+
+      const app = buildGenericApp(Payment);
+      const res = await request(app).get('/list?page=1&items=10');
+
+      expect(res.status).toBe(200);
+      expect(res.body.result.map((p) => p.number)).toEqual([3, 2, 1]);
+    });
+  });
+});

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -85,9 +85,9 @@ else
 fi
 
 # 1. Backend
-echo -e "${GREEN}[2/5] Starting backend (port 8888)...${NC}"
+echo -e "${GREEN}[2/5] Starting backend (port 8888) with nodemon hot reload...${NC}"
 cd "$CRM_DIR/backend"
-node src/server.js > /tmp/ola-backend.log 2>&1 &
+npx nodemon src/server.js --ignore public/ > /tmp/ola-backend.log 2>&1 &
 BACKEND_PID=$!
 
 # Wait for backend to bind port before starting MCP (both need MongoDB)
@@ -104,9 +104,9 @@ for i in $(seq 1 15); do
 done
 
 # 2. MCP Server
-echo -e "${GREEN}[3/5] Starting MCP server (port 8889)...${NC}"
+echo -e "${GREEN}[3/5] Starting MCP server (port 8889) with nodemon hot reload...${NC}"
 cd "$CRM_DIR/backend"
-node src/mcp/server.js > /tmp/ola-mcp.log 2>&1 &
+npx nodemon --watch src/mcp src/mcp/server.js > /tmp/ola-mcp.log 2>&1 &
 MCP_PID=$!
 
 # 3. NanoBot

--- a/stop-dev.sh
+++ b/stop-dev.sh
@@ -3,6 +3,11 @@
 
 echo "Stopping Ola dev services..."
 
+# Kill nodemon parents first; otherwise they respawn the node child immediately
+# after we kill it by port and stop-dev.sh appears to do nothing.
+pkill -f "nodemon.*src/server\.js" 2>/dev/null && echo "  Killed nodemon (backend)" || true
+pkill -f "nodemon.*src/mcp/server\.js" 2>/dev/null && echo "  Killed nodemon (mcp)" || true
+
 for PORT in 8888 8889 8900 3000; do
   PID=$(lsof -ti:$PORT 2>/dev/null || true)
   if [ -n "$PID" ]; then


### PR DESCRIPTION
## Summary

- Fixes the bug where newly created Quote / Invoice / PurchaseOrder / Payment / Merch / Factory documents do not appear on page 1 of their list page (#163)
- Root cause: 4 paginatedList controllers defaulted \`sortBy='enabled'\` — a field that doesn't exist on these schemas — so MongoDB silently fell back to natural order
- Fix: compound default \`{ created: -1, _id: -1 }\` (semantic for entities with \`created\`; \`_id\` desc tiebreaker for those without)
- Adds persistent jest + mongodb-memory-server + supertest infra in \`backend/test/\` with 6 regression cases (per zyd's instruction to move from throwaway \`_verify.js\` scripts to fixed regression tests)
- Side fix: \`start-dev.sh\` / \`stop-dev.sh\` now use nodemon hot-reload — this bug went unverified during dev because edits to backend code didn't take effect without manual restart

## Test plan

- [x] \`cd backend && npx jest\` — 6/6 green
- [x] Frontend \`vite build\` — 0 error
- [x] e2e: \`bash stop-dev.sh && bash start-dev.sh\` → admin@admin.com login → Quote page row 1 shows the most recently created quote
- [x] Verified hot-reload: editing a backend file after \`bash start-dev.sh\` triggers \`[nodemon] restarting\` in \`/tmp/ola-backend.log\`

## Out of scope (filed as separate issues)

- #164 — Quote/Invoice/PO 列表加 AntD 列排序 (sorter + defaultSortOrder)
- #165 — Quote/Invoice/PO 列表加表格筛选 (按客户 + 创建时间区间)
- #166 — 通用 CRUD 一键审计 (root-cause family of #163)
- #157 — Quote 页面 i18n 标题修正 (already open)

## Files changed

\`\`\`
M  backend/package.json
M  backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
M  backend/src/controllers/appControllers/quoteController/paginatedList.js
M  backend/src/controllers/appControllers/invoiceController/paginatedList.js
M  backend/src/controllers/appControllers/purchaseOrderController/paginatedList.js
A  backend/jest.config.js
A  backend/test/jest.setup.js
A  backend/test/paginatedList.test.js
M  start-dev.sh
M  stop-dev.sh
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)