### PR TITLE
feat(askola): live thinking panel + SSE pass-through (#131)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -53,7 +53,11 @@ app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-app.use(compression());
+// SSE-aware compression: never compress text/event-stream responses, otherwise
+// the gzip middleware buffers all chunks until res.end() and breaks live
+// streaming (Issue #131 — Ask Ola thinking panel + token streaming).
+const { sseAwareCompressionFilter } = require('@/utils/sseCompression');
+app.use(compression({ filter: sseAwareCompressionFilter }));
 
 // Simple health check route
 app.get('/health', (req, res) => {

--- a/backend/src/controllers/appControllers/olaController/chat.js
+++ b/backend/src/controllers/appControllers/olaController/chat.js
@@ -2,41 +2,90 @@ const http = require('http');
 const mongoose = require('mongoose');
 const { v4: uuidv4 } = require('uuid');
 const { toolEventsToBlocks } = require('./toolResultToBlocks');
+const { labelFor, STAGE_LABELS } = require('./thinkingLabels');
 
 const ChatSession = mongoose.model('ChatSession');
 const ChatMessage = mongoose.model('ChatMessage');
 
-// NanoBot serve 地址，走环境变量，默认本地
-const NANOBOT_HOST = process.env.NANOBOT_HOST || '127.0.0.1';
-const NANOBOT_PORT = process.env.NANOBOT_PORT || 8900;
-const NANOBOT_TIMEOUT_MS = 120000; // 2 分钟，与 nanobot 默认超时一致
+// Read env at request time so tests / hot-reload can override per call.
+const NANOBOT_TIMEOUT_MS = 120000;
+function nanobotEndpoint() {
+  return {
+    host: process.env.NANOBOT_HOST || '127.0.0.1',
+    port: process.env.NANOBOT_PORT || 8900,
+  };
+}
 
-/**
- * Fire-and-forget: ask NanoBot to generate a short title for the conversation.
- * Only called on the first exchange (when title is still "New Chat").
- */
+// ---------------------------------------------------------------------------
+// SSE writer helpers — output frames to the client (browser-facing protocol).
+// Schema documented in ola/plans/ thinking_panel plan §4.1.
+// ---------------------------------------------------------------------------
+
+function writeSSE(res, eventName, data) {
+  res.write(`event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+// ---------------------------------------------------------------------------
+// SSE parser — incremental decoder for NanoBot's upstream SSE stream.
+// NanoBot sends two kinds of frames:
+//   1. Default event (no `event:` line): OpenAI chat.completion.chunk JSON
+//      → for us, only the choices[0].delta.content matters
+//   2. Named `event: tool_event`: our L1 addition, JSON tool_event payload
+// And the literal terminator `data: [DONE]`.
+// ---------------------------------------------------------------------------
+
+function makeSSEParser(onFrame) {
+  let buffer = '';
+  return {
+    feed(chunkStr) {
+      buffer += chunkStr;
+      // SSE frames are separated by blank lines (\n\n).
+      let sep;
+      while ((sep = buffer.indexOf('\n\n')) !== -1) {
+        const rawFrame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        if (!rawFrame.trim()) continue;
+        let eventName = 'message';
+        const dataLines = [];
+        for (const line of rawFrame.split('\n')) {
+          if (line.startsWith('event:')) {
+            eventName = line.slice('event:'.length).trim();
+          } else if (line.startsWith('data:')) {
+            dataLines.push(line.slice('data:'.length).trim());
+          }
+        }
+        const dataStr = dataLines.join('\n');
+        onFrame(eventName, dataStr);
+      }
+    },
+    flush() {
+      if (buffer.trim()) {
+        // Drop trailing partial frame — NanoBot always ends with [DONE]\n\n.
+        buffer = '';
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Auto-title (unchanged from prior implementation, just relocated).
+// ---------------------------------------------------------------------------
+
 function generateTitle(session, messages) {
   const conversation = messages
     .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
     .join('\n');
   const prompt = `Based on this conversation, generate a short title (max 6 words, no quotes, no punctuation at the end). Reply with ONLY the title, nothing else.\n\n${conversation}`;
-
-  const payload = JSON.stringify({
-    messages: [{ role: 'user', content: prompt }],
-  });
-
+  const payload = JSON.stringify({ messages: [{ role: 'user', content: prompt }] });
+  const { host, port } = nanobotEndpoint();
   const options = {
-    hostname: NANOBOT_HOST,
-    port: NANOBOT_PORT,
+    hostname: host,
+    port,
     path: '/v1/chat/completions',
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Content-Length': Buffer.byteLength(payload),
-    },
+    headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) },
     timeout: 30000,
   };
-
   const titleReq = http.request(options, (titleRes) => {
     let data = '';
     titleRes.on('data', (chunk) => { data += chunk; });
@@ -54,14 +103,32 @@ function generateTitle(session, messages) {
       }
     });
   });
-
   titleReq.on('error', (err) => {
     console.error(`[AutoTitle] Request failed for session ${session._id}:`, err.message);
   });
-
   titleReq.write(payload);
   titleReq.end();
 }
+
+function maybeAutoTitle(session, userMessage, assistantContent) {
+  if (session.title !== 'New Chat') return;
+  ChatMessage.countDocuments({ sessionId: session._id, removed: false })
+    .then((count) => {
+      if (count >= 4) {
+        return ChatMessage.find({ sessionId: session._id, removed: false })
+          .sort({ created: 1 }).lean()
+          .then((msgs) => generateTitle(session, msgs));
+      }
+    })
+    .catch((err) => console.error(`[AutoTitle] count/find failed for session ${session._id}:`, err.message));
+}
+
+// ---------------------------------------------------------------------------
+// Main handler — POST /api/ola/chat
+// Streams Server-Sent Events to the client; pipes from NanoBot upstream and
+// translates NanoBot's frames to our user-facing protocol while buffering
+// content + thinking trace for persistence to ChatMessage on stream end.
+// ---------------------------------------------------------------------------
 
 const chat = async (req, res) => {
   const { message, sessionId } = req.body;
@@ -77,7 +144,6 @@ const chat = async (req, res) => {
   const userId = req.admin._id;
   let session;
 
-  // Resolve or create session
   if (sessionId) {
     session = await ChatSession.findOne({ _id: sessionId, userId, removed: false });
     if (!session) {
@@ -88,154 +154,169 @@ const chat = async (req, res) => {
       });
     }
   } else {
-    // Auto-create session when frontend doesn't provide one (transitional)
     const nanobotSessionId = `user:${userId}:conv:${uuidv4()}`;
-    session = await ChatSession.create({
-      userId,
-      nanobotSessionId,
-      createdBy: userId,
-    });
+    session = await ChatSession.create({ userId, nanobotSessionId, createdBy: userId });
   }
 
-  const payload = JSON.stringify({
+  // Switch to SSE mode.
+  res.status(200);
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // hint to nginx not to buffer
+  res.flushHeaders();
+
+  // Accumulators for stream-end persistence + final `done` frame payload.
+  const thinkingSteps = []; // [{label, ts}] — drives thinking_trace block
+  const finalToolEvents = []; // phase==='end' payloads → toolEventsToBlocks → widgets
+  let streamedText = '';
+  let upstreamFinished = false;
+  let upstreamErrored = false;
+
+  const proxyPayload = JSON.stringify({
     messages: [{ role: 'user', content: message.trim() }],
     session_id: session.nanobotSessionId,
+    stream: true,
   });
 
-  return new Promise((resolve) => {
-    const options = {
-      hostname: NANOBOT_HOST,
-      port: NANOBOT_PORT,
-      path: '/v1/chat/completions',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(payload),
-      },
-      timeout: NANOBOT_TIMEOUT_MS,
-    };
+  const { host: nanoHost, port: nanoPort } = nanobotEndpoint();
+  const proxyOptions = {
+    hostname: nanoHost,
+    port: nanoPort,
+    path: '/v1/chat/completions',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(proxyPayload),
+      'Accept': 'text/event-stream',
+    },
+    timeout: NANOBOT_TIMEOUT_MS,
+  };
 
-    const proxyReq = http.request(options, (proxyRes) => {
-      let data = '';
-
-      proxyRes.on('data', (chunk) => {
-        data += chunk;
-      });
-
-      proxyRes.on('end', () => {
-        try {
-          const parsed = JSON.parse(data);
-
-          // nanobot 返回错误
-          if (parsed.error) {
-            res.status(proxyRes.statusCode || 502).json({
-              success: false,
-              result: null,
-              message: parsed.error.message || 'NanoBot 返回错误',
-            });
-            return resolve();
-          }
-
-          // 正常响应：提取 assistant content
-          const content = parsed.choices?.[0]?.message?.content;
-
-          if (!content) {
-            res.status(502).json({
-              success: false,
-              result: null,
-              message: 'NanoBot 返回了空响应',
-            });
-            return resolve();
-          }
-
-          // NanoBot 透出的 tool_events（issue #129）→ 前端 widget/file blocks。
-          // 没有 tool 调用时 toolEventsToBlocks 返 []，message 仍只含 text block。
-          const toolEvents = parsed.metadata?.tool_events;
-          const extraBlocks = toolEventsToBlocks(toolEvents);
-          const blocks = [{ type: 'text', content }, ...extraBlocks];
-
-          // Return response to client first
-          res.status(200).json({
-            success: true,
-            result: {
-              content,
-              blocks,
-              sessionId: session._id,
-              model: parsed.model || null,
-            },
-            message: 'Chat response received',
-          });
-          resolve();
-
-          // Fire-and-forget: persist messages, then check auto-title
-          ChatMessage.insertMany([
-            {
-              sessionId: session._id,
-              role: 'user',
-              content: message.trim(),
-              blocks: [{ type: 'text', content: message.trim() }],
-              createdBy: userId,
-            },
-            {
-              sessionId: session._id,
-              role: 'assistant',
-              content,
-              blocks,
-              createdBy: userId,
-            },
-          ]).then(() => {
-            // Auto-generate title after 2nd exchange (4 messages = enough context)
-            // Chained after insertMany to avoid race condition on count
-            if (session.title === 'New Chat') {
-              return ChatMessage.countDocuments({ sessionId: session._id, removed: false })
-                .then((count) => {
-                  if (count >= 4) {
-                    return ChatMessage.find({ sessionId: session._id, removed: false })
-                      .sort({ created: 1 }).lean()
-                      .then((msgs) => generateTitle(session, msgs));
-                  }
-                });
-            }
-          }).catch((err) => {
-            console.error(
-              `[ChatMessage] Failed to persist messages for session ${session._id}:`,
-              err.message,
-              { sessionId: session._id, userMessage: message.trim(), assistantContent: content }
-            );
-          });
-        } catch (parseErr) {
-          res.status(502).json({
-            success: false,
-            result: null,
-            message: `NanoBot 响应解析失败: ${parseErr.message}`,
-          });
-          return resolve();
+  const handleUpstreamFrame = (eventName, dataStr) => {
+    if (eventName === 'tool_event') {
+      let payload;
+      try { payload = JSON.parse(dataStr); } catch { return; }
+      if (payload.phase === 'start') {
+        const label = labelFor(payload.name);
+        if (label) {
+          const step = { label, ts: Date.now() };
+          thinkingSteps.push(step);
+          writeSSE(res, 'thinking_step', step);
         }
-      });
-    });
+      } else if (payload.phase === 'end' || payload.phase === 'error') {
+        finalToolEvents.push(payload);
+      }
+      return;
+    }
+    // Default event = OpenAI chat.completion.chunk
+    if (dataStr === '[DONE]') return;
+    let chunk;
+    try { chunk = JSON.parse(dataStr); } catch { return; }
+    const delta = chunk?.choices?.[0]?.delta?.content;
+    if (typeof delta === 'string' && delta.length > 0) {
+      streamedText += delta;
+      writeSSE(res, 'text_token', { delta });
+    }
+  };
 
-    proxyReq.on('error', (err) => {
-      res.status(503).json({
-        success: false,
-        result: null,
-        message: `无法连接 NanoBot 服务 (${NANOBOT_HOST}:${NANOBOT_PORT}): ${err.message}`,
-      });
-      return resolve();
-    });
+  const finishStream = () => {
+    if (res.writableEnded) return;
+    // Build final blocks: thinking_trace prepend → text → widgets from tool_events.
+    const blocks = [];
+    if (thinkingSteps.length > 0) {
+      blocks.push({ type: 'thinking_trace', steps: thinkingSteps });
+    }
+    if (streamedText.length > 0) {
+      blocks.push({ type: 'text', content: streamedText });
+    }
+    blocks.push(...toolEventsToBlocks(finalToolEvents));
 
-    proxyReq.on('timeout', () => {
-      proxyReq.destroy();
-      res.status(504).json({
-        success: false,
-        result: null,
-        message: `NanoBot 请求超时 (${NANOBOT_TIMEOUT_MS / 1000}s)`,
-      });
-      return resolve();
-    });
+    writeSSE(res, 'done', { sessionId: session._id, blocks });
+    res.end();
 
-    proxyReq.write(payload);
-    proxyReq.end();
+    // Fire-and-forget persistence.
+    if (streamedText.length > 0 || blocks.length > 0) {
+      ChatMessage.insertMany([
+        {
+          sessionId: session._id,
+          role: 'user',
+          content: message.trim(),
+          blocks: [{ type: 'text', content: message.trim() }],
+          createdBy: userId,
+        },
+        {
+          sessionId: session._id,
+          role: 'assistant',
+          content: streamedText,
+          blocks,
+          createdBy: userId,
+        },
+      ])
+        .then(() => maybeAutoTitle(session, message.trim(), streamedText))
+        .catch((err) => {
+          console.error(
+            `[ChatMessage] Persist failed for session ${session._id}:`,
+            err.message,
+          );
+        });
+    }
+  };
+
+  const failStream = (errMessage) => {
+    if (res.writableEnded) return;
+    upstreamErrored = true;
+    writeSSE(res, 'error', { message: errMessage });
+    res.end();
+  };
+
+  const proxyReq = http.request(proxyOptions, (proxyRes) => {
+    if (proxyRes.statusCode !== 200) {
+      // NanoBot returned a JSON error envelope (4xx/5xx). Drain and surface.
+      let buf = '';
+      proxyRes.setEncoding('utf8');
+      proxyRes.on('data', (c) => { buf += c; });
+      proxyRes.on('end', () => {
+        let errMsg = 'NanoBot 返回错误';
+        try {
+          const parsed = JSON.parse(buf);
+          if (parsed?.error?.message) errMsg = parsed.error.message;
+        } catch { /* keep default */ }
+        failStream(`NanoBot ${proxyRes.statusCode}: ${errMsg}`);
+      });
+      return;
+    }
+
+    proxyRes.setEncoding('utf8');
+    const parser = makeSSEParser(handleUpstreamFrame);
+    proxyRes.on('data', (chunk) => parser.feed(chunk));
+    proxyRes.on('end', () => {
+      parser.flush();
+      upstreamFinished = true;
+      finishStream();
+    });
+    proxyRes.on('error', (err) => {
+      failStream(`NanoBot stream error: ${err.message}`);
+    });
   });
+
+  proxyReq.on('error', (err) => {
+    failStream(`无法连接 NanoBot 服务 (${nanoHost}:${nanoPort}): ${err.message}`);
+  });
+  proxyReq.on('timeout', () => {
+    proxyReq.destroy();
+    failStream(`NanoBot 请求超时 (${NANOBOT_TIMEOUT_MS / 1000}s)`);
+  });
+
+  // Client disconnect — abort upstream so we don't keep doing work for nobody.
+  req.on('close', () => {
+    if (!upstreamFinished && !upstreamErrored) {
+      proxyReq.destroy();
+    }
+  });
+
+  proxyReq.write(proxyPayload);
+  proxyReq.end();
 };
 
 module.exports = chat;

--- a/backend/src/controllers/appControllers/olaController/chat.js
+++ b/backend/src/controllers/appControllers/olaController/chat.js
@@ -12,7 +12,7 @@ const NANOBOT_TIMEOUT_MS = 120000;
 function nanobotEndpoint() {
   return {
     host: process.env.NANOBOT_HOST || '127.0.0.1',
-    port: process.env.NANOBOT_PORT || 8900,
+    port: parseInt(process.env.NANOBOT_PORT, 10) || 8900,
   };
 }
 
@@ -22,6 +22,10 @@ function nanobotEndpoint() {
 // ---------------------------------------------------------------------------
 
 function writeSSE(res, eventName, data) {
+  // No backpressure handling: res.write() can return false on a full TCP
+  // send buffer, but for a single chat session with short SSE frames the
+  // queue stays small. If we ever fan out one stream to many slow clients,
+  // revisit (likely use res.flush() + drain event).
   res.write(`event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`);
 }
 
@@ -167,6 +171,9 @@ const chat = async (req, res) => {
   res.flushHeaders();
 
   // Accumulators for stream-end persistence + final `done` frame payload.
+  // Each step's `ts` is reserved for future relative-timing UI (e.g. "step 2
+  // took 320ms"); not yet rendered, but persisted so we don't have to
+  // backfill schema later. Drop only if we decide that surface stays out.
   const thinkingSteps = []; // [{label, ts}] — drives thinking_trace block
   const finalToolEvents = []; // phase==='end' payloads → toolEventsToBlocks → widgets
   let streamedText = '';

--- a/backend/src/controllers/appControllers/olaController/mcpUtils.js
+++ b/backend/src/controllers/appControllers/olaController/mcpUtils.js
@@ -1,0 +1,24 @@
+// Shared MCP-naming helpers for olaController (PR #171 review feedback).
+//
+// NanoBot prefixes every MCP tool as `mcp_<server>_<rawToolName>`. The
+// MCP server name is `ola_crm`, defined in ola/nanobot.config.template.json.
+// Both thinkingLabels.js and toolResultToBlocks.js need to strip this
+// prefix to look up labels / dispatch block producers; keeping the
+// constants in one place prevents silent divergence if the server is ever
+// renamed.
+
+const MCP_SERVER_NAME = 'ola_crm';
+const MCP_PREFIX = `mcp_${MCP_SERVER_NAME}_`;
+
+function rawToolName(eventName) {
+  if (typeof eventName !== 'string') return '';
+  return eventName.startsWith(MCP_PREFIX)
+    ? eventName.slice(MCP_PREFIX.length)
+    : eventName;
+}
+
+module.exports = {
+  MCP_SERVER_NAME,
+  MCP_PREFIX,
+  rawToolName,
+};

--- a/backend/src/controllers/appControllers/olaController/thinkingLabels.js
+++ b/backend/src/controllers/appControllers/olaController/thinkingLabels.js
@@ -1,0 +1,84 @@
+// Friendly in-progress labels for the Ask Ola thinking panel (Issue #131).
+//
+// Maps NanoBot MCP tool names → user-facing English strings. Lives in the
+// CRM proxy (not in NanoBot) so UIUX (Will / Angel) can edit copy without
+// redeploying NanoBot, and so new MCP tools auto-fallback to "Working on
+// it..." instead of breaking when added before a label is registered.
+//
+// v1 is English-only; i18n / Chinese is tracked as a separate follow-up
+// (idurar_app_language is application-level not user-level — tech debt).
+//
+// NanoBot prefixes every MCP tool as `mcp_<server>_<rawToolName>`. The
+// MCP server name `ola_crm` is the same constant used in toolResultToBlocks.js.
+// labelFor() handles prefix stripping + skip-list + fallback in one call.
+
+const MCP_SERVER_NAME = 'ola_crm';
+const MCP_PREFIX = `mcp_${MCP_SERVER_NAME}_`;
+
+// Raw tool name (after stripping mcp_ola_crm_ prefix) → in-progress label.
+// All labels carry an "Ola is X..." subject for warmth + clarity (zyd).
+// Future v1.1: search-type tools should also surface the query argument
+// (see follow-up issue for "Ola is searching for 'stainless steel'...").
+const TOOL_LABELS = {
+  // Customer
+  'customer.search': 'Ola is searching customers...',
+  'customer.read':   'Ola is loading customer details...',
+  'customer.create': 'Ola is creating customer record...',
+  'customer.update': 'Ola is updating customer info...',
+
+  // Merchandise
+  'merch.search':    'Ola is searching your products...',
+  'merch.read':      'Ola is loading product details...',
+  'merch.create':    'Ola is adding product to catalog...',
+  'merch.update':    'Ola is updating product info...',
+
+  // Quote
+  'quote.search':    'Ola is searching quotes...',
+  'quote.read':      'Ola is loading quote...',
+  'quote.create':    'Ola is drafting your quote...',
+  'quote.update':    'Ola is updating quote...',
+};
+
+// Tools that should NOT surface a thinking step to the end user.
+// System-level / health-check tools belong here.
+const SKIP_TOOLS = new Set([
+  'health.ping',
+]);
+
+// Non-tool stages — used by chat.js / frontend when the agent is between
+// tool calls (e.g. before first tool fires, while composing final response,
+// or for unknown / unregistered tools).
+const STAGE_LABELS = {
+  __init__:    'Ola is thinking...',           // pre-tool / generic placeholder
+  __compose__: 'Ola is composing the reply...',
+  __unknown__: 'Ola is working on it...',      // fallback for unregistered tools
+};
+
+function rawToolName(eventName) {
+  if (typeof eventName !== 'string') return '';
+  return eventName.startsWith(MCP_PREFIX)
+    ? eventName.slice(MCP_PREFIX.length)
+    : eventName;
+}
+
+// Resolve a NanoBot tool event name (with or without mcp_ola_crm_ prefix)
+// to the user-facing label. Returns null for skip-list tools (caller should
+// suppress the SSE thinking_step entirely). Falls back to STAGE_LABELS.__unknown__
+// for tools we haven't registered yet — keeps the panel informative without
+// breaking when new MCP tools land.
+function labelFor(toolName) {
+  const raw = rawToolName(toolName);
+  if (!raw) return STAGE_LABELS.__unknown__;
+  if (SKIP_TOOLS.has(raw)) return null;
+  return TOOL_LABELS[raw] || STAGE_LABELS.__unknown__;
+}
+
+module.exports = {
+  TOOL_LABELS,
+  SKIP_TOOLS,
+  STAGE_LABELS,
+  MCP_SERVER_NAME,
+  MCP_PREFIX,
+  rawToolName,
+  labelFor,
+};

--- a/backend/src/controllers/appControllers/olaController/thinkingLabels.js
+++ b/backend/src/controllers/appControllers/olaController/thinkingLabels.js
@@ -8,12 +8,11 @@
 // v1 is English-only; i18n / Chinese is tracked as a separate follow-up
 // (idurar_app_language is application-level not user-level — tech debt).
 //
-// NanoBot prefixes every MCP tool as `mcp_<server>_<rawToolName>`. The
-// MCP server name `ola_crm` is the same constant used in toolResultToBlocks.js.
 // labelFor() handles prefix stripping + skip-list + fallback in one call.
+// Naming constants + rawToolName() are shared with toolResultToBlocks.js
+// via mcpUtils.js (single source of truth for MCP naming).
 
-const MCP_SERVER_NAME = 'ola_crm';
-const MCP_PREFIX = `mcp_${MCP_SERVER_NAME}_`;
+const { MCP_SERVER_NAME, MCP_PREFIX, rawToolName } = require('./mcpUtils');
 
 // Raw tool name (after stripping mcp_ola_crm_ prefix) → in-progress label.
 // All labels carry an "Ola is X..." subject for warmth + clarity (zyd).
@@ -53,13 +52,6 @@ const STAGE_LABELS = {
   __compose__: 'Ola is composing the reply...',
   __unknown__: 'Ola is working on it...',      // fallback for unregistered tools
 };
-
-function rawToolName(eventName) {
-  if (typeof eventName !== 'string') return '';
-  return eventName.startsWith(MCP_PREFIX)
-    ? eventName.slice(MCP_PREFIX.length)
-    : eventName;
-}
 
 // Resolve a NanoBot tool event name (with or without mcp_ola_crm_ prefix)
 // to the user-facing label. Returns null for skip-list tools (caller should

--- a/backend/src/controllers/appControllers/olaController/toolResultToBlocks.js
+++ b/backend/src/controllers/appControllers/olaController/toolResultToBlocks.js
@@ -21,15 +21,9 @@
 //   2. Add one entry to TOOL_BLOCK_PRODUCERS keyed by raw tool name
 //   No changes elsewhere in this file are needed.
 
-const MCP_SERVER_NAME = 'ola_crm';
-const MCP_PREFIX = `mcp_${MCP_SERVER_NAME}_`;
-
-function rawToolName(eventName) {
-  if (typeof eventName !== 'string') return '';
-  return eventName.startsWith(MCP_PREFIX)
-    ? eventName.slice(MCP_PREFIX.length)
-    : eventName;
-}
+// Naming constants + rawToolName() shared via mcpUtils.js — single source
+// of truth for MCP server name (PR #171 review feedback).
+const { MCP_SERVER_NAME, MCP_PREFIX, rawToolName } = require('./mcpUtils');
 
 function parseEnvelope(raw) {
   if (raw == null) return null;

--- a/backend/src/utils/sseCompression.js
+++ b/backend/src/utils/sseCompression.js
@@ -1,0 +1,26 @@
+const compression = require('compression');
+
+/**
+ * compression() filter that excludes Server-Sent Events responses
+ * (Issue #131).
+ *
+ * The default Express compression middleware buffers all res.write() chunks
+ * to gzip them at res.end(). For SSE this is fatal: the entire stream is
+ * held in memory and dumped at the end, defeating real-time streaming
+ * (thinking_step labels never tick, text never streams token-by-token).
+ *
+ * The controller signals SSE by setting `Content-Type: text/event-stream`
+ * before the first res.write(). compression() invokes this filter at the
+ * write boundary, by which point the header is set and visible here.
+ *
+ * Returns false → bypass compression. Returns compression.filter(req, res)
+ * for non-SSE responses → preserves the library's default Accept-Encoding /
+ * Cache-Control / size heuristics.
+ */
+function sseAwareCompressionFilter(req, res) {
+  const ct = res.getHeader('Content-Type');
+  if (typeof ct === 'string' && ct.includes('text/event-stream')) return false;
+  return compression.filter(req, res);
+}
+
+module.exports = { sseAwareCompressionFilter };

--- a/backend/test/integration/test_ola_chat_sse.sh
+++ b/backend/test/integration/test_ola_chat_sse.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Real-stack integration test for /api/ola/chat SSE pass-through.
+# (Ola CRM issue #131, backlog L3 verification.)
+#
+# Unlike backend/test/olaController.chat.test.js (jest with mocked NanoBot),
+# this hits the FULL stack: CRM backend → real NanoBot → real MCP → real Mongo
+# → real Gemini. Catches integration bugs the mock layer can't see.
+#
+# Prerequisites:
+#   - Full dev stack running: bash ~/Documents/GitHub/crm/start-dev.sh
+#   - Backend on 8888, MCP on 8889, NanoBot on 8900, Mongo accessible
+#   - Test admin: admin@admin.com / admin123 (per reference_external_systems memory)
+#
+# Usage:
+#   bash backend/test/integration/test_ola_chat_sse.sh
+#
+# Exit code: 0 if all scenarios PASS, 1 if any FAIL.
+#
+# Scenarios:
+#   1. Auth gate: /api/ola/chat without cookie → 401 (auth not bypassed by SSE)
+#   2. Empty message → 400 with Chinese error (validation runs before SSE setup)
+#   3. Happy path: tool-triggering message → SSE with thinking_step + text_token + done
+#   4. Pure text prompt → SSE with text_token + done, NO thinking_step
+
+set -u
+
+BACKEND="${BACKEND_URL:-http://localhost:8888}"
+EMAIL="admin@admin.com"
+PASSWORD="admin123"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/ola-chat-integ-XXXX")"
+COOKIE_JAR="$WORKDIR/cookies.txt"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASSES=0
+FAILS=0
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Pre-flight + login
+# ---------------------------------------------------------------------------
+
+echo "==> Pre-flight: backend reachable at $BACKEND?"
+if ! curl -sf -o /dev/null --max-time 5 "$BACKEND/health"; then
+  red "FAIL: cannot reach $BACKEND/health — is start-dev.sh running?"
+  exit 1
+fi
+green "    OK"
+
+echo "==> Login as $EMAIL to capture cookie"
+LOGIN_RESP="$WORKDIR/login.json"
+curl -s -X POST "$BACKEND/api/login" \
+  -H 'Content-Type: application/json' \
+  -c "$COOKIE_JAR" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+  > "$LOGIN_RESP"
+
+if ! grep -q '"success":true' "$LOGIN_RESP"; then
+  red "FAIL: login failed — see $LOGIN_RESP"
+  cat "$LOGIN_RESP"
+  exit 1
+fi
+if ! grep -q 'token' "$COOKIE_JAR"; then
+  red "FAIL: no 'token' cookie in jar — see $COOKIE_JAR"
+  cat "$COOKIE_JAR"
+  exit 1
+fi
+green "    OK (cookie set)"
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — auth gate (no cookie)
+# ---------------------------------------------------------------------------
+
+echo
+echo "==> Scenario 1: /api/ola/chat without cookie → 401"
+S1_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BACKEND/api/ola/chat" \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"hi"}')
+if [[ "$S1_STATUS" == "401" ]]; then
+  green "    PASS — got 401 as expected"
+  PASSES=$((PASSES + 1))
+else
+  red "    FAIL — got HTTP $S1_STATUS, expected 401"
+  FAILS=$((FAILS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — empty message validation (early-return JSON, not SSE)
+# ---------------------------------------------------------------------------
+
+echo
+echo "==> Scenario 2: empty message → 400 with Chinese error"
+S2_BODY="$WORKDIR/s2.json"
+S2_STATUS=$(curl -s -o "$S2_BODY" -w '%{http_code}' -X POST "$BACKEND/api/ola/chat" \
+  -H 'Content-Type: application/json' \
+  -b "$COOKIE_JAR" \
+  -d '{"message":""}')
+if [[ "$S2_STATUS" == "400" ]] && grep -q '"success":false' "$S2_BODY" \
+   && grep -q 'message 字段' "$S2_BODY"; then
+  green "    PASS — got 400 with specific message"
+  PASSES=$((PASSES + 1))
+else
+  red "    FAIL — got HTTP $S2_STATUS, body:"
+  cat "$S2_BODY"
+  FAILS=$((FAILS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — tool-triggering message → thinking_step + text_token + done
+# ---------------------------------------------------------------------------
+
+echo
+echo "==> Scenario 3: tool-triggering message → SSE with thinking_step + text_token + done"
+S3_BODY="$WORKDIR/s3.sse"
+curl -sN -X POST "$BACKEND/api/ola/chat" \
+  -H 'Content-Type: application/json' \
+  -b "$COOKIE_JAR" \
+  --max-time 90 \
+  -d '{"message":"Please use the merch.search tool to find products containing the word stainless"}' \
+  > "$S3_BODY" 2>&1
+
+S3_THINKING=$(grep -c '^event: thinking_step' "$S3_BODY" || true)
+S3_TEXT=$(grep -c '^event: text_token' "$S3_BODY" || true)
+S3_DONE=$(grep -c '^event: done' "$S3_BODY" || true)
+S3_LABEL=$(grep '^data: {"label"' "$S3_BODY" | head -1)
+
+if [[ $S3_THINKING -ge 1 && $S3_TEXT -ge 1 && $S3_DONE -eq 1 ]] \
+   && echo "$S3_LABEL" | grep -q 'Ola is searching your products\.\.\.'; then
+  green "    PASS — thinking_step=$S3_THINKING (label '$S3_LABEL' = friendly), text_token=$S3_TEXT, done=$S3_DONE"
+  PASSES=$((PASSES + 1))
+else
+  red "    FAIL — thinking_step=$S3_THINKING (>=1), text_token=$S3_TEXT (>=1), done=$S3_DONE (==1)"
+  echo "    Sample label line: $S3_LABEL"
+  echo "    Full SSE: $S3_BODY"
+  FAILS=$((FAILS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — pure text (no tool) → no thinking_step
+# ---------------------------------------------------------------------------
+
+echo
+echo "==> Scenario 4: pure text prompt → SSE with text_token + done, NO thinking_step"
+S4_BODY="$WORKDIR/s4.sse"
+curl -sN -X POST "$BACKEND/api/ola/chat" \
+  -H 'Content-Type: application/json' \
+  -b "$COOKIE_JAR" \
+  --max-time 90 \
+  -d '{"message":"Reply with the single word: pong. Do not call any tools."}' \
+  > "$S4_BODY" 2>&1
+
+S4_THINKING=$(grep -c '^event: thinking_step' "$S4_BODY" || true)
+S4_TEXT=$(grep -c '^event: text_token' "$S4_BODY" || true)
+S4_DONE=$(grep -c '^event: done' "$S4_BODY" || true)
+
+if [[ $S4_THINKING -eq 0 && $S4_TEXT -ge 1 && $S4_DONE -eq 1 ]]; then
+  green "    PASS — thinking_step=0 (as expected), text_token=$S4_TEXT, done=$S4_DONE"
+  PASSES=$((PASSES + 1))
+else
+  red "    FAIL — thinking_step=$S4_THINKING (==0), text_token=$S4_TEXT (>=1), done=$S4_DONE (==1)"
+  echo "    Full SSE: $S4_BODY"
+  FAILS=$((FAILS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+echo "==================================================================="
+if [[ $FAILS -eq 0 ]]; then
+  green "ALL $PASSES SCENARIOS PASSED"
+  exit 0
+else
+  red "FAILED: $FAILS scenario(s) failed, $PASSES passed"
+  echo "Artifacts kept at $WORKDIR (manual inspection)"
+  trap - EXIT
+  exit 1
+fi

--- a/backend/test/olaController.chat.test.js
+++ b/backend/test/olaController.chat.test.js
@@ -1,0 +1,431 @@
+/**
+ * Tests for olaController/chat.js — SSE pass-through (Issue #131, backlog L3).
+ *
+ * Pattern: spin up a fake NanoBot HTTP server on a fixed port (18900) so the
+ * chat handler talks to it instead of the real one; supertest hits the
+ * controller; we assert on the SSE response body + on what got persisted to
+ * Mongo.
+ *
+ * unit-then-integration discipline (feedback_unit_then_integration.md): this
+ * file covers the unit/component layer with mocked NanoBot. End-to-end real
+ * stack (NanoBot+MCP+Mongo+Gemini+CRM with browser cookie) is the shell
+ * integration test at backend/test/integration/test_ola_chat_sse.sh.
+ */
+
+const path = require('path');
+const http = require('http');
+const express = require('express');
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { globSync } = require('glob');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+const adminId = new mongoose.Types.ObjectId();
+const FAKE_NANOBOT_PORT = 18900;
+
+let mongo;
+let fakeNanoBot;
+// Per-test responder: function(req, res) → drives the upstream behavior.
+let nanoBotResponder = null;
+
+beforeAll(async () => {
+  // Load all mongoose models (chat.js depends on ChatSession + ChatMessage).
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+
+  // Point chat.js at our fake NanoBot.
+  process.env.NANOBOT_HOST = '127.0.0.1';
+  process.env.NANOBOT_PORT = String(FAKE_NANOBOT_PORT);
+
+  fakeNanoBot = http.createServer((req, res) => {
+    if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+      // Drain request body before handing off (chat.js may need it).
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        req._body = body;
+        if (typeof nanoBotResponder === 'function') {
+          nanoBotResponder(req, res);
+        } else {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: { message: 'No responder set' } }));
+        }
+      });
+    } else {
+      res.statusCode = 404;
+      res.end();
+    }
+  });
+  await new Promise((resolve) => fakeNanoBot.listen(FAKE_NANOBOT_PORT, '127.0.0.1', resolve));
+}, 120000);
+
+afterAll(async () => {
+  // Let any pending fire-and-forget ChatMessage.insertMany / auto-title
+  // writes settle before tearing down mongo (otherwise their .catch logs
+  // a noise "Operation interrupted because client was closed").
+  await new Promise((r) => setTimeout(r, 200));
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+  if (fakeNanoBot) await new Promise((resolve) => fakeNanoBot.close(resolve));
+});
+
+beforeEach(async () => {
+  nanoBotResponder = null;
+  for (const name of ['ChatSession', 'ChatMessage']) {
+    if (mongoose.models[name]) await mongoose.models[name].deleteMany({});
+  }
+});
+
+function buildChatApp() {
+  // Re-require to pick up the controller fresh; chat.js reads env at request
+  // time so this is idempotent.
+  const chat = require(
+    path.join(BACKEND_ROOT, 'src/controllers/appControllers/olaController/chat')
+  );
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.admin = { _id: adminId };
+    next();
+  });
+  app.post('/api/ola/chat', (req, res) => chat(req, res));
+  return app;
+}
+
+// Helpers to build NanoBot SSE frames the way the real server.py would.
+function nanoTextChunk(content) {
+  const payload = {
+    id: 'chatcmpl-test',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'm',
+    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+  };
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+function nanoToolEvent(event) {
+  return `event: tool_event\ndata: ${JSON.stringify(event)}\n\n`;
+}
+const NANO_DONE = `data: [DONE]\n\n`;
+
+function startSSE(res) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+}
+
+// Parse the SSE response from chat.js into structured frames.
+function parseClientSSE(body) {
+  const frames = [];
+  for (const block of body.split('\n\n')) {
+    if (!block.trim()) continue;
+    let event = 'message';
+    const dataLines = [];
+    for (const line of block.split('\n')) {
+      if (line.startsWith('event:')) event = line.slice(6).trim();
+      else if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+    }
+    if (dataLines.length === 0) continue;
+    let data;
+    try { data = JSON.parse(dataLines.join('\n')); } catch { data = dataLines.join('\n'); }
+    frames.push({ event, data });
+  }
+  return frames;
+}
+
+// ===========================================================================
+// Validation / auth shape
+// ===========================================================================
+
+describe('chat — input validation (early-return JSON, not SSE)', () => {
+  test('empty message → 400 with Chinese message', async () => {
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/message/);
+  });
+
+  test('missing message → 400', async () => {
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('non-string message → 400', async () => {
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 42 });
+    expect(res.status).toBe(400);
+  });
+
+  test('invalid sessionId → 404', async () => {
+    const app = buildChatApp();
+    const res = await request(app)
+      .post('/api/ola/chat')
+      .send({ message: 'hi', sessionId: new mongoose.Types.ObjectId().toString() });
+    expect(res.status).toBe(404);
+    expect(res.body.message).toMatch(/Session not found/);
+  });
+});
+
+// ===========================================================================
+// SSE pass-through — happy paths
+// ===========================================================================
+
+describe('chat — SSE pass-through (frame translation)', () => {
+  test('text-only stream → text_token frames + done, no thinking_step', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('Hello'));
+      res.write(nanoTextChunk(' world'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+    const frames = parseClientSSE(res.text);
+    const textFrames = frames.filter((f) => f.event === 'text_token');
+    const thinkFrames = frames.filter((f) => f.event === 'thinking_step');
+    const doneFrames = frames.filter((f) => f.event === 'done');
+    expect(textFrames).toHaveLength(2);
+    expect(textFrames[0].data).toEqual({ delta: 'Hello' });
+    expect(textFrames[1].data).toEqual({ delta: ' world' });
+    expect(thinkFrames).toHaveLength(0);
+    expect(doneFrames).toHaveLength(1);
+    expect(doneFrames[0].data.sessionId).toBeTruthy();
+    expect(doneFrames[0].data.blocks).toEqual([
+      { type: 'text', content: 'Hello world' },
+    ]);
+  });
+
+  test('tool_event start → thinking_step with translated friendly label', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoToolEvent({
+        version: 1, phase: 'start', call_id: 'c1',
+        name: 'mcp_ola_crm_merch.search', arguments: { q: 'x' },
+      }));
+      res.write(nanoToolEvent({
+        version: 1, phase: 'end', call_id: 'c1',
+        name: 'mcp_ola_crm_merch.search', arguments: { q: 'x' },
+        result: '{"ok":true,"data":{"found":false}}',
+      }));
+      res.write(nanoTextChunk('Done'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'find x' });
+    const frames = parseClientSSE(res.text);
+    const thinkFrames = frames.filter((f) => f.event === 'thinking_step');
+    expect(thinkFrames).toHaveLength(1);
+    expect(thinkFrames[0].data.label).toBe('Ola is searching your products...');
+    expect(typeof thinkFrames[0].data.ts).toBe('number');
+  });
+
+  test('tool_event end is NOT emitted as thinking_step (only start triggers labels)', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      // Just an end event with no preceding start.
+      res.write(nanoToolEvent({
+        version: 1, phase: 'end', call_id: 'c1', name: 'mcp_ola_crm_merch.search',
+      }));
+      res.write(nanoTextChunk('ok'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    const thinkFrames = parseClientSSE(res.text).filter((f) => f.event === 'thinking_step');
+    expect(thinkFrames).toHaveLength(0);
+  });
+
+  test('skip-list tool (health.ping) does NOT emit thinking_step', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoToolEvent({
+        version: 1, phase: 'start', call_id: 'c1', name: 'mcp_ola_crm_health.ping',
+      }));
+      res.write(nanoTextChunk('ok'));  // real agent always speaks (SOUL.md invariant)
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    const thinkFrames = parseClientSSE(res.text).filter((f) => f.event === 'thinking_step');
+    expect(thinkFrames).toHaveLength(0);
+  });
+
+  test('unknown tool → fallback "Working on it..." label', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoToolEvent({
+        version: 1, phase: 'start', call_id: 'c1', name: 'mcp_ola_crm_compute.profitMargin',
+      }));
+      // Real agent always emits text after tool calls (SOUL.md: never silent-error).
+      // Without this the persistence step would fail ChatMessage.content required —
+      // which is the desired behavior; we just don't want it triggering here.
+      res.write(nanoTextChunk('done'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    const thinkFrames = parseClientSSE(res.text).filter((f) => f.event === 'thinking_step');
+    expect(thinkFrames).toHaveLength(1);
+    expect(thinkFrames[0].data.label).toBe('Ola is working on it...');
+  });
+});
+
+// ===========================================================================
+// Final blocks (done frame payload) + persistence
+// ===========================================================================
+
+describe('chat — done frame blocks + Mongo persistence', () => {
+  test('done.blocks prepends thinking_trace, then text, then widgets', async () => {
+    const quoteResult = JSON.stringify({
+      ok: true,
+      data: {
+        _id: '67abc1234567890123456789',
+        number: 'Q-TEST-001',
+        currency: 'USD',
+        items: [{ itemName: 'Item A', quantity: 1, total: 100 }],
+        subTotal: 100,
+        total: 100,
+      },
+    });
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoToolEvent({
+        version: 1, phase: 'start', call_id: 'q1',
+        name: 'mcp_ola_crm_quote.create', arguments: {},
+      }));
+      res.write(nanoToolEvent({
+        version: 1, phase: 'end', call_id: 'q1',
+        name: 'mcp_ola_crm_quote.create', arguments: {}, result: quoteResult,
+      }));
+      res.write(nanoTextChunk('Done'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'create' });
+    const done = parseClientSSE(res.text).find((f) => f.event === 'done');
+    expect(done).toBeTruthy();
+    const blocks = done.data.blocks;
+    expect(blocks[0].type).toBe('thinking_trace');
+    expect(blocks[0].steps).toHaveLength(1);
+    expect(blocks[0].steps[0].label).toBe('Ola is drafting your quote...');
+    expect(blocks[1]).toEqual({ type: 'text', content: 'Done' });
+    // Widget block from quote.create result envelope.
+    expect(blocks.find((b) => b.type === 'widget' && b.widgetType === 'quote_preview')).toBeTruthy();
+    expect(blocks.find((b) => b.type === 'file' && b.fileType === 'pdf')).toBeTruthy();
+  });
+
+  test('persists user + assistant ChatMessages with full blocks shape', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoToolEvent({
+        version: 1, phase: 'start', call_id: 'c1', name: 'mcp_ola_crm_customer.search',
+      }));
+      res.write(nanoTextChunk('Found 0'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    await request(app).post('/api/ola/chat').send({ message: 'search bangkok' });
+
+    // Fire-and-forget persist — wait briefly.
+    await new Promise((r) => setTimeout(r, 100));
+    const ChatMessage = mongoose.model('ChatMessage');
+    const msgs = await ChatMessage.find({}).sort({ created: 1 }).lean();
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].role).toBe('user');
+    expect(msgs[0].content).toBe('search bangkok');
+    expect(msgs[1].role).toBe('assistant');
+    expect(msgs[1].content).toBe('Found 0');
+    expect(msgs[1].blocks[0].type).toBe('thinking_trace');
+    expect(msgs[1].blocks[1]).toEqual({ type: 'text', content: 'Found 0' });
+  });
+
+  test('reuses existing session when sessionId provided', async () => {
+    const ChatSession = mongoose.model('ChatSession');
+    const session = await ChatSession.create({
+      userId: adminId,
+      nanobotSessionId: 'user:x:conv:y',
+      createdBy: adminId,
+    });
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('hi'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app)
+      .post('/api/ola/chat')
+      .send({ message: 'hello', sessionId: session._id.toString() });
+    const done = parseClientSSE(res.text).find((f) => f.event === 'done');
+    expect(done.data.sessionId).toBe(session._id.toString());
+    // No new session created.
+    const count = await ChatSession.countDocuments({});
+    expect(count).toBe(1);
+  });
+});
+
+// ===========================================================================
+// Upstream error paths
+// ===========================================================================
+
+describe('chat — upstream error handling', () => {
+  test('NanoBot returns 503 → emit event: error frame', async () => {
+    nanoBotResponder = (_req, res) => {
+      res.statusCode = 503;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: { message: 'NanoBot busy' } }));
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    const errFrames = parseClientSSE(res.text).filter((f) => f.event === 'error');
+    expect(errFrames).toHaveLength(1);
+    expect(errFrames[0].data.message).toMatch(/NanoBot 503/);
+    expect(errFrames[0].data.message).toMatch(/NanoBot busy/);
+  });
+
+  test('connection refused → emit event: error frame with host:port', async () => {
+    process.env.NANOBOT_PORT = '1';  // nothing listens on port 1
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    process.env.NANOBOT_PORT = String(FAKE_NANOBOT_PORT);  // restore
+    const errFrames = parseClientSSE(res.text).filter((f) => f.event === 'error');
+    expect(errFrames).toHaveLength(1);
+    expect(errFrames[0].data.message).toMatch(/无法连接 NanoBot/);
+    expect(errFrames[0].data.message).toMatch(/127\.0\.0\.1:1/);
+  });
+
+  test('NanoBot returns malformed SSE → does not crash, ends cleanly', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write('garbage\n\n');
+      res.write('event: tool_event\ndata: {bad json\n\n');
+      res.write(nanoTextChunk('survived'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    expect(res.status).toBe(200);
+    const frames = parseClientSSE(res.text);
+    expect(frames.find((f) => f.event === 'text_token' && f.data.delta === 'survived')).toBeTruthy();
+    expect(frames.find((f) => f.event === 'done')).toBeTruthy();
+  });
+});

--- a/backend/test/sseCompression.test.js
+++ b/backend/test/sseCompression.test.js
@@ -1,0 +1,96 @@
+/**
+ * Tests for sseAwareCompressionFilter (Issue #131 follow-up).
+ *
+ * The bug this prevents: express compression() middleware was buffering
+ * SSE responses entirely until res.end(), which defeated the real-time
+ * streaming /api/ola/chat depends on. A passing browser smoke would
+ * SILENTLY break if anyone re-applied plain compression() globally; this
+ * test makes that regression loud.
+ */
+
+const path = require('path');
+const compression = require('compression');
+const express = require('express');
+const request = require('supertest');
+
+const { sseAwareCompressionFilter } = require(
+  path.join(__dirname, '..', 'src/utils/sseCompression')
+);
+
+function buildApp() {
+  const app = express();
+  app.use(compression({ filter: sseAwareCompressionFilter }));
+  app.get('/sse', (req, res) => {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.flushHeaders();
+    res.write('event: tick\ndata: {"i":1}\n\n');
+    res.write('event: tick\ndata: {"i":2}\n\n');
+    res.end();
+  });
+  app.get('/json', (req, res) => {
+    // Large enough that compression()'s default size threshold engages.
+    res.json({ data: 'x'.repeat(2000) });
+  });
+  app.get('/sse-charset', (req, res) => {
+    // Some clients/middleware tack on charset — make sure substring match wins.
+    res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+    res.flushHeaders();
+    res.write('event: tick\ndata: {}\n\n');
+    res.end();
+  });
+  return app;
+}
+
+describe('sseAwareCompressionFilter', () => {
+  test('SSE response is NOT compressed (preserves real-time streaming)', async () => {
+    const res = await request(buildApp())
+      .get('/sse')
+      .set('Accept-Encoding', 'gzip');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+    // Frames present and intact (would be unreadable if gzipped accidentally).
+    expect(res.text).toContain('event: tick');
+    expect(res.text).toContain('"i":1');
+    expect(res.text).toContain('"i":2');
+  });
+
+  test('SSE with charset suffix is also NOT compressed (substring match)', async () => {
+    const res = await request(buildApp())
+      .get('/sse-charset')
+      .set('Accept-Encoding', 'gzip');
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+
+  test('Regular JSON response IS compressed (default behavior preserved)', async () => {
+    const res = await request(buildApp())
+      .get('/json')
+      .set('Accept-Encoding', 'gzip');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+  });
+
+  test('filter returns false for SSE Content-Type', () => {
+    const fakeRes = { getHeader: (k) => (k === 'Content-Type' ? 'text/event-stream' : null) };
+    expect(sseAwareCompressionFilter({}, fakeRes)).toBe(false);
+  });
+
+  test('filter returns false for SSE Content-Type with charset', () => {
+    const fakeRes = { getHeader: () => 'text/event-stream; charset=utf-8' };
+    expect(sseAwareCompressionFilter({}, fakeRes)).toBe(false);
+  });
+
+  test('filter delegates to compression default for non-SSE Content-Type', () => {
+    // Default filter returns true when there's no Content-Type yet (compression
+    // makes the call later) — we just verify ours doesn't short-circuit to false.
+    const fakeReq = { headers: {} };
+    const fakeRes = {
+      getHeader: (k) => (k === 'Content-Type' ? 'application/json' : null),
+    };
+    // compression.filter signature: returns truthy for compressible, false otherwise.
+    // Whatever it returns, we should match it (i.e. not false-by-our-rule).
+    const expected = compression.filter(fakeReq, fakeRes);
+    expect(sseAwareCompressionFilter(fakeReq, fakeRes)).toBe(expected);
+  });
+});

--- a/backend/test/thinkingLabels.test.js
+++ b/backend/test/thinkingLabels.test.js
@@ -1,0 +1,101 @@
+// Tests for thinkingLabels.js — friendly label dictionary for Ask Ola
+// thinking panel (Issue #131, backlog L2).
+//
+// No DB / express needed — pure dictionary + helper logic.
+
+const {
+  TOOL_LABELS,
+  SKIP_TOOLS,
+  STAGE_LABELS,
+  MCP_PREFIX,
+  rawToolName,
+  labelFor,
+} = require('@/controllers/appControllers/olaController/thinkingLabels');
+
+describe('thinkingLabels — TOOL_LABELS dictionary', () => {
+  test('covers all 12 v1 user-facing MCP tools', () => {
+    const expected = [
+      'customer.search', 'customer.read', 'customer.create', 'customer.update',
+      'merch.search', 'merch.read', 'merch.create', 'merch.update',
+      'quote.search', 'quote.read', 'quote.create', 'quote.update',
+    ];
+    expect(Object.keys(TOOL_LABELS).sort()).toEqual(expected.sort());
+  });
+
+  test('does NOT include health.ping (it is in SKIP_TOOLS)', () => {
+    expect(TOOL_LABELS).not.toHaveProperty('health.ping');
+    expect(SKIP_TOOLS.has('health.ping')).toBe(true);
+  });
+
+  test('every value is a non-empty string ending with ellipsis-style "..."', () => {
+    for (const [key, value] of Object.entries(TOOL_LABELS)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+      expect(value).toMatch(/\.\.\.$/);  // visual signal of in-progress
+    }
+  });
+});
+
+describe('thinkingLabels — STAGE_LABELS', () => {
+  test('has __init__, __compose__, __unknown__ (all carry Ola subject)', () => {
+    expect(STAGE_LABELS.__init__).toBe('Ola is thinking...');
+    expect(STAGE_LABELS.__compose__).toBe('Ola is composing the reply...');
+    expect(STAGE_LABELS.__unknown__).toBe('Ola is working on it...');
+  });
+});
+
+describe('thinkingLabels — rawToolName()', () => {
+  test('strips mcp_ola_crm_ prefix when present', () => {
+    expect(rawToolName('mcp_ola_crm_merch.search')).toBe('merch.search');
+    expect(rawToolName('mcp_ola_crm_quote.create')).toBe('quote.create');
+  });
+
+  test('returns input unchanged when prefix absent', () => {
+    expect(rawToolName('merch.search')).toBe('merch.search');
+    expect(rawToolName('something.else')).toBe('something.else');
+  });
+
+  test('returns empty string for non-string input', () => {
+    expect(rawToolName(null)).toBe('');
+    expect(rawToolName(undefined)).toBe('');
+    expect(rawToolName(42)).toBe('');
+    expect(rawToolName({})).toBe('');
+  });
+});
+
+describe('thinkingLabels — labelFor()', () => {
+  test('resolves a known raw tool name (with Ola subject)', () => {
+    expect(labelFor('merch.search')).toBe('Ola is searching your products...');
+    expect(labelFor('quote.create')).toBe('Ola is drafting your quote...');
+  });
+
+  test('resolves a prefixed tool name (mcp_ola_crm_*)', () => {
+    expect(labelFor('mcp_ola_crm_customer.search')).toBe('Ola is searching customers...');
+    expect(labelFor('mcp_ola_crm_merch.update')).toBe('Ola is updating product info...');
+  });
+
+  test('returns null for skip-list tools (caller should suppress)', () => {
+    expect(labelFor('health.ping')).toBeNull();
+    expect(labelFor('mcp_ola_crm_health.ping')).toBeNull();
+  });
+
+  test('falls back to __unknown__ for unregistered tools', () => {
+    expect(labelFor('compute.profitMargin')).toBe('Ola is working on it...');
+    expect(labelFor('mcp_ola_crm_factory.list')).toBe('Ola is working on it...');
+    expect(labelFor('totally_made_up_tool')).toBe('Ola is working on it...');
+  });
+
+  test('falls back to __unknown__ for empty / non-string input', () => {
+    expect(labelFor('')).toBe('Ola is working on it...');
+    expect(labelFor(null)).toBe('Ola is working on it...');
+    expect(labelFor(undefined)).toBe('Ola is working on it...');
+  });
+});
+
+describe('thinkingLabels — MCP_PREFIX constant', () => {
+  test('matches toolResultToBlocks.js convention exactly', () => {
+    // toolResultToBlocks.js hardcodes MCP_SERVER_NAME = 'ola_crm';
+    // both must agree or label resolution silently breaks for prefixed names.
+    expect(MCP_PREFIX).toBe('mcp_ola_crm_');
+  });
+});

--- a/frontend/src/components/AskOla/MessageBubble.jsx
+++ b/frontend/src/components/AskOla/MessageBubble.jsx
@@ -3,6 +3,7 @@ import FileBlock from './blocks/FileBlock';
 import ThinkingBlock from './blocks/ThinkingBlock';
 import ActionBlock from './blocks/ActionBlock';
 import WidgetBlock from './blocks/WidgetBlock';
+import ThinkingPanel from './ThinkingPanel';
 
 /**
  * Block component mapping table — extend here for new block types
@@ -19,6 +20,12 @@ const BLOCK_MAP = {
     />
   ),
   thinking: (block, i) => <ThinkingBlock key={i} content={block.content} />,
+  // thinking_trace: persistent record of the live progress steps captured
+  // during streaming (Issue #131). Renders as the collapsed `▶ View thinking
+  // process` panel — same component as the live mode, just always folded.
+  thinking_trace: (block, i) => (
+    <ThinkingPanel key={i} mode="collapsed" steps={block.steps || []} />
+  ),
   action: (block, i) => <ActionBlock key={i} actions={block.actions} />,
   widget: (block, i) => (
     <WidgetBlock key={i} widgetType={block.widgetType} data={block.data} />

--- a/frontend/src/components/AskOla/ThinkingPanel.jsx
+++ b/frontend/src/components/AskOla/ThinkingPanel.jsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { LoadingOutlined, DownOutlined, RightOutlined } from '@ant-design/icons';
+
+/**
+ * ThinkingPanel — Ask Ola live progress + post-answer collapsed trace
+ * (Issue #131).
+ *
+ * Two modes (driven by `mode` prop):
+ *
+ *   mode="live"
+ *     Single-line in-place updating indicator. Shows `currentLabel` next to a
+ *     spinner. Replaces the hardcoded `Ola is thinking...` while a stream is
+ *     active. AskOla.jsx swaps `currentLabel` as new SSE thinking_step frames
+ *     arrive.
+ *
+ *   mode="collapsed" (default)
+ *     Used after the answer arrives, and for historical assistant messages
+ *     loaded from ChatMessage.blocks (thinking_trace block). Renders as
+ *     `▶ View thinking process`; click expands to a sequential numbered list
+ *     of the steps Ola took.
+ *
+ * Step shape (consistent with backend thinking_trace block):
+ *   { label: string, ts: number }
+ *
+ * v1 is English-only; localized labels deferred (see thinkingLabels.js).
+ */
+export default function ThinkingPanel({
+  mode = 'collapsed',
+  currentLabel = null,
+  steps = [],
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (mode === 'live') {
+    return (
+      <div className="askola-thinking-panel askola-thinking-panel--live">
+        <LoadingOutlined spin style={{ fontSize: 13, color: '#8c8c8c' }} />
+        <span className="askola-thinking-panel-label">
+          {currentLabel || 'Ola is working on it...'}
+        </span>
+      </div>
+    );
+  }
+
+  // collapsed mode: nothing to show if no steps were captured.
+  if (!Array.isArray(steps) || steps.length === 0) return null;
+
+  return (
+    <div className="askola-thinking-panel askola-thinking-panel--collapsed">
+      <button
+        type="button"
+        className="askola-thinking-panel-toggle"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        {expanded ? <DownOutlined /> : <RightOutlined />}
+        <span className="askola-thinking-panel-toggle-label">
+          {' '}View thinking process
+        </span>
+      </button>
+      {expanded && (
+        <ol className="askola-thinking-panel-steps">
+          {steps.map((step, i) => (
+            <li key={i} className="askola-thinking-panel-step">
+              {step.label}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/AskOla/ThinkingPanel.jsx
+++ b/frontend/src/components/AskOla/ThinkingPanel.jsx
@@ -33,7 +33,11 @@ export default function ThinkingPanel({
 
   if (mode === 'live') {
     return (
-      <div className="askola-thinking-panel askola-thinking-panel--live">
+      <div
+        className="askola-thinking-panel askola-thinking-panel--live"
+        role="status"
+        aria-live="polite"
+      >
         <LoadingOutlined spin style={{ fontSize: 13, color: '#8c8c8c' }} />
         <span className="askola-thinking-panel-label">
           {currentLabel || 'Ola is working on it...'}

--- a/frontend/src/components/AskOla/__tests__/MessageBubble.test.jsx
+++ b/frontend/src/components/AskOla/__tests__/MessageBubble.test.jsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+//
+// Tests for MessageBubble — specifically the thinking_trace block branch
+// added for Issue #131 / backlog L6. The other block types are exercised
+// indirectly through usage; this file focuses on the new wiring.
+
+import { describe, test, expect, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import MessageBubble from '../MessageBubble';
+
+afterEach(cleanup);
+
+const sampleThinkingTrace = {
+  type: 'thinking_trace',
+  steps: [
+    { label: 'Ola is thinking...', ts: 1 },
+    { label: 'Searching products...', ts: 2 },
+  ],
+};
+
+describe('MessageBubble — thinking_trace block', () => {
+  test('renders a collapsed ThinkingPanel when assistant message has thinking_trace', () => {
+    const message = {
+      role: 'assistant',
+      blocks: [sampleThinkingTrace, { type: 'text', content: 'Done' }],
+    };
+    const { getByRole, getByText } = render(<MessageBubble message={message} />);
+    // Toggle button is rendered (the ▶ View thinking process control).
+    const toggle = getByRole('button');
+    expect(toggle.textContent).toMatch(/View thinking process/);
+    // Default is folded — no step labels visible yet.
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    // The text block also rendered alongside.
+    expect(getByText('Done')).toBeTruthy();
+  });
+
+  test('clicking the toggle expands the trace and shows steps', () => {
+    const message = {
+      role: 'assistant',
+      blocks: [sampleThinkingTrace],
+    };
+    const { getByRole, getByText } = render(<MessageBubble message={message} />);
+    fireEvent.click(getByRole('button'));
+    expect(getByText('Ola is thinking...')).toBeTruthy();
+    expect(getByText('Searching products...')).toBeTruthy();
+  });
+
+  test('thinking_trace with empty steps[] renders nothing for that block', () => {
+    const message = {
+      role: 'assistant',
+      blocks: [
+        { type: 'thinking_trace', steps: [] },
+        { type: 'text', content: 'Hi' },
+      ],
+    };
+    const { queryByRole, getByText } = render(<MessageBubble message={message} />);
+    // ThinkingPanel renders null when steps empty → no toggle button.
+    expect(queryByRole('button')).toBeNull();
+    // Text block still renders.
+    expect(getByText('Hi')).toBeTruthy();
+  });
+
+  test('unknown block type still renders the placeholder fallback', () => {
+    const message = {
+      role: 'assistant',
+      blocks: [{ type: 'made_up_block', payload: {} }],
+    };
+    const { getByText } = render(<MessageBubble message={message} />);
+    expect(getByText(/不支持的内容类型/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/AskOla/__tests__/ThinkingPanel.test.jsx
+++ b/frontend/src/components/AskOla/__tests__/ThinkingPanel.test.jsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+//
+// Tests for ThinkingPanel (Issue #131, backlog L4).
+//
+// Pure React component, no API / Redux dependencies. vitest + @testing-library/react.
+
+import { describe, test, expect, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import ThinkingPanel from '../ThinkingPanel';
+
+// vitest doesn't run @testing-library auto-cleanup like jest does, so DOM
+// from previous tests would leak and break getByRole('button') etc.
+afterEach(cleanup);
+
+describe('ThinkingPanel — live mode', () => {
+  test('renders the currentLabel passed in', () => {
+    const { getByText } = render(
+      <ThinkingPanel mode="live" currentLabel="Ola is searching your products..." />
+    );
+    expect(getByText('Ola is searching your products...')).toBeTruthy();
+  });
+
+  test('falls back to "Working on it..." when currentLabel is null', () => {
+    const { getByText } = render(<ThinkingPanel mode="live" currentLabel={null} />);
+    expect(getByText('Ola is working on it...')).toBeTruthy();
+  });
+
+  test('falls back to "Working on it..." when currentLabel omitted entirely', () => {
+    const { getByText } = render(<ThinkingPanel mode="live" />);
+    expect(getByText('Ola is working on it...')).toBeTruthy();
+  });
+
+  test('renders a spinning loading icon', () => {
+    const { container } = render(
+      <ThinkingPanel mode="live" currentLabel="..." />
+    );
+    // AntD LoadingOutlined renders as <span> with `anticon-loading` class.
+    expect(container.querySelector('.anticon-loading')).toBeTruthy();
+  });
+
+  test('does NOT show the View thinking process toggle in live mode', () => {
+    const { queryByText } = render(
+      <ThinkingPanel mode="live" currentLabel="..." />
+    );
+    expect(queryByText(/View thinking process/)).toBeNull();
+  });
+});
+
+describe('ThinkingPanel — collapsed mode', () => {
+  const sampleSteps = [
+    { label: 'Ola is thinking...', ts: 1000 },
+    { label: 'Ola is searching your products...', ts: 1100 },
+    { label: 'Drafting your quote...', ts: 1200 },
+  ];
+
+  test('renders nothing when steps is empty', () => {
+    const { container } = render(<ThinkingPanel mode="collapsed" steps={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders nothing when steps prop omitted', () => {
+    const { container } = render(<ThinkingPanel mode="collapsed" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders nothing when steps is not an array (defensive)', () => {
+    const { container } = render(<ThinkingPanel mode="collapsed" steps={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('default folded: shows toggle, hides step list', () => {
+    const { getByRole, queryByText } = render(
+      <ThinkingPanel mode="collapsed" steps={sampleSteps} />
+    );
+    const toggle = getByRole('button');
+    expect(toggle.textContent).toMatch(/View thinking process/);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    // Steps should not be visible while folded.
+    expect(queryByText('Ola is thinking...')).toBeNull();
+    expect(queryByText('Ola is searching your products...')).toBeNull();
+  });
+
+  test('click toggle → expands and shows all steps in order', () => {
+    const { getByRole, getByText, container } = render(
+      <ThinkingPanel mode="collapsed" steps={sampleSteps} />
+    );
+    fireEvent.click(getByRole('button'));
+    expect(getByRole('button').getAttribute('aria-expanded')).toBe('true');
+    expect(getByText('Ola is thinking...')).toBeTruthy();
+    expect(getByText('Ola is searching your products...')).toBeTruthy();
+    expect(getByText('Drafting your quote...')).toBeTruthy();
+    // Steps render as an ordered list — preserve user-visible order.
+    const items = container.querySelectorAll('ol li');
+    expect(items).toHaveLength(3);
+    expect(items[0].textContent).toBe('Ola is thinking...');
+    expect(items[2].textContent).toBe('Drafting your quote...');
+  });
+
+  test('click toggle again → folds back', () => {
+    const { getByRole, queryByText } = render(
+      <ThinkingPanel mode="collapsed" steps={sampleSteps} />
+    );
+    const toggle = getByRole('button');
+    fireEvent.click(toggle);
+    expect(queryByText('Ola is thinking...')).toBeTruthy();
+    fireEvent.click(toggle);
+    expect(queryByText('Ola is thinking...')).toBeNull();
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+});
+
+describe('ThinkingPanel — default mode is collapsed', () => {
+  test('omitting mode prop → behaves as collapsed', () => {
+    const { container } = render(<ThinkingPanel steps={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/AskOla/__tests__/consumeSSEStream.test.js
+++ b/frontend/src/components/AskOla/__tests__/consumeSSEStream.test.js
@@ -1,0 +1,125 @@
+// Unit tests for consumeSSEStream (Issue #131, backlog L5).
+// Pure logic — no DOM needed, default vitest node environment is fine.
+
+import { describe, test, expect, vi } from 'vitest';
+import { consumeSSEStream } from '../consumeSSEStream';
+
+// Build a Fetch-like Response whose body is a ReadableStream that emits the
+// given byte chunks in sequence. Lets us simulate SSE delivery patterns
+// (whole-frame chunks, mid-frame chunks, multi-frame chunks) without a real
+// HTTP server.
+function makeMockResponse(chunks) {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return { body };
+}
+
+describe('consumeSSEStream', () => {
+  test('routes named events to matching handlers with parsed JSON data', async () => {
+    const calls = [];
+    const handlers = {
+      thinking_step: (d) => calls.push(['thinking_step', d]),
+      text_token:    (d) => calls.push(['text_token', d]),
+      done:          (d) => calls.push(['done', d]),
+    };
+    const sse = [
+      'event: thinking_step\ndata: {"label":"Searching products...","ts":1}\n\n',
+      'event: text_token\ndata: {"delta":"Hi"}\n\n',
+      'event: done\ndata: {"sessionId":"abc","blocks":[]}\n\n',
+    ].join('');
+    await consumeSSEStream(makeMockResponse([sse]), handlers);
+    expect(calls).toEqual([
+      ['thinking_step', { label: 'Searching products...', ts: 1 }],
+      ['text_token', { delta: 'Hi' }],
+      ['done', { sessionId: 'abc', blocks: [] }],
+    ]);
+  });
+
+  test('handles frames split across chunk boundaries', async () => {
+    const handler = vi.fn();
+    // The "data:" line is split mid-string between two ReadableStream chunks.
+    await consumeSSEStream(
+      makeMockResponse([
+        'event: text_token\ndata: {"delt',
+        'a":"hello"}\n\n',
+      ]),
+      { text_token: handler },
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ delta: 'hello' });
+  });
+
+  test('handles multiple frames arriving in a single chunk', async () => {
+    const seen = [];
+    const sse =
+      'event: text_token\ndata: {"delta":"a"}\n\n' +
+      'event: text_token\ndata: {"delta":"b"}\n\n' +
+      'event: text_token\ndata: {"delta":"c"}\n\n';
+    await consumeSSEStream(makeMockResponse([sse]), {
+      text_token: (d) => seen.push(d.delta),
+    });
+    expect(seen).toEqual(['a', 'b', 'c']);
+  });
+
+  test('drops unknown events silently (forward-compat)', async () => {
+    const knownHandler = vi.fn();
+    const sse =
+      'event: text_token\ndata: {"delta":"x"}\n\n' +
+      'event: future_event\ndata: {"foo":"bar"}\n\n' +
+      'event: text_token\ndata: {"delta":"y"}\n\n';
+    await consumeSSEStream(makeMockResponse([sse]), {
+      text_token: knownHandler,
+    });
+    expect(knownHandler).toHaveBeenCalledTimes(2);
+    expect(knownHandler.mock.calls[0][0]).toEqual({ delta: 'x' });
+    expect(knownHandler.mock.calls[1][0]).toEqual({ delta: 'y' });
+  });
+
+  test('passes raw string through when data is not valid JSON', async () => {
+    const handler = vi.fn();
+    await consumeSSEStream(
+      makeMockResponse(['event: weird\ndata: not-json-here\n\n']),
+      { weird: handler },
+    );
+    expect(handler).toHaveBeenCalledWith('not-json-here');
+  });
+
+  test('awaits async handlers in order', async () => {
+    const order = [];
+    const slow = async (d) => {
+      await new Promise((r) => setTimeout(r, 10));
+      order.push(['slow', d.delta]);
+    };
+    const fast = (d) => order.push(['fast', d.delta]);
+    const sse =
+      'event: a\ndata: {"delta":"1"}\n\n' +
+      'event: b\ndata: {"delta":"2"}\n\n' +
+      'event: a\ndata: {"delta":"3"}\n\n';
+    await consumeSSEStream(makeMockResponse([sse]), { a: slow, b: fast });
+    expect(order).toEqual([
+      ['slow', '1'],
+      ['fast', '2'],
+      ['slow', '3'],
+    ]);
+  });
+
+  test('throws when response.body is missing', async () => {
+    await expect(consumeSSEStream({}, {})).rejects.toThrow(/response\.body is missing/);
+  });
+
+  test('handles default-event (no event: line) frames with handler key "message"', async () => {
+    const handler = vi.fn();
+    await consumeSSEStream(
+      makeMockResponse(['data: {"x":1}\n\n']),
+      { message: handler },
+    );
+    expect(handler).toHaveBeenCalledWith({ x: 1 });
+  });
+});

--- a/frontend/src/components/AskOla/__tests__/consumeSSEStream.test.js
+++ b/frontend/src/components/AskOla/__tests__/consumeSSEStream.test.js
@@ -122,4 +122,63 @@ describe('consumeSSEStream', () => {
     );
     expect(handler).toHaveBeenCalledWith({ x: 1 });
   });
+
+  test('returns immediately if signal is already aborted', async () => {
+    const handler = vi.fn();
+    const ac = new AbortController();
+    ac.abort();
+    await consumeSSEStream(
+      makeMockResponse(['event: x\ndata: {}\n\n']),
+      { x: handler },
+      ac.signal,
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('aborting mid-stream stops handler dispatch and exits cleanly', async () => {
+    // Build a stream that emits 3 frames but pauses after the first via a
+    // controlled async iterator so we can abort between frames.
+    const encoder = new TextEncoder();
+    let releaseSecond;
+    const secondReady = new Promise((r) => { releaseSecond = r; });
+    const body = new ReadableStream({
+      async start(controller) {
+        controller.enqueue(encoder.encode('event: a\ndata: {"i":1}\n\n'));
+        await secondReady;  // wait until test signals the second chunk can flow
+        controller.enqueue(encoder.encode('event: a\ndata: {"i":2}\n\n'));
+        controller.close();
+      },
+    });
+
+    const ac = new AbortController();
+    const seen = [];
+    const handler = (d) => seen.push(d.i);
+
+    const consumePromise = consumeSSEStream(
+      { body },
+      { a: handler },
+      ac.signal,
+    );
+    // Yield so the first chunk is processed.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen).toEqual([1]);
+    // Abort BEFORE letting the second chunk flow.
+    ac.abort();
+    // Now allow the second chunk — it should NOT be dispatched (consumer aborted).
+    releaseSecond();
+    await consumePromise;  // must resolve, not throw
+    expect(seen).toEqual([1]);
+  });
+
+  test('aborting before reader.read resolves does not throw', async () => {
+    // Stream that hangs forever on the first read.
+    const body = new ReadableStream({
+      start() { /* never enqueue, never close */ },
+    });
+    const ac = new AbortController();
+    const consumePromise = consumeSSEStream({ body }, {}, ac.signal);
+    setTimeout(() => ac.abort(), 10);
+    // Should resolve cleanly (no throw) within reasonable time.
+    await consumePromise;
+  });
 });

--- a/frontend/src/components/AskOla/consumeSSEStream.js
+++ b/frontend/src/components/AskOla/consumeSSEStream.js
@@ -1,0 +1,72 @@
+/**
+ * consumeSSEStream — generic Fetch+ReadableStream SSE consumer (Issue #131).
+ *
+ * EventSource doesn't support POST bodies, so /api/ola/chat is hit via
+ * fetch() and we read the response.body ReadableStream manually. This is the
+ * standard workaround used by OpenAI / Anthropic / Google JS SDKs.
+ *
+ * Usage:
+ *
+ *   const response = await fetch('/api/ola/chat', { method: 'POST', ... });
+ *   await consumeSSEStream(response, {
+ *     thinking_step: (data) => { ... },
+ *     text_token:    (data) => { ... },
+ *     done:          (data) => { ... },
+ *     error:         (data) => { ... },
+ *   });
+ *
+ * Frame format follows the SSE spec: lines `event: NAME\n` and `data: JSON\n`,
+ * frames separated by blank line. JSON-decoded `data` is passed to the
+ * matching handler. Unknown events are silently dropped (forward-compat).
+ */
+export async function consumeSSEStream(response, handlers) {
+  if (!response || !response.body) {
+    throw new Error('consumeSSEStream: response.body is missing');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let sep;
+      while ((sep = buffer.indexOf('\n\n')) !== -1) {
+        const rawFrame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        if (!rawFrame.trim()) continue;
+
+        let event = 'message';
+        const dataLines = [];
+        for (const line of rawFrame.split('\n')) {
+          if (line.startsWith('event:')) {
+            event = line.slice('event:'.length).trim();
+          } else if (line.startsWith('data:')) {
+            dataLines.push(line.slice('data:'.length).trim());
+          }
+        }
+        const dataStr = dataLines.join('\n');
+        let data;
+        try {
+          data = dataStr ? JSON.parse(dataStr) : null;
+        } catch {
+          // Non-JSON data line — pass raw string through.
+          data = dataStr;
+        }
+
+        const handler = handlers[event];
+        if (typeof handler === 'function') {
+          await handler(data);
+        }
+      }
+    }
+  } finally {
+    // Make sure we don't leave the underlying reader locked if the caller
+    // bails out (e.g. handler throws).
+    try { reader.releaseLock(); } catch { /* already released */ }
+  }
+}

--- a/frontend/src/components/AskOla/consumeSSEStream.js
+++ b/frontend/src/components/AskOla/consumeSSEStream.js
@@ -7,30 +7,55 @@
  *
  * Usage:
  *
- *   const response = await fetch('/api/ola/chat', { method: 'POST', ... });
+ *   const ac = new AbortController();
+ *   const response = await fetch('/api/ola/chat', { signal: ac.signal, ... });
  *   await consumeSSEStream(response, {
  *     thinking_step: (data) => { ... },
  *     text_token:    (data) => { ... },
  *     done:          (data) => { ... },
  *     error:         (data) => { ... },
- *   });
+ *   }, ac.signal);
  *
  * Frame format follows the SSE spec: lines `event: NAME\n` and `data: JSON\n`,
  * frames separated by blank line. JSON-decoded `data` is passed to the
  * matching handler. Unknown events are silently dropped (forward-compat).
+ *
+ * Pass an AbortSignal (3rd arg) to cancel mid-stream — when aborted, the
+ * reader is cancelled and the function returns cleanly without throwing.
+ * Caller should also pass the same signal to fetch() so the upstream
+ * connection is torn down too.
  */
-export async function consumeSSEStream(response, handlers) {
+export async function consumeSSEStream(response, handlers, signal) {
   if (!response || !response.body) {
     throw new Error('consumeSSEStream: response.body is missing');
   }
+  if (signal && signal.aborted) return;
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
 
+  // Cancelling the reader on abort makes the in-flight read() resolve to
+  // {done: true} (or reject in some impls — handled below), so the loop
+  // terminates promptly instead of blocking on a stalled stream.
+  const onAbort = () => {
+    reader.cancel().catch(() => { /* already closed */ });
+  };
+  if (signal) signal.addEventListener('abort', onAbort, { once: true });
+
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      if (signal && signal.aborted) break;
+      let chunk;
+      try {
+        chunk = await reader.read();
+      } catch (err) {
+        // reader.cancel() can surface here as AbortError / TypeError depending
+        // on the platform. Treat any error as abort if the signal fired.
+        if (signal && signal.aborted) break;
+        throw err;
+      }
+      const { done, value } = chunk;
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 
@@ -65,8 +90,7 @@ export async function consumeSSEStream(response, handlers) {
       }
     }
   } finally {
-    // Make sure we don't leave the underlying reader locked if the caller
-    // bails out (e.g. handler throws).
+    if (signal) signal.removeEventListener('abort', onAbort);
     try { reader.releaseLock(); } catch { /* already released */ }
   }
 }

--- a/frontend/src/pages/AskOla.jsx
+++ b/frontend/src/pages/AskOla.jsx
@@ -5,19 +5,30 @@ import request from '@/request/request';
 import { useAppContext } from '@/context/appContext';
 import MessageBubble from '@/components/AskOla/MessageBubble';
 import ChatInput from '@/components/AskOla/ChatInput';
+import ThinkingPanel from '@/components/AskOla/ThinkingPanel';
+import TextBlock from '@/components/AskOla/blocks/TextBlock';
+import { consumeSSEStream } from '@/components/AskOla/consumeSSEStream';
 
 export default function AskOla() {
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(false);
+  // Live streaming UI state — replaces hardcoded "Ola is thinking..." placeholder.
+  // liveLabel: current friendly thinking-step label, or null when text is streaming
+  //            or the panel should not render. Cleared on stream end.
+  // streamingText: assistant reply accumulated token-by-token while the SSE stream
+  //                is in flight; replaced by the final blocks-based MessageBubble
+  //                when the `done` frame arrives.
+  const [liveLabel, setLiveLabel] = useState(null);
+  const [streamingText, setStreamingText] = useState('');
   const bottomRef = useRef(null);
   const { state: stateApp, appContextAction } = useAppContext();
   const { activeSessionId } = stateApp;
   const { chatSession } = appContextAction;
 
-  // Auto-scroll to bottom when messages change
+  // Auto-scroll to bottom on new messages or while streaming chunks arrive.
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+  }, [messages, liveLabel, streamingText]);
 
   // Load messages when activeSessionId changes
   const loadMessages = useCallback(async (sessionId) => {
@@ -65,49 +76,88 @@ export default function AskOla() {
     };
     setMessages((prev) => [...prev, userMessage]);
     setLoading(true);
+    setLiveLabel('Ola is thinking...');  // STAGE_LABELS.__init__ (kept in sync with backend)
+    setStreamingText('');
 
     try {
-      const jsonData = { message: text };
-      if (activeSessionId) {
-        jsonData.sessionId = activeSessionId;
-      }
+      const body = { message: text };
+      if (activeSessionId) body.sessionId = activeSessionId;
 
-      const response = await request.post({
-        entity: 'ola/chat',
-        jsonData,
+      // EventSource doesn't support POST bodies, so we use fetch + manual SSE
+      // parsing. Same approach the OpenAI / Anthropic / Google JS SDKs use.
+      const resp = await fetch('/api/ola/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body),
       });
 
-      if (response.success) {
-        // If this was the first message, set the returned sessionId as active
-        if (!activeSessionId && response.result.sessionId) {
-          chatSession.setActive(response.result.sessionId);
-        }
+      if (!resp.ok) {
+        // Non-SSE failure (validation 400, auth 401, session-not-found 404).
+        // Backend returned a JSON error envelope.
+        let errMsg = `HTTP ${resp.status}`;
+        try {
+          const j = await resp.json();
+          if (j && j.message) errMsg = j.message;
+        } catch { /* keep default */ }
+        notification.error({ message: 'Ola 响应失败', description: errMsg });
+        return;
+      }
 
+      let finalSessionId = null;
+      let finalBlocks = null;
+      let errored = false;
+
+      await consumeSSEStream(resp, {
+        thinking_step: (data) => {
+          if (data && data.label) setLiveLabel(data.label);
+        },
+        text_token: (data) => {
+          if (!data || typeof data.delta !== 'string') return;
+          // Once text starts streaming, hide the live thinking panel — the
+          // streaming text bubble takes over visually.
+          setLiveLabel(null);
+          setStreamingText((prev) => prev + data.delta);
+        },
+        done: (data) => {
+          if (!data) return;
+          finalSessionId = data.sessionId || null;
+          finalBlocks = Array.isArray(data.blocks) ? data.blocks : null;
+        },
+        error: (data) => {
+          errored = true;
+          notification.error({
+            message: 'Ola 响应失败',
+            description: (data && data.message) || '未知错误',
+          });
+        },
+      });
+
+      // Commit final assistant message from `done` payload (which has
+      // thinking_trace + text + widget blocks already assembled by the backend).
+      if (!errored && finalBlocks) {
         const assistantMessage = {
           id: `msg_assistant_${Date.now()}`,
           role: 'assistant',
           timestamp: new Date().toISOString(),
-          blocks: response.result.blocks?.length
-            ? response.result.blocks
-            : [{ type: 'text', content: response.result.content }],
+          blocks: finalBlocks,
         };
         setMessages((prev) => [...prev, assistantMessage]);
 
-        // Refresh session list (new session may have been created)
+        if (!activeSessionId && finalSessionId) {
+          chatSession.setActive(finalSessionId);
+        }
         refreshSessionList();
-      } else {
-        notification.error({
-          message: 'Ola 响应失败',
-          description: response.message || '未知错误',
-        });
       }
     } catch (err) {
       notification.error({
         message: '无法连接 Ola',
-        description: '请确认后端服务和 NanoBot 是否正常运行',
+        description: err.message || '请确认后端服务和 NanoBot 是否正常运行',
       });
     } finally {
       setLoading(false);
+      setLiveLabel(null);
+      setStreamingText('');
     }
   };
 
@@ -131,12 +181,13 @@ export default function AskOla() {
               {messages.map((msg) => (
                 <MessageBubble key={msg.id} message={msg} />
               ))}
-              {loading && (
+              {loading && (liveLabel || streamingText) && (
                 <div className="askola-message askola-message--assistant">
                   <div className="askola-message-blocks">
-                    <div className="askola-block-text">
-                      <p className="askola-typing-indicator">Ola is thinking...</p>
-                    </div>
+                    {liveLabel && (
+                      <ThinkingPanel mode="live" currentLabel={liveLabel} />
+                    )}
+                    {streamingText && <TextBlock content={streamingText} />}
                   </div>
                 </div>
               )}

--- a/frontend/src/pages/AskOla.jsx
+++ b/frontend/src/pages/AskOla.jsx
@@ -21,6 +21,10 @@ export default function AskOla() {
   const [liveLabel, setLiveLabel] = useState(null);
   const [streamingText, setStreamingText] = useState('');
   const bottomRef = useRef(null);
+  // Tracks the in-flight /api/ola/chat fetch so a New Chat click or a fresh
+  // send can cancel a stale stream — otherwise the still-streaming `done`
+  // frame would silently re-open the previous session (PR #171 review bug).
+  const abortRef = useRef(null);
   const { state: stateApp, appContextAction } = useAppContext();
   const { activeSessionId } = stateApp;
   const { chatSession } = appContextAction;
@@ -36,15 +40,27 @@ export default function AskOla() {
       setMessages([]);
       return;
     }
-    const response = await request.get({ entity: `ola/session/messages/${sessionId}` });
-    if (response.success) {
-      const loaded = response.result.map((msg) => ({
-        id: msg._id,
-        role: msg.role,
-        timestamp: msg.created,
-        blocks: msg.blocks || [{ type: 'text', content: msg.content }],
-      }));
-      setMessages(loaded);
+    try {
+      const response = await request.get({ entity: `ola/session/messages/${sessionId}` });
+      if (response.success) {
+        const loaded = response.result.map((msg) => ({
+          id: msg._id,
+          role: msg.role,
+          timestamp: msg.created,
+          blocks: msg.blocks || [{ type: 'text', content: msg.content }],
+        }));
+        setMessages(loaded);
+      } else {
+        notification.error({
+          message: '无法加载历史消息',
+          description: response.message || '会话消息加载失败，请刷新重试',
+        });
+      }
+    } catch (err) {
+      notification.error({
+        message: '无法加载历史消息',
+        description: err.message || '网络错误',
+      });
     }
   }, []);
 
@@ -54,19 +70,40 @@ export default function AskOla() {
 
   // Refresh session list — no deps on chatSession to avoid infinite re-render
   const refreshSessionList = async () => {
-    const response = await request.get({ entity: 'ola/session/list' });
-    if (response.success) {
-      chatSession.setList(response.result);
+    try {
+      const response = await request.get({ entity: 'ola/session/list' });
+      if (response.success) {
+        chatSession.setList(response.result);
+      } else {
+        notification.error({
+          message: '无法刷新会话列表',
+          description: response.message || '请刷新页面重试',
+        });
+      }
+    } catch (err) {
+      notification.error({
+        message: '无法刷新会话列表',
+        description: err.message || '网络错误',
+      });
     }
   };
 
   const handleNewChat = () => {
+    // Cancel any in-flight stream so its `done` frame can't quietly re-open
+    // the old session right after the user clicked into a fresh chat.
+    abortRef.current?.abort();
     chatSession.setActive(null);
     setMessages([]);
   };
 
   const handleSend = async (messageContent) => {
     const text = messageContent.text;
+
+    // Cancel any previous in-flight stream defensively (e.g. user spam-clicks
+    // send before the previous turn finishes).
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
 
     const userMessage = {
       id: `msg_user_${Date.now()}`,
@@ -90,6 +127,7 @@ export default function AskOla() {
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify(body),
+        signal: ac.signal,
       });
 
       if (!resp.ok) {
@@ -131,7 +169,12 @@ export default function AskOla() {
             description: (data && data.message) || '未知错误',
           });
         },
-      });
+      }, ac.signal);
+
+      // If the user cancelled (New Chat / fresh send) while we were streaming,
+      // don't commit a stale assistant message back into state — that would
+      // visibly snap the user away from their fresh chat.
+      if (ac.signal.aborted) return;
 
       // Commit final assistant message from `done` payload (which has
       // thinking_trace + text + widget blocks already assembled by the backend).
@@ -150,14 +193,21 @@ export default function AskOla() {
         refreshSessionList();
       }
     } catch (err) {
+      // AbortError on cancel is expected; suppress the user-facing toast.
+      if (err.name === 'AbortError' || ac.signal.aborted) return;
       notification.error({
         message: '无法连接 Ola',
         description: err.message || '请确认后端服务和 NanoBot 是否正常运行',
       });
     } finally {
-      setLoading(false);
-      setLiveLabel(null);
-      setStreamingText('');
+      // Only clear if this is still the active stream — a newer handleSend may
+      // have already replaced abortRef.current and set fresh loading state.
+      if (abortRef.current === ac) {
+        abortRef.current = null;
+        setLoading(false);
+        setLiveLabel(null);
+        setStreamingText('');
+      }
     }
   };
 

--- a/frontend/src/style/partials/askola.css
+++ b/frontend/src/style/partials/askola.css
@@ -554,3 +554,68 @@
   font-weight: 600;
   font-size: 12px;
 }
+
+/* ===== ThinkingPanel — live progress + collapsed trace (Issue #131) ===== */
+
+/* Live mode — single-line in-place updating indicator */
+.askola-thinking-panel--live {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  margin-bottom: 8px;
+  background: #f5f5f7;
+  border-radius: 8px;
+  color: #595959;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.askola-thinking-panel-label {
+  color: #595959;
+}
+
+/* Collapsed mode — `▶ View thinking process` with expandable list */
+.askola-thinking-panel--collapsed {
+  margin-bottom: 8px;
+}
+
+.askola-thinking-panel-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: transparent;
+  border: none;
+  color: #8c8c8c;
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s ease;
+}
+
+.askola-thinking-panel-toggle:hover {
+  background: #f5f5f5;
+  color: #595959;
+}
+
+.askola-thinking-panel-toggle .anticon {
+  font-size: 11px;
+}
+
+.askola-thinking-panel-steps {
+  margin: 6px 0 0 0;
+  padding: 8px 12px 8px 28px;
+  background: #fafafa;
+  border-left: 2px solid #e8e8e8;
+  border-radius: 0 4px 4px 0;
+  list-style-type: decimal;
+  color: #595959;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.askola-thinking-panel-step {
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
## Summary

Replaces the static `Ola is thinking...` indicator on Ask Ola with a real-time streaming progress panel that surfaces NanoBot tool events as friendly labels (e.g. `Ola is searching your products...`), and persists the thinking trace into ChatMessage so reloaded sessions keep the collapsed `▶ View thinking process` trail. Closes #131.

## Cross-repo dependency

Requires the matching SSE extension on the NanoBot side: [`Ola_bot@255fdad`](https://github.com/SeekMi-Technologies/Ola_bot/commit/255fdad) on `ola-dev`. That commit adds `event: tool_event` frames + the `on_stream_end(resuming=True)` bug fix this PR depends on. **Both must ship together.**

## Architecture (β path — 3 layers)

```
NanoBot serve  (../Ola_bot, ola-dev, commit 255fdad)
  └─ /v1/chat/completions: SSE now also emits `event: tool_event` frames
     ↓
CRM olaController/chat.js  (this PR)
  └─ /api/ola/chat: rewritten as SSE pass-through
     ↓ translates NanoBot raw tool name → friendly label via thinkingLabels.labelFor()
     ↓ buffers thinking steps + text → prepends thinking_trace block → ChatMessage.insertMany on stream end
     ↓
Frontend AskOla.jsx  (this PR)
  └─ fetch() + ReadableStream + consumeSSEStream → ThinkingPanel
```

Single SSE channel, multiple event types (`thinking_step` / `text_token` / `done` / `error`) — industry-standard pattern (OpenAI / Anthropic / Google).

## Backend changes

- `olaController/chat.js` — full rewrite from one-shot POST proxy to SSE pass-through. Preserves session resolve/create, ChatMessage persistence, and auto-title logic. Reads `NANOBOT_HOST`/`PORT` per-request (12-factor + testable).
- `olaController/thinkingLabels.js` (new) — dictionary for 12 user-facing MCP tools + skip list (`health.ping`) + stage labels. All labels carry an `Ola is X...` subject. Unknown tools fall back to `Ola is working on it...`.

## Frontend changes

- `ThinkingPanel.jsx` (new) — two modes: `live` (single-line + spinner) and `collapsed` (default folded `▶ View thinking process`).
- `consumeSSEStream.js` (new) — generic fetch+ReadableStream SSE parser handling chunk boundaries, multi-frame chunks, async handler ordering, and forward-compat unknown events.
- `AskOla.jsx` — `handleSend` rewritten: replaces axios `request.post()` with `fetch()` + `consumeSSEStream`. Live `liveLabel` + `streamingText` state.
- `MessageBubble.jsx` — `BLOCK_MAP` gains a `thinking_trace` branch so reloaded sessions show the same collapsed panel.
- `askola.css` — ThinkingPanel styling.

## Bugs caught + fixed during implementation

1. **`on_stream_end(resuming=True)` terminating the SSE drain loop** (NanoBot side). Real-stack curl uncovered it — mock-based unit tests had passed cleanly. Reinforced the unit→integration discipline (memory: `feedback_unit_then_integration.md`).
2. **`ChatMessage.content` schema discussion**: a draft change relaxing `required: true` was reverted on zyd's review — the SOUL.md invariant is that the agent always speaks ("never silent-error on missing Merch"); empty content should crash persistence so we can detect prompt regressions, not be silently allowed.

## Tests

| Layer | Count | Status |
|---|---|---|
| jest unit (backend) | 28 new (13 thinkingLabels + 15 olaController.chat) | ✅ all green |
| Integration shell (backend, real stack) | 4 scenarios (`backend/test/integration/test_ola_chat_sse.sh`) | ✅ all pass |
| vitest (frontend) | 24 new (12 ThinkingPanel + 4 MessageBubble + 8 consumeSSEStream) | ✅ all green |
| `npx vite build` | AskOla bundle 130.87 kB / gzip 40.95 kB | ✅ pass |
| Browser smoke (zyd manual) | live label / streaming text / collapsed trace / reload persistence | ✅ pass |

## Out of scope (follow-ups)

- **#169** — v1.1 query-parameter surfacing (`Ola is searching for "stainless steel"...`). Specific to search-type tools; needs per-tool formatter design.
- **i18n / Chinese labels** — deferred until user-level locale + i18n pipeline exists (`idurar_app_language` is application-level tech debt).
- **Production nginx SSE compatibility** — separate issue (already opened by zyd). Must be resolved before this PR merges to dev. SSE requires `proxy_buffering off` + sufficient `proxy_read_timeout`.

## Test plan
- [ ] Browser smoke on dev environment after merge: send tool-triggering prompt → verify live `Ola is searching your products...` → answer streams → collapses to `▶ View thinking process`
- [ ] Reload session: historical assistant messages still show collapsed trace
- [ ] Quote create flow: PDF widget + thinking_trace coexist
- [ ] Pure text prompt: no thinking_step frames, just text streaming
- [ ] Verify nginx SSE config in production before final dev→main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)