### PR TITLE
fix(prod-nginx): proxy_buffering off for /api/ola SSE

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -43,6 +43,14 @@ server {
 
     # /api/ola/* 走 NanoBot → Gemini，长链路 LLM 请求允许 3 分钟
     # 必须放在 /api/ 之前 —— nginx 最长前缀匹配优先
+    #
+    # SSE streaming (Issue #131): /api/ola/chat returns text/event-stream and
+    # writes thinking_step / text_token chunks LIVE as the agent loop runs.
+    # Default nginx behavior buffers the full upstream response before
+    # forwarding (and may gzip it) — that would queue every chunk until the
+    # backend res.end() and silently break the streaming UX. proxy_buffering
+    # off + proxy_cache off makes nginx pass each chunk through immediately.
+    # The backend also sets X-Accel-Buffering: no defensively (chat.js).
     location /api/ola/ {
         set $upstream_backend backend:8888;
         proxy_pass http://$upstream_backend;
@@ -53,6 +61,8 @@ server {
         proxy_set_header X-Forwarded-Proto https;
         proxy_read_timeout 180s;
         proxy_send_timeout 180s;
+        proxy_buffering off;
+        proxy_cache off;
         client_max_body_size 20M;
     }
 

--- a/ola/SETUP.md
+++ b/ola/SETUP.md
@@ -1,56 +1,238 @@
 # Ola workspace — dev machine setup
 
-This directory is what makes **Ask Ola** behave as a real tool-calling agent
-(not a plain chat proxy) on any machine that clones this repo. It contains:
+> **For coding agents (Claude Code / Cursor / Antigravity) bootstrapping
+> wzh's or yili's machine**: read [§ TL;DR — wzh / yili (UI-only) one-shot
+> quickstart](#tldr--wzh--yili-ui-only-one-shot-quickstart) first. That
+> section is intentionally complete and ordered so an agent can execute
+> it top-to-bottom without judgment calls.
+
+This directory makes **Ask Ola** behave as a real tool-calling agent (not a
+plain chat proxy). It contains:
 
 - `nanobot-workspace/` — the 5 markdown files that define Ola's persona,
   behaviors, and tool-usage rules. Loaded by nanobot at startup.
 - `nanobot.config.template.json` — nanobot's config, with secrets replaced
   by `${VAR}` placeholders. Rendered by `start-dev.sh` at first boot.
 
-## Prerequisites
+---
 
-- Node.js 20.x, npm 10.x
-- Python 3.11+
-- The Ola CRM and Ola_bot repos cloned as **siblings** —
-  `start-dev.sh` expects `$CRM_DIR/../Ola_bot/` (or the legacy
-  `../nanobot/`) to exist and launches `python -m nanobot serve` from
-  there. Use the Ola fork, not upstream, so future Ola-specific patches
-  land in the right place:
+## Repo & path topology (read this first)
 
-  ```bash
-  mkdir -p ~/dev && cd ~/dev
-  git clone git@github.com:SeekMi-Technologies/ola.git
-  git clone git@github.com:SeekMi-Technologies/Ola_bot.git
-  # upstream is git@github.com:HKUDS/nanobot.git — already set as
-  # `upstream` remote on zyd's main mac; add if you want upstream merges.
-  # Older clones may still be named `crm/` and `nanobot/` locally;
-  # start-dev.sh handles either name.
-  ```
+Ola's dev environment spans **2 sibling git repos** + **2 dotfile
+locations** + **2 .env files**. The agent must understand all four to
+bootstrap correctly:
 
-### Python deps for nanobot
-Fresh clone 后必须装一次（之后改源码免重装）：
+```
+~/dev/                              ← any directory; pick one and stick with it
+├── crm/                            ← THIS REPO (SeekMi-Technologies/Ola)
+│   ├── backend/                    ← Node 20 / Express, MCP server
+│   │   ├── .env                    ← per-machine secrets, gitignored
+│   │   └── .env.example            ← template, commit ok
+│   ├── frontend/                   ← React 18 + Vite + Ant Design
+│   ├── ola/
+│   │   ├── SETUP.md                ← this file
+│   │   ├── nanobot.config.template.json   ← rendered into ~/.nanobot/config.json
+│   │   └── nanobot-workspace/      ← 5 .md files copied into ~/.nanobot/workspace/
+│   ├── .env                        ← project-root, only used by docker-compose
+│   ├── start-dev.sh                ← one-command launcher for the 4 services
+│   └── stop-dev.sh
+│
+└── nanobot/  (or  Ola_bot/)        ← MUST be a sibling of crm/
+    └── NOTE: Use SeekMi-Technologies/Ola_bot, NOT upstream HKUDS/nanobot.
+        We carry Ola-specific patches on branch `ola-dev`.
+
+~/.nanobot/                         ← provisioned by start-dev.sh on first boot
+├── config.json                     ← rendered from ola/nanobot.config.template.json
+│                                     (mode 600 — contains MCP_SERVICE_TOKEN +
+│                                     GEMINI_API_KEY substituted in)
+└── workspace/
+    ├── SOUL.md   USER.md   AGENTS.md   TOOLS.md   HEARTBEAT.md
+    │                                 (copied verbatim from ola/nanobot-workspace/)
+    ├── memory/                     ← runtime agent memory, per-machine
+    └── sessions/                   ← chat session logs, per-machine
+```
+
+**Hard rules** (will silently break if violated):
+- The two repos **must be siblings** at the same parent dir. `start-dev.sh`
+  resolves nanobot via `${CRM_DIR}/../nanobot/` or `${CRM_DIR}/../Ola_bot/`.
+- `~/.nanobot/` is in the user's home dir (not inside either repo). It
+  persists across `git pull`s — your local agent memory + chat history
+  outlive code updates.
+- `backend/.env` is **gitignored, never commit**. `.env` (project root) is
+  also gitignored as of #144.
+
+---
+
+## Service ports + processes
+
+`start-dev.sh` brings up **4 services** simultaneously. If any port is
+already taken, the corresponding service fails — see Troubleshooting.
+
+| Port | Service | Process | Source dir |
+|---|---|---|---|
+| `3000` | Frontend (Vite dev server) | `npx vite --port 3000` | `frontend/` |
+| `8888` | Backend (Express + nodemon) | `npx nodemon src/server.js` | `backend/` |
+| `8889` | MCP Server (Node + nodemon) | `npx nodemon --watch src/mcp src/mcp/server.js` | `backend/` |
+| `8900` | NanoBot (Python — the AI agent) | `python -m nanobot serve` | `../nanobot/` (sibling) |
+
+For the **production stack** (which the docker-compose deploys), the
+topology shifts: `frontend` becomes an `nginx:alpine` container on port 80
+that reverse-proxies `/api/*` to backend, plus 2 sibling boxes for nanobot
+(Box2) and Gotenberg (Box3) over Tailscale. See `docker-compose.yml` and
+`frontend/Dockerfile.prod` for details.
+
+---
+
+## TL;DR — wzh / yili (UI-only) one-shot quickstart
+
+> Agent: execute these 8 steps in order. Stop at the first failure and
+> return the verify-step error to the user before guessing.
 
 ```bash
-cd ../Ola_bot
+# ───────────────── 1. Install runtime tools ─────────────────
+# macOS (Homebrew). Skip any tool the user already has.
+brew install node@20 git
+# (Optional, only if Ask Ola interaction needed — wzh/yili usually skip)
+brew install python@3.11 uv
+
+# Verify:
+node --version    # → v20.x.x
+npm --version     # → 10.x.x
+git --version     # any modern git
+
+# ───────────────── 2. Clone both repos as siblings ─────────────────
+mkdir -p ~/dev && cd ~/dev
+
+# Main CRM repo (this one)
+git clone git@github.com:SeekMi-Technologies/Ola.git crm
+
+# NanoBot fork — REQUIRED for `start-dev.sh` to find at ../nanobot/.
+# Use the SeekMi fork (NOT upstream HKUDS/nanobot) so Ola patches apply.
+git clone git@github.com:SeekMi-Technologies/Ola_bot.git nanobot
+# (`Ola_bot` is the GitHub repo name; cloning into a directory named
+# `nanobot` matches the path that start-dev.sh probes first.)
+
+# Verify:
+ls ~/dev/      # → crm  nanobot
+test -d ~/dev/crm/backend && test -d ~/dev/nanobot/nanobot && echo "siblings OK"
+
+# ───────────────── 3. Get backend/.env from zyd ─────────────────
+# Ask zyd for the dev shared values for these 4 keys (paste over the
+# example file). Never commit this file — it's gitignored.
+cd ~/dev/crm
+cp backend/.env.example backend/.env
+# Now open backend/.env and fill these 4 (zyd will hand them over Slack/1Password):
+#   DATABASE=mongodb+srv://...        (shared Atlas cluster)
+#   JWT_SECRET=...                    (any 64-hex string; `openssl rand -hex 32`)
+#   MCP_SERVICE_TOKEN=...             (dev-shared value from zyd)
+#   GEMINI_API_KEY=AIza...            (zyd's dev key, OR your own from aistudio.google.com)
+
+# Verify:
+grep -E '^(DATABASE|JWT_SECRET|MCP_SERVICE_TOKEN|GEMINI_API_KEY)=' backend/.env | wc -l
+# → should print  4
+
+# ───────────────── 4. Project-root .env (only needed for docker compose) ─────
+# wzh/yili: SKIP this step. Required only for `docker compose up` (prod
+# stack staging). For day-to-day UI work via start-dev.sh you do NOT
+# need a project-root .env file at all.
+
+# ───────────────── 5. Install Node deps ─────────────────
+cd ~/dev/crm/backend  && npm install
+cd ~/dev/crm/frontend && npm install
+
+# Verify:
+test -d ~/dev/crm/backend/node_modules && test -d ~/dev/crm/frontend/node_modules \
+  && echo "node deps OK"
+
+# ───────────────── 6. Install nanobot Python deps (skip if UI-only) ────────
+# wzh/yili: This is OPTIONAL. Skip if you don't need to test Ask Ola
+# locally — the rest of the UI works fine without it. Skipping means
+# the Ask Ola tab will show "Cannot connect to Ola" but every other
+# page (Quote, Invoice, Customer, Settings, Dashboard...) is unaffected.
+#
+# To enable Ask Ola locally:
+cd ~/dev/nanobot
 pip install -e .
+# (or: uv pip install -e . if you use uv)
+
+# Verify:
+python -c "import nanobot; print('nanobot installed:', nanobot.__file__)"
+
+# ───────────────── 7. Start the stack ─────────────────
+cd ~/dev/crm
+bash start-dev.sh
+# ↑ This will:
+#   - First boot only: render ~/.nanobot/config.json from ola/ template,
+#     copy 5 .md files into ~/.nanobot/workspace/
+#   - Start 4 services (3000 / 8888 / 8889 / 8900)
+#   - Print a status table — all 4 should show "running"
+# Logs at /tmp/ola-{backend,mcp,nanobot,frontend}.log
+
+# Verify:
+curl -s http://localhost:8888/health    # → {"status":"ok",...}
+curl -s -I http://localhost:3000/       # → HTTP/1.1 200 OK
+
+# ───────────────── 8. Open the app + verify login ─────────────────
+# Open in browser: http://localhost:3000
+# Login with the test admin (ask zyd for shared dev creds):
+#   email: admin@admin.com
+#   password: admin123
+# If login redirects to the dashboard with no errors, you're done.
+# Now click around; CSS/className edits in frontend/ hot-reload via Vite.
+
+# When done for the day:
+bash stop-dev.sh
 ```
 
-Sync 上游后如果引入新 deps（例如 v0.1.4 → v0.1.5 引入 pypdf/filelock），重跑一次 `pip install -e .`。
+**Common stop conditions for an agent:**
+- Step 2 `git clone` fails with permission denied → user's GitHub SSH key
+  isn't added to SeekMi-Technologies. Have user add it before continuing.
+- Step 3 ends with anything other than `4` → backend/.env is incomplete;
+  ask zyd which key is missing.
+- Step 5 fails with `EACCES` or sudo prompt → npm permissions broken;
+  reinstall Node via `brew install node@20` (don't use sudo).
+- Step 7's status table shows `FAILED` for nanobot → pip install (step 6)
+  was skipped or failed; UI still works without it (Ask Ola tab broken
+  only) so this is non-blocking for wzh/yili.
 
-- MongoDB connection string (Atlas shared cluster or your own)
-- Gemini API key (from [aistudio.google.com](https://aistudio.google.com))
+---
 
-## Frontend-only setup（wzh / UI-only 开发者）
+## Full-stack setup (Yuandong / Ziyue)
 
-最小工作环境：
+Same as the wzh/yili 8-step quickstart above, plus:
 
+- **Step 4 IS required** — `.env` (project root) needs `MCP_BIND_ADDR=127.0.0.1`
+  for local docker compose / prod-stack staging. Other engineers don't need
+  to copy this from anywhere; just create the file with that one line:
+  ```bash
+  echo 'MCP_BIND_ADDR=127.0.0.1' > .env
+  ```
+- **Step 6 IS required** — nanobot Python install is mandatory for backend
+  + MCP development. Use `uv pip install -e .` for fast installs.
+- Run `npx jest` from `backend/` and `npx vitest run` from `frontend/` to
+  exercise the regression test suites before opening a PR.
+
+---
+
+## Project-root `.env` — only for docker compose
+
+The project root `.env` (gitignored, separate from `backend/.env`) carries
+**docker-compose orchestration variables**, not application secrets. Most
+developers never create this file. Required values:
+
+| Variable | When required | Value |
+|---|---|---|
+| `MCP_BIND_ADDR` | Whenever you run `docker compose up` | `127.0.0.1` for local; `<Box1 Tailscale IP>` for prod (e.g. `100.109.220.126`) |
+
+If you're only running `start-dev.sh` (the host-mode dev launcher), you
+don't need this file. `start-dev.sh` doesn't read it.
+
+If you do create it for local docker testing:
 ```bash
-cd backend && npm install && npm run dev   # API on 8888
-cd frontend && npm install && npm run dev  # UI on 3000
+echo 'MCP_BIND_ADDR=127.0.0.1' > .env
 ```
 
-跳过：MCP server、NanoBot、Gotenberg、Python 装包。Ask Ola tab 会因 NanoBot 没起报"无法连接"，但不影响 CSS/JSX 改动。
+---
 
 ## First-boot flow (what `start-dev.sh` does for you)
 
@@ -161,8 +343,11 @@ provision with `rm ~/.nanobot/workspace/SOUL.md && bash start-dev.sh`.
 | `ola/nanobot-workspace/*.md` | yes | persona template (source of truth) |
 | `ola/nanobot.config.template.json` | yes | nanobot config skeleton with placeholders |
 | `ola/SETUP.md` | yes | this file |
-| `backend/.env` | no (gitignored, untracked via #144) | per-machine secrets — never stage |
+| `backend/.env` | no (gitignored via #144) | per-machine app secrets — never stage |
+| `.env` (project root) | no (gitignored) | docker-compose orchestration vars only — `MCP_BIND_ADDR=...` |
 | `~/.nanobot/workspace/*.md` | no | provisioned copy (first-boot) — safe to edit locally |
 | `~/.nanobot/workspace/memory/` | no | runtime agent memory — per machine |
 | `~/.nanobot/workspace/sessions/` | no | chat session logs — per machine |
+| `~/.nanobot/config.json` | no (mode 600) | rendered config with real `MCP_SERVICE_TOKEN` + `GEMINI_API_KEY` substituted in |
+| `../nanobot/` (sibling) | (separate repo) | NanoBot Python AI backbone — `SeekMi-Technologies/Ola_bot` fork, branch `ola-dev` |
 | `~/.nanobot/config.json` | no | rendered config with real `MCP_SERVICE_TOKEN` and `GEMINI_API_KEY` — mode 600 |


### PR DESCRIPTION
## Summary

Production nginx (frontend container in `Dockerfile.prod`) was buffering the SSE response from `/api/ola/chat` — defeating the live thinking panel + token streaming that #171 / #131 just shipped.

zyd reproduced this after #171 merged: the live label stayed on \`Ola is thinking...\` for the whole turn, then everything dumped at once. Local jest/vitest/integration shells all passed because none of them exercised the prod nginx layer; #171's compression-middleware fix was necessary but not sufficient.

## Change

- `/api/ola/` location in the embedded nginx config gains:
  ```nginx
  proxy_buffering off;
  proxy_cache off;
  ```
- 8-line block comment explaining why (cross-references the backend's `X-Accel-Buffering: no` defensive header in `chat.js`)
- `/api/` (non-ola) untouched — keeps gzip+buffer for normal JSON APIs

## Verification (local prod-stack staging)

Built + ran the prod docker compose stack locally (`docker compose up -d --build`), curl-tested through the prod nginx (port 80):

```
[+1654ms] event: thinking_step
[+1654ms] data: {"label":"Ola is searching your products...",...}

[+3792ms] event: text_token       ← 2.1s gap, live label visible
[+3792ms] data: {"delta":"未"}

[+3801ms] event: text_token       ← Gemini chunks 50ms apart
[+3801ms] data: {"delta":"找到包含 stainless 的产品。"}

[+3827ms] event: done
```

4/4 assertions:
- `/health` → 200
- no-cookie `/api/setting/listAll` → 401
- login through prod nginx → cookie set
- SSE timestamped through prod nginx — chunks arrive at distinct times, NOT clustered

## Cross-repo dependency

None. Self-contained nginx config change. Pairs with already-merged #171.

## Test plan
- [ ] Production curl E2E during deploy (memory: feedback_infra_change_curl_e2e mandatory):
  - `curl https://app.olatech.ai/health` → 200
  - no-cookie `/api/setting/listAll` → 401
  - SSE timestamped curl: thinking_step / text_token / done arrive at distinct times
- [ ] Browser smoke after deploy: live label + token streaming on real prod domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)