### PR TITLE
UI: Quote 术语统一 + Merch 字段 label

### DIFF
--- a/frontend/src/pages/Merchandise/config.js
+++ b/frontend/src/pages/Merchandise/config.js
@@ -2,31 +2,40 @@ export const fields = {
   serialNumber: {
     type: 'string',
     required: true,
+    label: 'Serial Number',
   },
   serialNumberLong: {
     type: 'string',
+    label: 'Serial Number (Long)',
   },
   description_en: {
     type: 'string',
     required: true,
+    label: 'Description (EN)',
   },
   description_cn: {
     type: 'string',
+    label: 'Description (CN)',
   },
   weight: {
     type: 'number',
+    label: 'Weight (kg)',
   },
   VAT: {
     type: 'number',
+    label: 'VAT (%)',
   },
   ETR: {
     type: 'number',
+    label: 'ETR (%)',
   },
   unit_en: {
     type: 'string',
     required: true,
+    label: 'Unit (EN)',
   },
   unit_cn: {
     type: 'string',
+    label: 'Unit (CN)',
   },
 };

--- a/frontend/src/pages/Quote/index.jsx
+++ b/frontend/src/pages/Quote/index.jsx
@@ -86,10 +86,10 @@ export default function Quote() {
   ];
 
   const Labels = {
-    PANEL_TITLE: translate('proforma invoice'),
-    DATATABLE_TITLE: translate('proforma invoice_list'),
-    ADD_NEW_ENTITY: translate('add_new_proforma invoice'),
-    ENTITY_NAME: translate('proforma invoice'),
+    PANEL_TITLE: translate('quote'),
+    DATATABLE_TITLE: translate('quote_list'),
+    ADD_NEW_ENTITY: translate('add_new_quote'),
+    ENTITY_NAME: translate('quote'),
   };
 
   const configPage = {


### PR DESCRIPTION
## Summary

两个原子修复，都是纯 UI 文案改动（无业务逻辑、无 API、无 type）：

- **#157** — Quote 页面顶部标题 "Proforma Invoice List" → "Quote List"，与侧栏术语统一
- **#156** — Merch 表单字段不再露出驼峰命名（`SerialNumber` → `Serial Number` 等）

## Changes

| 文件 | 改动 |
|---|---|
| `frontend/src/pages/Quote/index.jsx` | Labels 从 `'proforma invoice'` 系列翻译 key 改为 `'quote'` 系列 |
| `frontend/src/pages/Merchandise/config.js` | 9 个字段都补了 `label`，VAT/ETR/weight 加单位 |

## Why this works

- Quote: `quote` / `quote_list` / `add_new_quote` 已存在于 `en_us.js`（第 216、397、398 行）✅
- Merch: `DynamicForm/index.jsx` 第 22-23 行——缺 label 时 fallback 到 key，加 label 即可

## Test plan

- [x] `npm run lint` pass（0 warnings on touched files）
- [x] `npm run build` pass（4.02s, 0 error）
- [x] Local Vite preview confirmed by Angel — Quote 页和 Merch 抽屉表单 label 都正确

## Out of scope

- 不动 locale 文件（`#168 双语言系统` 是技术债，等系统重构）
- VAT/ETR 没加 ⓘ tooltip（需要改 `DynamicForm`，超出 ui-tweak 范围；后续可单开）

Closes #157
Closes #156