### PR TITLE
feat(mcp): user-scope isolation via X-Acting-As header (closes #185)

### DIFF
--- a/backend/src/controllers/appControllers/olaController/chat.js
+++ b/backend/src/controllers/appControllers/olaController/chat.js
@@ -206,6 +206,12 @@ const chat = async (req, res) => {
       'Content-Type': 'application/json',
       'Content-Length': Buffer.byteLength(proxyPayload),
       'Accept': 'text/event-stream',
+      // ISO5c (issue #185): pass logged-in admin._id so nanobot's MCP HTTP
+      // calls inject X-Acting-As; MCP server then scopes business tools to
+      // this admin instead of falling back to systemAdmin. End-to-end:
+      //   browser cookie → req.admin._id → here → nanobot api/server.py
+      //   → set_acting_as → contextvar → mcp.py event_hook → MCP server
+      'X-Ola-Acting-As': userId.toString(),
     },
     timeout: NANOBOT_TIMEOUT_MS,
   };

--- a/backend/src/mcp/adapters/controllerAdapter.js
+++ b/backend/src/mcp/adapters/controllerAdapter.js
@@ -1,4 +1,4 @@
-// Ola CRM MCP — Controller adapter (A2)
+// Ola CRM MCP — Controller adapter (A2; ISO2 update issue #185)
 //
 // 把现有 CRM controller 的 (req, res, next) 签名包装成 async (input) => output，
 // 让 MCP tools 能直接复用 controller，不必重写业务逻辑。
@@ -17,10 +17,28 @@
 //
 // 30s timeout 强制兜底，避免 controller 挂死阻塞 NanoBot。
 //
-// 注意：A2 阶段 adapter 是纯函数（不 require 任何 controller），方便单元自检。
-// A5+ 才会被真实 CRUD tool 使用。
+// ISO2: buildReq resolves req.admin from a 3-tier chain:
+//   1. input.admin (explicit) — caller passes it (legacy A5-A7 path)
+//   2. AsyncLocalStorage context.actingAdmin (set by server.js per-request)
+//   3. null (controller will likely crash; tool authors should handle this)
+// Tools that want server.js-managed acting-as can omit input.admin entirely
+// and rely on the context. This makes ISO3 (business tools) a drop of the
+// `admin: getSystemAdmin()` lines in each tool's call() helper.
+
+const { getCurrentActingAdmin } = require('../context');
 
 const DEFAULT_TIMEOUT_MS = 30 * 1000;
+
+// Read context.actingAdmin without throwing when called outside an MCP request
+// scope (e.g. unit tests that invoke buildReq directly). Returns null if no
+// scope is active or no admin was set.
+function readContextAdminSafe() {
+  try {
+    return getCurrentActingAdmin();
+  } catch (_outsideScope) {
+    return null;
+  }
+}
 
 function statusToCode(status) {
   if (status >= 200 && status < 300) return null; // 成功无 code
@@ -43,11 +61,17 @@ function statusToCode(status) {
  * @param {object} [input.headers]
  */
 function buildReq(input = {}) {
+  // ISO2 admin resolution: explicit input.admin first, then per-request
+  // context (set by server.js when X-Acting-As header is present), then null.
+  const admin =
+    input.admin !== undefined && input.admin !== null
+      ? input.admin
+      : readContextAdminSafe();
   return {
     body: input.body || {},
     params: input.params || {},
     query: input.query || {},
-    admin: input.admin || null,
+    admin,
     headers: input.headers || {},
     // 一些 controller 会用 req.method / req.originalUrl 做 logging，给点合理默认
     method: 'POST',

--- a/backend/src/mcp/bootstrap.js
+++ b/backend/src/mcp/bootstrap.js
@@ -119,8 +119,15 @@ async function resolveActingAdmin(adminId) {
     ACTING_AS_CACHE.delete(trimmed);
   }
 
+  // PR #193 follow-up: project to a minimal safe shape — controllers only
+  // ever need _id (createdBy filter), and we keep email/role for audit log
+  // surface area. Anything else (incl. any future sensitive field added to
+  // Admin schema) stays out of the in-memory cache by construction.
   const Admin = mongoose.model('Admin');
-  const admin = await Admin.findById(trimmed).exec();
+  const admin = await Admin.findById(trimmed)
+    .select('_id email role enabled removed')
+    .lean()
+    .exec();
   if (!admin) {
     return { ok: false, code: 'NOT_FOUND', message: `admin not found: ${trimmed}` };
   }

--- a/backend/src/mcp/bootstrap.js
+++ b/backend/src/mcp/bootstrap.js
@@ -17,6 +17,18 @@ const path = require('path');
 
 let systemAdmin = null;
 
+// ISO1 (issue #185): per-request acting-as admin cache. Maps admin._id (string)
+// to { admin, expiresAt } — TTL-bound so admin disable/remove takes effect
+// without requiring an MCP restart. Default TTL 5 minutes balances DB load
+// (cache hit on every chat turn) against staleness on admin status changes.
+// Capped to 100 entries; admin set is small in practice (~5-10 salespeople).
+//
+// MCP_ACTING_AS_CACHE_TTL_MS env var overrides for dev/test (e.g. 5000 for
+// quick E2E verification of stale-admin rejection).
+const ACTING_AS_CACHE = new Map();
+const ACTING_AS_CACHE_MAX = 100;
+const ACTING_AS_CACHE_TTL_MS = Number(process.env.MCP_ACTING_AS_CACHE_TTL_MS) || 5 * 60 * 1000;
+
 async function loadModels() {
   // Same glob the main backend uses (src/server.js).
   const modelsFiles = globSync('./src/models/**/*.js');
@@ -72,4 +84,82 @@ function getSystemAdmin() {
   return systemAdmin;
 }
 
-module.exports = { bootstrap, getSystemAdmin };
+/**
+ * Resolve an X-Acting-As admin id into a full Admin doc.
+ *
+ * Returns one of:
+ *   { ok: true, admin }                   admin exists, enabled, !removed
+ *   { ok: false, code: 'VALIDATION', message }  bad format / not ObjectId
+ *   { ok: false, code: 'NOT_FOUND', message }   admin id does not exist
+ *   { ok: false, code: 'PERMISSION', message }  admin removed or disabled
+ *
+ * Throws only on infrastructure errors (mongo down). Callers map to HTTP:
+ *   VALIDATION → 400, PERMISSION → 403, NOT_FOUND → 403 (treat as no-perm
+ *   to avoid admin id enumeration).
+ *
+ * @param {string} adminId  raw value from X-Acting-As header
+ */
+async function resolveActingAdmin(adminId) {
+  if (!adminId || typeof adminId !== 'string') {
+    return { ok: false, code: 'VALIDATION', message: 'X-Acting-As must be a non-empty string' };
+  }
+  const trimmed = adminId.trim();
+  if (!mongoose.isValidObjectId(trimmed)) {
+    return { ok: false, code: 'VALIDATION', message: `X-Acting-As is not a valid ObjectId: ${trimmed}` };
+  }
+
+  const cached = ACTING_AS_CACHE.get(trimmed);
+  if (cached) {
+    if (Date.now() < cached.expiresAt) {
+      return { ok: true, admin: cached.admin };
+    }
+    // Expired — drop and fall through to DB lookup. Lazy eviction means
+    // expired entries that nobody asks about linger until the size cap
+    // evicts them, which is fine.
+    ACTING_AS_CACHE.delete(trimmed);
+  }
+
+  const Admin = mongoose.model('Admin');
+  const admin = await Admin.findById(trimmed).exec();
+  if (!admin) {
+    return { ok: false, code: 'NOT_FOUND', message: `admin not found: ${trimmed}` };
+  }
+  if (admin.removed === true) {
+    return { ok: false, code: 'PERMISSION', message: `admin removed: ${trimmed}` };
+  }
+  if (admin.enabled === false) {
+    return { ok: false, code: 'PERMISSION', message: `admin disabled: ${trimmed}` };
+  }
+
+  if (ACTING_AS_CACHE.size >= ACTING_AS_CACHE_MAX) {
+    // Evict oldest (Map preserves insertion order)
+    const firstKey = ACTING_AS_CACHE.keys().next().value;
+    ACTING_AS_CACHE.delete(firstKey);
+  }
+  ACTING_AS_CACHE.set(trimmed, {
+    admin,
+    expiresAt: Date.now() + ACTING_AS_CACHE_TTL_MS,
+  });
+  return { ok: true, admin };
+}
+
+/**
+ * Drop the acting-as cache. With no arg clears all entries; with an
+ * adminId only that entry. Call after admin update/disable/remove flows.
+ */
+function invalidateActingAsCache(adminId) {
+  if (adminId === undefined) {
+    ACTING_AS_CACHE.clear();
+    return;
+  }
+  ACTING_AS_CACHE.delete(adminId);
+}
+
+module.exports = {
+  bootstrap,
+  getSystemAdmin,
+  resolveActingAdmin,
+  invalidateActingAsCache,
+  // exported for tests that already manage their own mongo connection
+  resolveSystemAdmin,
+};

--- a/backend/src/mcp/context.js
+++ b/backend/src/mcp/context.js
@@ -1,0 +1,60 @@
+// Ola CRM MCP — Per-request context (ISO1, issue #185)
+//
+// The MCP SDK's tool handler signature is async (input) => output — there is
+// no request-scoped context parameter. To pass the resolved acting-as admin
+// from server.js (HTTP handler) down to individual tool handlers, we use
+// Node's AsyncLocalStorage, a standard idiomatic per-request context.
+//
+// Lifecycle:
+//   1. server.js receives POST /mcp
+//   2. server.js parses `X-Acting-As` header → bootstrap.resolveActingAdmin(id)
+//   3. server.js wraps transport.handleRequest in runWithContext({...})
+//   4. Tool handlers (loaded via registry.js) call getCurrentActingAdmin()
+//      to read the resolved admin (or null when no header was sent)
+//
+// System-scope tools (salesperson.*, health.*) treat null as a fallback to
+// systemAdmin (back-compat). Business-scope tools (customer/merch/quote) will
+// reject when null in ISO3.
+
+const { AsyncLocalStorage } = require('async_hooks');
+
+const als = new AsyncLocalStorage();
+
+/**
+ * Run `fn` with the given per-request context.
+ * Called by server.js HTTP handler to wrap transport.handleRequest.
+ *
+ * @param {{ actingAdmin: object|null, isSystemFallback: boolean }} ctx
+ * @param {Function} fn  async function to run inside the context
+ */
+function runWithContext(ctx, fn) {
+  return als.run(ctx, fn);
+}
+
+/**
+ * Read the current request's resolved acting-as admin.
+ * @returns {object|null} Mongoose Admin doc, or null when no header was sent.
+ * @throws when called outside an MCP request scope (programmer error).
+ */
+function getCurrentActingAdmin() {
+  const ctx = als.getStore();
+  if (!ctx) {
+    throw new Error(
+      '[mcp/context] getCurrentActingAdmin called outside MCP request scope — ' +
+        'ensure tool runs via server.js handler, not direct invocation.',
+    );
+  }
+  return ctx.actingAdmin;
+}
+
+/**
+ * Whether the current request fell back to systemAdmin (no X-Acting-As).
+ * Used by tool handlers to decide back-compat vs strict-mode behavior.
+ */
+function isSystemFallback() {
+  const ctx = als.getStore();
+  if (!ctx) return false;
+  return ctx.isSystemFallback === true;
+}
+
+module.exports = { runWithContext, getCurrentActingAdmin, isSystemFallback };

--- a/backend/src/mcp/headerResolver.js
+++ b/backend/src/mcp/headerResolver.js
@@ -1,0 +1,45 @@
+// Ola CRM MCP — X-Acting-As header decision (ISO1 + ISO4, issue #185)
+//
+// Pure helper: takes the raw value of the X-Acting-As HTTP header and decides
+// whether the caller is acting as a specific admin, falling back to the
+// system admin (legacy back-compat for askola web), or rejecting the request.
+//
+// Extracted from server.js into its own module so jest can cover the full
+// decision path without spinning the MCP server / SDK transport.
+
+const { resolveActingAdmin, getSystemAdmin } = require('./bootstrap');
+
+/**
+ * Decide the acting-as admin for an MCP request.
+ *
+ * @param {string|undefined|null} rawHeader  raw X-Acting-As header value
+ * @returns {Promise<
+ *   | { ok: true, actingAdmin: object, isSystemFallback: boolean }
+ *   | { ok: false, status: number, code: string, message: string }
+ * >}
+ */
+async function decideActingAdmin(rawHeader) {
+  if (typeof rawHeader !== 'string' || rawHeader.trim().length === 0) {
+    // Back-compat: askola web flow does not yet inject the header.
+    // Fall back to systemAdmin so existing tools keep working.
+    return {
+      ok: true,
+      actingAdmin: getSystemAdmin(),
+      isSystemFallback: true,
+    };
+  }
+  const result = await resolveActingAdmin(rawHeader.trim());
+  if (!result.ok) {
+    // VALIDATION → 400; NOT_FOUND/PERMISSION → 403 (uniform deny to avoid
+    // admin id enumeration through differing status codes).
+    const status = result.code === 'VALIDATION' ? 400 : 403;
+    return { ok: false, status, code: result.code, message: result.message };
+  }
+  return {
+    ok: true,
+    actingAdmin: result.admin,
+    isSystemFallback: false,
+  };
+}
+
+module.exports = { decideActingAdmin };

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -25,6 +25,8 @@ const {
 const requireAuth = require('./auth');
 const { auditLog, hashInput } = require('./logger');
 const { bootstrap } = require('./bootstrap');
+const { runWithContext } = require('./context');
+const { decideActingAdmin } = require('./headerResolver');
 // NOTE: do NOT require('./tools/registry') at top-level — it transitively
 // requires controllers which call mongoose.model('Client'/...), which
 // throws unless bootstrap() has run first. Lazy-load inside main().
@@ -133,6 +135,22 @@ async function main() {
       });
     };
 
+    // ISO1/3/4 (issue #185): X-Acting-As header → acting-as admin decision.
+    // Pure helper in ./headerResolver.js so jest can cover the full path.
+    const decision = await decideActingAdmin(req.headers['x-acting-as']);
+    if (!decision.ok) {
+      logOnce(false, decision.code, decision.message);
+      if (!res.headersSent) {
+        res.status(decision.status).json({
+          ok: false,
+          code: decision.code,
+          message: decision.message,
+        });
+      }
+      return;
+    }
+    const { actingAdmin, isSystemFallback } = decision;
+
     // Stateless: per-request server + transport，确保每个 HTTP POST 是一个独立完整的 MCP 生命周期
     const server = createMcpServer();
     const transport = new StreamableHTTPServerTransport({
@@ -148,8 +166,13 @@ async function main() {
     });
 
     try {
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
+      // Wrap transport handling in AsyncLocalStorage so tool handlers (loaded
+      // by the SDK during transport.handleRequest) can read the resolved
+      // acting-as admin via getCurrentActingAdmin().
+      await runWithContext({ actingAdmin, isSystemFallback }, async () => {
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+      });
       // transport 把 status 写进 res；handler 走到这里说明协议层没抛，按 res.statusCode 判断结果
       const ok = res.statusCode < 400;
       logOnce(ok, ok ? null : mapStatusToCode(res.statusCode));

--- a/backend/src/mcp/tools/crud/customer.js
+++ b/backend/src/mcp/tools/crud/customer.js
@@ -19,10 +19,6 @@ const { runController } = require('../../adapters/controllerAdapter');
 
 const SEARCH_FIELDS = 'name,email,phone,country';
 
-async function call(method, input) {
-  return runController(method, input);
-}
-
 const search = {
   name: 'customer.search',
   description:
@@ -31,7 +27,7 @@ const search = {
     q: z.string().min(1).describe('Search query — partial match across name/email/phone/country'),
   },
   handler: async ({ q }) => {
-    const res = await call(clientController.search, {
+    const res = await runController(clientController.search, {
       query: { q, fields: SEARCH_FIELDS },
     });
     if (res.ok && Array.isArray(res.data) && res.data.length > 0) {
@@ -55,7 +51,7 @@ const read = {
   inputSchema: {
     id: z.string().min(1).describe('Customer _id'),
   },
-  handler: async ({ id }) => call(clientController.read, { params: { id } }),
+  handler: async ({ id }) => runController(clientController.read, { params: { id } }),
 };
 
 const create = {
@@ -69,7 +65,7 @@ const create = {
     country: z.string().optional(),
     address: z.string().optional(),
   },
-  handler: async (input) => call(clientController.create, { body: input }),
+  handler: async (input) => runController(clientController.create, { body: input }),
 };
 
 const update = {
@@ -85,7 +81,7 @@ const update = {
     address: z.string().optional(),
   },
   handler: async ({ id, ...patch }) =>
-    call(clientController.update, { params: { id }, body: patch }),
+    runController(clientController.update, { params: { id }, body: patch }),
 };
 
 module.exports = { tools: [search, read, create, update] };

--- a/backend/src/mcp/tools/crud/customer.js
+++ b/backend/src/mcp/tools/crud/customer.js
@@ -7,17 +7,20 @@
 // `{ found: false, message: 'No matching customer' }` so the Agent has an explicit
 // signal to ask the user for more details (CLAUDE.md MVP rule).
 //
-// All tools impersonate the cached system admin (see ../../bootstrap.js).
+// ISO3 (issue #185): tools no longer import getSystemAdmin. Per-request
+// acting-as admin is injected by server.js into AsyncLocalStorage context;
+// controllerAdapter.buildReq picks it up automatically. Back-compat for
+// askola web (no X-Acting-As header) is preserved by server.js falling back
+// to systemAdmin in the context — business tools see a valid admin either way.
 
 const { z } = require('zod');
 const clientController = require('@/controllers/appControllers/clientController');
 const { runController } = require('../../adapters/controllerAdapter');
-const { getSystemAdmin } = require('../../bootstrap');
 
 const SEARCH_FIELDS = 'name,email,phone,country';
 
 async function call(method, input) {
-  return runController(method, { ...input, admin: getSystemAdmin() });
+  return runController(method, input);
 }
 
 const search = {

--- a/backend/src/mcp/tools/crud/merch.js
+++ b/backend/src/mcp/tools/crud/merch.js
@@ -13,7 +13,6 @@
 const { z } = require('zod');
 const merchController = require('@/controllers/appControllers/merchController');
 const { runController } = require('../../adapters/controllerAdapter');
-const { getSystemAdmin } = require('../../bootstrap');
 
 // description_cn first so partial match wins for both zh and en inquiries
 const SEARCH_FIELDS = 'serialNumber,description_cn,description_en,serialNumberLong';
@@ -36,7 +35,8 @@ function projectMerch(m) {
 }
 
 async function call(method, input) {
-  return runController(method, { ...input, admin: getSystemAdmin() });
+  // ISO3 (issue #185): admin injected by server.js → context → buildReq.
+  return runController(method, input);
 }
 
 const search = {

--- a/backend/src/mcp/tools/crud/merch.js
+++ b/backend/src/mcp/tools/crud/merch.js
@@ -17,6 +17,9 @@ const { runController } = require('../../adapters/controllerAdapter');
 // description_cn first so partial match wins for both zh and en inquiries
 const SEARCH_FIELDS = 'serialNumber,description_cn,description_en,serialNumberLong';
 
+// PR #193 follow-up: dropped the dead `call()` wrapper. ISO3 made it a
+// no-op around runController since context now provides the admin.
+
 function projectMerch(m) {
   if (!m) return m;
   const o = m.toObject ? m.toObject() : m;
@@ -34,11 +37,6 @@ function projectMerch(m) {
   };
 }
 
-async function call(method, input) {
-  // ISO3 (issue #185): admin injected by server.js → context → buildReq.
-  return runController(method, input);
-}
-
 const search = {
   name: 'merch.search',
   description:
@@ -50,7 +48,7 @@ const search = {
       .describe('Product name or serial number — partial match in EN/CN'),
   },
   handler: async ({ q }) => {
-    const res = await call(merchController.search, {
+    const res = await runController(merchController.search, {
       query: { q, fields: SEARCH_FIELDS },
     });
     if (res.ok && Array.isArray(res.data) && res.data.length > 0) {
@@ -71,7 +69,7 @@ const read = {
   description: 'Read a single merchandise item by id.',
   inputSchema: { id: z.string().min(1).describe('Merch _id') },
   handler: async ({ id }) => {
-    const res = await call(merchController.read, { params: { id } });
+    const res = await runController(merchController.read, { params: { id } });
     if (res.ok && res.data) return { ok: true, data: projectMerch(res.data) };
     return res;
   },
@@ -92,7 +90,7 @@ const create = {
     unit_en: z.string().min(1).describe('English unit, e.g. PCS (required)'),
     unit_cn: z.string().min(1).describe('Chinese unit, e.g. 个 (required)'),
   },
-  handler: async (input) => call(merchController.create, { body: input }),
+  handler: async (input) => runController(merchController.create, { body: input }),
 };
 
 const update = {
@@ -112,7 +110,7 @@ const update = {
     unit_cn: z.string().optional(),
   },
   handler: async ({ id, ...patch }) =>
-    call(merchController.update, { params: { id }, body: patch }),
+    runController(merchController.update, { params: { id }, body: patch }),
 };
 
 module.exports = { tools: [search, read, create, update] };

--- a/backend/src/mcp/tools/crud/quote.js
+++ b/backend/src/mcp/tools/crud/quote.js
@@ -23,7 +23,6 @@ const { z } = require('zod');
 const mongoose = require('mongoose');
 const quoteController = require('@/controllers/appControllers/quoteController');
 const { runController } = require('../../adapters/controllerAdapter');
-const { getSystemAdmin } = require('../../bootstrap');
 
 // Auto-fill `items[].description` from the Merch master record (by
 // serialNumber) so the generated Quote shows meaningful descriptions in
@@ -81,7 +80,8 @@ async function enrichItemDescriptions(items) {
 }
 
 async function call(method, input) {
-  return runController(method, { ...input, admin: getSystemAdmin() });
+  // ISO3 (issue #185): admin injected by server.js → context → buildReq.
+  return runController(method, input);
 }
 
 function pad2(n) { return n < 10 ? `0${n}` : `${n}`; }

--- a/backend/src/mcp/tools/crud/quote.js
+++ b/backend/src/mcp/tools/crud/quote.js
@@ -79,10 +79,8 @@ async function enrichItemDescriptions(items) {
   return { items: enriched, warnings };
 }
 
-async function call(method, input) {
-  // ISO3 (issue #185): admin injected by server.js → context → buildReq.
-  return runController(method, input);
-}
+// PR #193 follow-up: dropped the dead `call()` wrapper. ISO3 made it a
+// no-op around runController since context now provides the admin.
 
 function pad2(n) { return n < 10 ? `0${n}` : `${n}`; }
 
@@ -112,7 +110,7 @@ const search = {
     q: z.string().min(1).describe('Quote number fragment'),
   },
   handler: async ({ q }) => {
-    const res = await call(quoteController.search, { query: { q, fields: 'number' } });
+    const res = await runController(quoteController.search, { query: { q, fields: 'number' } });
     if (res.ok && Array.isArray(res.data) && res.data.length > 0) {
       return { ok: true, data: { found: true, results: res.data } };
     }
@@ -124,7 +122,7 @@ const read = {
   name: 'quote.read',
   description: 'Read a single quote by id (includes items, totals, currency, status).',
   inputSchema: { id: z.string().min(1) },
-  handler: async ({ id }) => call(quoteController.read, { params: { id } }),
+  handler: async ({ id }) => runController(quoteController.read, { params: { id } }),
 };
 
 const create = {
@@ -184,7 +182,7 @@ const create = {
     };
     if (input.exchangeRate !== undefined) body.exchangeRate = input.exchangeRate;
 
-    const result = await call(quoteController.create, { body });
+    const result = await runController(quoteController.create, { body });
     if (result.ok && warnings.length > 0) {
       return { ...result, warnings };
     }
@@ -250,7 +248,7 @@ const update = {
       discount: rest.discount ?? 0,
     };
     if (rest.exchangeRate !== undefined) body.exchangeRate = rest.exchangeRate;
-    const result = await call(quoteController.update, { params: { id }, body });
+    const result = await runController(quoteController.update, { params: { id }, body });
     if (result.ok && warnings.length > 0) {
       return { ...result, warnings };
     }

--- a/backend/test/mcp/iso1.test.js
+++ b/backend/test/mcp/iso1.test.js
@@ -153,17 +153,18 @@ describe('resolveActingAdmin — cache', () => {
   });
 
   test('invalidateActingAsCache() with no arg clears all', async () => {
-    const a = await makeAdmin();
+    const a = await makeAdmin({ email: 'before@example.com' });
     const b = await makeAdmin();
     await resolveActingAdmin(a._id.toString());
     await resolveActingAdmin(b._id.toString());
 
     invalidateActingAsCache();
 
-    // After clear, mutations show up
-    await mongoose.model('Admin').updateOne({ _id: a._id }, { name: 'Updated' });
+    // After clear, mutations to projected fields show up on next resolve.
+    // Cache shape is _id/email/role/enabled/removed (PR #193 follow-up).
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { email: 'after@example.com' });
     const r = await resolveActingAdmin(a._id.toString());
-    expect(r.admin.name).toBe('Updated');
+    expect(r.admin.email).toBe('after@example.com');
   });
 });
 

--- a/backend/test/mcp/iso1.test.js
+++ b/backend/test/mcp/iso1.test.js
@@ -1,0 +1,340 @@
+/**
+ * ISO1 (issue #185) — MCP user-scope isolation building blocks.
+ *
+ * Covers:
+ *  - bootstrap.resolveActingAdmin: validation / not-found / removed / disabled / happy / cache
+ *  - context.runWithContext + getCurrentActingAdmin: per-request propagation
+ *
+ * HTTP-level coverage (X-Acting-As header → 400/403/200) is verified by ISO4
+ * E2E curl scripts; here we test the resolver and context primitives directly.
+ */
+
+const path = require('path');
+const { globSync } = require('glob');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..', '..');
+
+const {
+  resolveActingAdmin,
+  invalidateActingAsCache,
+} = require(path.join(BACKEND_ROOT, 'src/mcp/bootstrap'));
+const {
+  runWithContext,
+  getCurrentActingAdmin,
+  isSystemFallback,
+} = require(path.join(BACKEND_ROOT, 'src/mcp/context'));
+
+let mongo;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f)),
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  invalidateActingAsCache();
+  if (mongoose.models.Admin) {
+    await mongoose.models.Admin.deleteMany({});
+  }
+});
+
+async function makeAdmin(overrides = {}) {
+  return mongoose.model('Admin').create({
+    email: `${Math.random().toString(36).slice(2)}@example.com`,
+    name: 'Test',
+    surname: 'Admin',
+    role: 'admin',
+    enabled: true,
+    removed: false,
+    ...overrides,
+  });
+}
+
+describe('resolveActingAdmin — input validation', () => {
+  test('rejects empty string', async () => {
+    const r = await resolveActingAdmin('');
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('VALIDATION');
+  });
+
+  test('rejects null', async () => {
+    const r = await resolveActingAdmin(null);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('VALIDATION');
+  });
+
+  test('rejects undefined', async () => {
+    const r = await resolveActingAdmin(undefined);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('VALIDATION');
+  });
+
+  test('rejects non-ObjectId string', async () => {
+    const r = await resolveActingAdmin('not-an-objectid');
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('VALIDATION');
+    expect(r.message).toMatch(/not a valid ObjectId/);
+  });
+
+  test('rejects number input', async () => {
+    const r = await resolveActingAdmin(12345);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('VALIDATION');
+  });
+});
+
+describe('resolveActingAdmin — admin lookup', () => {
+  test('not found → NOT_FOUND', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const r = await resolveActingAdmin(fakeId);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('NOT_FOUND');
+  });
+
+  test('removed admin → PERMISSION', async () => {
+    const a = await makeAdmin({ removed: true });
+    const r = await resolveActingAdmin(a._id.toString());
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('PERMISSION');
+    expect(r.message).toMatch(/removed/);
+  });
+
+  test('disabled admin → PERMISSION', async () => {
+    const a = await makeAdmin({ enabled: false });
+    const r = await resolveActingAdmin(a._id.toString());
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('PERMISSION');
+    expect(r.message).toMatch(/disabled/);
+  });
+
+  test('valid enabled admin → ok with admin doc', async () => {
+    const a = await makeAdmin({ email: 'happy@example.com' });
+    const r = await resolveActingAdmin(a._id.toString());
+    expect(r.ok).toBe(true);
+    expect(r.admin._id.toString()).toBe(a._id.toString());
+    expect(r.admin.email).toBe('happy@example.com');
+  });
+});
+
+describe('resolveActingAdmin — cache', () => {
+  test('second call hits cache (no DB roundtrip)', async () => {
+    const a = await makeAdmin({ email: 'cached@example.com' });
+    const r1 = await resolveActingAdmin(a._id.toString());
+    expect(r1.ok).toBe(true);
+
+    // Mutate the DB doc — if cache is bypassed, the second call would
+    // see the mutation. Cache hit means we still get the original.
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { email: 'mutated@example.com' });
+
+    const r2 = await resolveActingAdmin(a._id.toString());
+    expect(r2.ok).toBe(true);
+    expect(r2.admin.email).toBe('cached@example.com'); // stale = cache hit
+  });
+
+  test('invalidateActingAsCache(id) drops one entry', async () => {
+    const a = await makeAdmin({ email: 'first@example.com' });
+    await resolveActingAdmin(a._id.toString()); // populate cache
+
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { email: 'second@example.com' });
+    invalidateActingAsCache(a._id.toString());
+
+    const r = await resolveActingAdmin(a._id.toString());
+    expect(r.admin.email).toBe('second@example.com'); // re-fetched
+  });
+
+  test('invalidateActingAsCache() with no arg clears all', async () => {
+    const a = await makeAdmin();
+    const b = await makeAdmin();
+    await resolveActingAdmin(a._id.toString());
+    await resolveActingAdmin(b._id.toString());
+
+    invalidateActingAsCache();
+
+    // After clear, mutations show up
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { name: 'Updated' });
+    const r = await resolveActingAdmin(a._id.toString());
+    expect(r.admin.name).toBe('Updated');
+  });
+});
+
+describe('resolveActingAdmin — cache TTL', () => {
+  // Use surgical Date.now mocking instead of jest.useFakeTimers to keep
+  // mongoose / mongodb-memory-server timers untouched.
+  const realNow = Date.now;
+  let fakeNow = realNow();
+
+  beforeEach(() => {
+    fakeNow = realNow();
+    Date.now = () => fakeNow;
+  });
+  afterEach(() => {
+    Date.now = realNow;
+  });
+
+  function advanceMinutes(n) {
+    fakeNow += n * 60 * 1000;
+  }
+
+  test('cache entry valid within TTL — second call hits cache', async () => {
+    const a = await makeAdmin({ email: 'within-ttl@example.com' });
+    const r1 = await resolveActingAdmin(a._id.toString());
+    expect(r1.ok).toBe(true);
+
+    // Mutate DB — if cache bypassed, second call would see new email
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { email: 'changed@example.com' });
+    advanceMinutes(4); // still within 5min TTL
+
+    const r2 = await resolveActingAdmin(a._id.toString());
+    expect(r2.admin.email).toBe('within-ttl@example.com'); // stale = cache hit
+  });
+
+  test('cache entry expires after TTL — refetches from DB', async () => {
+    const a = await makeAdmin({ email: 'expiring@example.com' });
+    await resolveActingAdmin(a._id.toString()); // populate cache
+
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { email: 'fresh@example.com' });
+    advanceMinutes(6); // past 5min TTL
+
+    const r = await resolveActingAdmin(a._id.toString());
+    expect(r.ok).toBe(true);
+    expect(r.admin.email).toBe('fresh@example.com'); // fresh DB read
+  });
+
+  test('admin disabled mid-cache — rejected after TTL expires', async () => {
+    const a = await makeAdmin({ email: 'tobedisabled@example.com' });
+    await resolveActingAdmin(a._id.toString()); // cache enabled=true
+
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { enabled: false });
+
+    // Within TTL: still passes (this is the documented 5min window)
+    advanceMinutes(2);
+    const r1 = await resolveActingAdmin(a._id.toString());
+    expect(r1.ok).toBe(true); // cache hit, stale enabled=true
+
+    // After TTL: rejected
+    advanceMinutes(4); // total 6min
+    const r2 = await resolveActingAdmin(a._id.toString());
+    expect(r2.ok).toBe(false);
+    expect(r2.code).toBe('PERMISSION');
+    expect(r2.message).toMatch(/disabled/);
+  });
+
+  test('admin removed mid-cache — rejected after TTL expires', async () => {
+    const a = await makeAdmin({ email: 'tobedeleted@example.com' });
+    await resolveActingAdmin(a._id.toString());
+
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { removed: true });
+    advanceMinutes(6);
+
+    const r = await resolveActingAdmin(a._id.toString());
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('PERMISSION');
+    expect(r.message).toMatch(/removed/);
+  });
+
+  test('expired entry is lazily evicted from Map', async () => {
+    const a = await makeAdmin();
+    await resolveActingAdmin(a._id.toString());
+    advanceMinutes(6);
+    await resolveActingAdmin(a._id.toString()); // triggers eviction + refetch
+
+    // The post-refetch entry has a fresh expiresAt; advance past again to
+    // confirm the Map doesn't grow unboundedly with stale entries.
+    advanceMinutes(6);
+    await resolveActingAdmin(a._id.toString());
+    // No assertion on map size needed; behaviour is "not crashing, returns ok".
+  });
+
+  test('boundary: exactly at expiresAt is treated as expired', async () => {
+    const a = await makeAdmin({ email: 'boundary@example.com' });
+    await resolveActingAdmin(a._id.toString());
+
+    await mongoose.model('Admin').updateOne({ _id: a._id }, { email: 'after-boundary@example.com' });
+    // The TTL is 5min by default; advance EXACTLY 5min — Date.now() ===
+    // expiresAt. Strict-less-than logic in the cache should treat this as
+    // expired (boundary belongs to the "expired" side).
+    advanceMinutes(5);
+
+    const r = await resolveActingAdmin(a._id.toString());
+    expect(r.admin.email).toBe('after-boundary@example.com'); // refetched
+  });
+});
+
+describe('context — AsyncLocalStorage', () => {
+  test('getCurrentActingAdmin throws outside scope', () => {
+    expect(() => getCurrentActingAdmin()).toThrow(/outside MCP request scope/);
+  });
+
+  test('isSystemFallback returns false outside scope', () => {
+    expect(isSystemFallback()).toBe(false);
+  });
+
+  test('inside runWithContext sees the admin', async () => {
+    const fakeAdmin = { _id: new mongoose.Types.ObjectId(), email: 'ctx@example.com' };
+    const seen = await runWithContext(
+      { actingAdmin: fakeAdmin, isSystemFallback: false },
+      async () => {
+        return {
+          admin: getCurrentActingAdmin(),
+          fallback: isSystemFallback(),
+        };
+      },
+    );
+    expect(seen.admin._id.toString()).toBe(fakeAdmin._id.toString());
+    expect(seen.fallback).toBe(false);
+  });
+
+  test('null actingAdmin (system fallback) propagates correctly', async () => {
+    const seen = await runWithContext(
+      { actingAdmin: null, isSystemFallback: true },
+      async () => ({
+        admin: getCurrentActingAdmin(),
+        fallback: isSystemFallback(),
+      }),
+    );
+    expect(seen.admin).toBeNull();
+    expect(seen.fallback).toBe(true);
+  });
+
+  test('nested runWithContext — inner scope wins', async () => {
+    const outer = { _id: new mongoose.Types.ObjectId(), email: 'outer@example.com' };
+    const inner = { _id: new mongoose.Types.ObjectId(), email: 'inner@example.com' };
+
+    const result = await runWithContext(
+      { actingAdmin: outer, isSystemFallback: false },
+      async () => {
+        return runWithContext(
+          { actingAdmin: inner, isSystemFallback: false },
+          async () => getCurrentActingAdmin(),
+        );
+      },
+    );
+    expect(result.email).toBe('inner@example.com');
+  });
+
+  test('parallel async inside runWithContext both see admin', async () => {
+    const fakeAdmin = { _id: new mongoose.Types.ObjectId(), email: 'parallel@example.com' };
+    const result = await runWithContext(
+      { actingAdmin: fakeAdmin, isSystemFallback: false },
+      async () => {
+        const [a, b] = await Promise.all([
+          Promise.resolve().then(() => getCurrentActingAdmin()),
+          Promise.resolve().then(() => getCurrentActingAdmin()),
+        ]);
+        return { a, b };
+      },
+    );
+    expect(result.a.email).toBe('parallel@example.com');
+    expect(result.b.email).toBe('parallel@example.com');
+  });
+});

--- a/backend/test/mcp/iso2.test.js
+++ b/backend/test/mcp/iso2.test.js
@@ -1,0 +1,85 @@
+/**
+ * ISO2 (issue #185) — controllerAdapter buildReq picks up acting-as admin
+ * from AsyncLocalStorage context when input.admin is omitted.
+ *
+ * Three-tier resolution priority:
+ *   1. input.admin (explicit override — legacy path)
+ *   2. context.actingAdmin (server.js per-request injection)
+ *   3. null (controller will likely 401/500; ISO3 surfaces this as PERMISSION)
+ */
+
+const path = require('path');
+const mongoose = require('mongoose');
+
+const BACKEND_ROOT = path.join(__dirname, '..', '..');
+
+const { buildReq } = require(path.join(BACKEND_ROOT, 'src/mcp/adapters/controllerAdapter'));
+const { runWithContext } = require(path.join(BACKEND_ROOT, 'src/mcp/context'));
+
+describe('buildReq — admin resolution priority', () => {
+  test('outside any context returns admin: null (no scope)', () => {
+    const req = buildReq({});
+    expect(req.admin).toBeNull();
+  });
+
+  test('explicit input.admin wins over context', async () => {
+    const explicit = { _id: new mongoose.Types.ObjectId(), email: 'explicit@example.com' };
+    const ctxAdmin = { _id: new mongoose.Types.ObjectId(), email: 'ctx@example.com' };
+
+    const req = await runWithContext(
+      { actingAdmin: ctxAdmin, isSystemFallback: false },
+      async () => buildReq({ admin: explicit }),
+    );
+
+    expect(req.admin.email).toBe('explicit@example.com');
+  });
+
+  test('omitted input.admin falls back to context', async () => {
+    const ctxAdmin = { _id: new mongoose.Types.ObjectId(), email: 'ctx@example.com' };
+
+    const req = await runWithContext(
+      { actingAdmin: ctxAdmin, isSystemFallback: false },
+      async () => buildReq({ body: { name: 'foo' } }),
+    );
+
+    expect(req.admin.email).toBe('ctx@example.com');
+    expect(req.body).toEqual({ name: 'foo' });
+  });
+
+  test('context.actingAdmin null (system fallback) propagates as null', async () => {
+    const req = await runWithContext(
+      { actingAdmin: null, isSystemFallback: true },
+      async () => buildReq({}),
+    );
+    expect(req.admin).toBeNull();
+  });
+
+  test('input.admin null does NOT override context (only undefined/null skipped)', async () => {
+    // Subtle behavior: input.admin === null is treated as "not provided"
+    // because the legacy contract was `input.admin || null` — passing null
+    // explicitly is indistinguishable from passing nothing. ISO3 tools should
+    // not pass null deliberately.
+    const ctxAdmin = { _id: new mongoose.Types.ObjectId(), email: 'ctx@example.com' };
+
+    const req = await runWithContext(
+      { actingAdmin: ctxAdmin, isSystemFallback: false },
+      async () => buildReq({ admin: null }),
+    );
+    expect(req.admin.email).toBe('ctx@example.com');
+  });
+
+  test('builds full req shape with body/params/query/headers', () => {
+    const req = buildReq({
+      body: { a: 1 },
+      params: { id: 'abc' },
+      query: { q: 'foo' },
+      headers: { 'x-test': '1' },
+    });
+    expect(req.body).toEqual({ a: 1 });
+    expect(req.params).toEqual({ id: 'abc' });
+    expect(req.query).toEqual({ q: 'foo' });
+    expect(req.headers).toEqual({ 'x-test': '1' });
+    expect(req.method).toBe('POST');
+    expect(req.originalUrl).toBe('/mcp/internal');
+  });
+});

--- a/backend/test/mcp/iso3.test.js
+++ b/backend/test/mcp/iso3.test.js
@@ -1,0 +1,160 @@
+/**
+ * ISO3 (issue #185) — business tool integration: context → buildReq → controller
+ * → mongoose query MUST filter by acting-as admin._id (not systemAdmin).
+ *
+ * Real-stack test: MongoMemoryServer + actual Admin/Client models + real
+ * customer tool handler. Proves the full propagation chain.
+ */
+
+const path = require('path');
+const { globSync } = require('glob');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..', '..');
+
+const { runWithContext } = require(path.join(BACKEND_ROOT, 'src/mcp/context'));
+
+// customerTools is loaded inside beforeAll AFTER models are registered —
+// requiring the tool triggers clientController which references models like
+// Invoice that need to be loaded first.
+let customerTools;
+let mongo;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f)),
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  // Now models are loaded — safe to require the tool.
+  // eslint-disable-next-line global-require
+  customerTools = require(path.join(BACKEND_ROOT, 'src/mcp/tools/crud/customer'));
+}, 120000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.model('Admin').deleteMany({});
+  await mongoose.model('Client').deleteMany({});
+});
+
+async function makeAdmin(email) {
+  return mongoose.model('Admin').create({
+    email,
+    name: email.split('@')[0],
+    surname: 'X',
+    role: 'admin',
+    enabled: true,
+    removed: false,
+  });
+}
+
+async function makeClient(name, createdBy) {
+  return mongoose.model('Client').create({
+    name,
+    country: 'CN',
+    createdBy,
+    enabled: true,
+    removed: false,
+  });
+}
+
+function findTool(name) {
+  return customerTools.tools.find((t) => t.name === name);
+}
+
+describe('ISO3 — business tool isolates by acting-as admin', () => {
+  test('customer.search inside runWithContext(adminA) sees only A creations', async () => {
+    const adminA = await makeAdmin('a@example.com');
+    const adminB = await makeAdmin('b@example.com');
+    await makeClient('Acme Corp', adminA._id);
+    await makeClient('Beta Inc', adminB._id);
+
+    const search = findTool('customer.search');
+    const result = await runWithContext(
+      { actingAdmin: adminA, isSystemFallback: false },
+      async () => search.handler({ q: 'corp' }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.data.found).toBe(true);
+    const names = result.data.results.map((c) => c.name);
+    expect(names).toContain('Acme Corp');
+    expect(names).not.toContain('Beta Inc');
+  });
+
+  test('customer.search inside runWithContext(adminB) sees only B creations', async () => {
+    const adminA = await makeAdmin('a@example.com');
+    const adminB = await makeAdmin('b@example.com');
+    await makeClient('Acme Corp', adminA._id);
+    await makeClient('Beta Inc', adminB._id);
+
+    const search = findTool('customer.search');
+    const result = await runWithContext(
+      { actingAdmin: adminB, isSystemFallback: false },
+      async () => search.handler({ q: 'inc' }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.data.found).toBe(true);
+    const names = result.data.results.map((c) => c.name);
+    expect(names).toContain('Beta Inc');
+    expect(names).not.toContain('Acme Corp');
+  });
+
+  test('cross-tenant: A searches for B-owned name → not found', async () => {
+    const adminA = await makeAdmin('a@example.com');
+    const adminB = await makeAdmin('b@example.com');
+    await makeClient('Beta Inc', adminB._id); // only B creates
+
+    const search = findTool('customer.search');
+    const result = await runWithContext(
+      { actingAdmin: adminA, isSystemFallback: false },
+      async () => search.handler({ q: 'beta' }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.data.found).toBe(false);
+    expect(result.data.message).toMatch(/No matching customer/);
+  });
+
+  test('customer.create writes createdBy = acting-as admin (not systemAdmin)', async () => {
+    const adminA = await makeAdmin('a@example.com');
+
+    const create = findTool('customer.create');
+    const result = await runWithContext(
+      { actingAdmin: adminA, isSystemFallback: false },
+      async () => create.handler({ name: 'New Customer', country: 'US' }),
+    );
+
+    expect(result.ok).toBe(true);
+    // Verify by direct DB read that createdBy === adminA._id
+    const created = await mongoose
+      .model('Client')
+      .findOne({ name: 'New Customer' })
+      .lean();
+    expect(created).toBeTruthy();
+    expect(created.createdBy.toString()).toBe(adminA._id.toString());
+  });
+
+  test('back-compat: systemFallback context (passes a sysAdmin) still works', async () => {
+    // Mirrors server.js fallback path: askola web flow with no X-Acting-As
+    // header still injects systemAdmin into context.actingAdmin.
+    const sysAdmin = await makeAdmin('sys@example.com');
+    await makeClient('Sys Corp', sysAdmin._id);
+
+    const search = findTool('customer.search');
+    const result = await runWithContext(
+      { actingAdmin: sysAdmin, isSystemFallback: true },
+      async () => search.handler({ q: 'sys' }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.data.found).toBe(true);
+    expect(result.data.results[0].name).toBe('Sys Corp');
+  });
+});

--- a/backend/test/mcp/iso4.test.js
+++ b/backend/test/mcp/iso4.test.js
@@ -53,9 +53,9 @@ async function makeAdmin(overrides = {}) {
     email: `${Math.random().toString(36).slice(2)}@example.com`,
     name: 'T',
     surname: 'A',
-    role: overrides.role || 'admin',
-    enabled: overrides.enabled ?? true,
-    removed: overrides.removed ?? false,
+    role: 'admin',
+    enabled: true,
+    removed: false,
     ...overrides,
   });
 }

--- a/backend/test/mcp/iso4.test.js
+++ b/backend/test/mcp/iso4.test.js
@@ -1,0 +1,151 @@
+/**
+ * ISO4 (issue #185) — HTTP-layer X-Acting-As header decision E2E.
+ *
+ * Covers the `decideActingAdmin` helper end-to-end with real Mongo +
+ * registered Admin docs. This is what server.js calls per request before
+ * wrapping transport.handleRequest in runWithContext.
+ *
+ * Status mapping verified:
+ *   missing/empty header   → 200 path, isSystemFallback=true, actingAdmin=systemAdmin
+ *   non-ObjectId           → 400 VALIDATION
+ *   unknown ObjectId       → 403 NOT_FOUND
+ *   removed/disabled admin → 403 PERMISSION
+ *   valid enabled admin    → 200 path, isSystemFallback=false, actingAdmin=that admin
+ */
+
+const path = require('path');
+const { globSync } = require('glob');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..', '..');
+
+const {
+  resolveSystemAdmin,
+  invalidateActingAsCache,
+} = require(path.join(BACKEND_ROOT, 'src/mcp/bootstrap'));
+const {
+  decideActingAdmin,
+} = require(path.join(BACKEND_ROOT, 'src/mcp/headerResolver'));
+
+let mongo;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f)),
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  invalidateActingAsCache();
+  await mongoose.model('Admin').deleteMany({});
+});
+
+async function makeAdmin(overrides = {}) {
+  return mongoose.model('Admin').create({
+    email: `${Math.random().toString(36).slice(2)}@example.com`,
+    name: 'T',
+    surname: 'A',
+    role: overrides.role || 'admin',
+    enabled: overrides.enabled ?? true,
+    removed: overrides.removed ?? false,
+    ...overrides,
+  });
+}
+
+async function bootstrapWithSystemAdmin() {
+  // Mongo is already connected by beforeAll via MongoMemoryServer; we only
+  // need to seed an owner Admin and prime the systemAdmin cache.
+  await mongoose.model('Admin').create({
+    email: 'sys@example.com',
+    name: 'Sys',
+    surname: 'Admin',
+    role: 'owner',
+    enabled: true,
+    removed: false,
+  });
+  await resolveSystemAdmin();
+}
+
+describe('decideActingAdmin — header decision E2E', () => {
+  test('missing header → fallback to systemAdmin', async () => {
+    await bootstrapWithSystemAdmin();
+    const d = await decideActingAdmin(undefined);
+    expect(d.ok).toBe(true);
+    expect(d.isSystemFallback).toBe(true);
+    expect(d.actingAdmin.email).toBe('sys@example.com');
+  });
+
+  test('empty string header → fallback to systemAdmin', async () => {
+    await bootstrapWithSystemAdmin();
+    const d = await decideActingAdmin('');
+    expect(d.ok).toBe(true);
+    expect(d.isSystemFallback).toBe(true);
+  });
+
+  test('whitespace-only header → fallback to systemAdmin', async () => {
+    await bootstrapWithSystemAdmin();
+    const d = await decideActingAdmin('   ');
+    expect(d.ok).toBe(true);
+    expect(d.isSystemFallback).toBe(true);
+  });
+
+  test('non-ObjectId header → 400 VALIDATION', async () => {
+    await bootstrapWithSystemAdmin();
+    const d = await decideActingAdmin('not-a-valid-id');
+    expect(d.ok).toBe(false);
+    expect(d.status).toBe(400);
+    expect(d.code).toBe('VALIDATION');
+  });
+
+  test('unknown ObjectId → 403 NOT_FOUND', async () => {
+    await bootstrapWithSystemAdmin();
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const d = await decideActingAdmin(fakeId);
+    expect(d.ok).toBe(false);
+    expect(d.status).toBe(403);
+    expect(d.code).toBe('NOT_FOUND');
+  });
+
+  test('removed admin → 403 PERMISSION', async () => {
+    await bootstrapWithSystemAdmin();
+    const a = await makeAdmin({ email: 'gone@example.com', removed: true });
+    const d = await decideActingAdmin(a._id.toString());
+    expect(d.ok).toBe(false);
+    expect(d.status).toBe(403);
+    expect(d.code).toBe('PERMISSION');
+  });
+
+  test('disabled admin → 403 PERMISSION', async () => {
+    await bootstrapWithSystemAdmin();
+    const a = await makeAdmin({ email: 'off@example.com', enabled: false });
+    const d = await decideActingAdmin(a._id.toString());
+    expect(d.ok).toBe(false);
+    expect(d.status).toBe(403);
+    expect(d.code).toBe('PERMISSION');
+  });
+
+  test('valid enabled admin → returns admin, not fallback', async () => {
+    await bootstrapWithSystemAdmin();
+    const a = await makeAdmin({ email: 'sales@example.com' });
+    const d = await decideActingAdmin(a._id.toString());
+    expect(d.ok).toBe(true);
+    expect(d.isSystemFallback).toBe(false);
+    expect(d.actingAdmin.email).toBe('sales@example.com');
+  });
+
+  test('header value with surrounding whitespace → trimmed and resolved', async () => {
+    await bootstrapWithSystemAdmin();
+    const a = await makeAdmin({ email: 'trimmed@example.com' });
+    const d = await decideActingAdmin(`  ${a._id.toString()}  `);
+    expect(d.ok).toBe(true);
+    expect(d.actingAdmin.email).toBe('trimmed@example.com');
+  });
+});

--- a/backend/test/olaController.chat.test.js
+++ b/backend/test/olaController.chat.test.js
@@ -428,4 +428,47 @@ describe('chat — upstream error handling', () => {
     expect(frames.find((f) => f.event === 'text_token' && f.data.delta === 'survived')).toBeTruthy();
     expect(frames.find((f) => f.event === 'done')).toBeTruthy();
   });
+
+  // =========================================================================
+  // ISO5c (issue #185) — X-Ola-Acting-As header propagated to NanoBot
+  // =========================================================================
+
+  test('passes req.admin._id as X-Ola-Acting-As header to NanoBot', async () => {
+    let capturedHeader;
+    nanoBotResponder = (req, res) => {
+      capturedHeader = req.headers['x-ola-acting-as'];
+      startSSE(res);
+      res.write(nanoTextChunk('ok'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    expect(res.status).toBe(200);
+    expect(capturedHeader).toBe(adminId.toString());
+  });
+
+  test('different admin._id → different X-Ola-Acting-As header', async () => {
+    let capturedHeader;
+    nanoBotResponder = (req, res) => {
+      capturedHeader = req.headers['x-ola-acting-as'];
+      startSSE(res);
+      res.write(nanoTextChunk('ok'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const otherAdminId = new mongoose.Types.ObjectId();
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.admin = { _id: otherAdminId };
+      next();
+    });
+    const chat = require(path.join(BACKEND_ROOT, 'src/controllers/appControllers/olaController/chat.js'));
+    app.post('/api/ola/chat', (req, res) => chat(req, res));
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    expect(res.status).toBe(200);
+    expect(capturedHeader).toBe(otherAdminId.toString());
+    expect(capturedHeader).not.toBe(adminId.toString());
+  });
 });


### PR DESCRIPTION
## Summary

修复 MCP server 的 user-scope isolation 漏洞 — 之前所有 MCP 调用都注入缓存的 systemAdmin (admin@admin.com)，导致多 admin 场景下 askola 无法做用户隔离（任何登录用户聊天看到的都是 systemAdmin 的数据）。

行业 SaaS 标准方案：service token + 用户 context header (参考 Stripe-Account / GitHub Apps installation token)。Channel adapter 在系统层注入 `X-Acting-As`，agent 完全不感知。

## Changes

**MCP server (backend/src/mcp/)**
- `context.js` (new) — AsyncLocalStorage per-request context for acting-as admin
- `headerResolver.js` (new) — `decideActingAdmin` helper, extracted for testability
- `bootstrap.js` — `resolveActingAdmin(adminId)` with 5min TTL cache (env-overridable via `MCP_ACTING_AS_CACHE_TTL_MS`); export `resolveSystemAdmin` for tests
- `server.js` — parse `X-Acting-As` header → `runWithContext` wrap around `transport.handleRequest`
- `adapters/controllerAdapter.js` — `buildReq` three-tier admin resolution (input.admin > context > null)
- `tools/crud/{customer,merch,quote}.js` — drop `getSystemAdmin()` injection; rely on context

**askola web wiring (backend/src/controllers/appControllers/olaController/chat.js)**
- Add `X-Ola-Acting-As: <admin._id>` header on the proxy request to nanobot. Nanobot's MCP HTTP client picks it up via the per-call event hook (companion change in [Ola_bot ola-dev](https://github.com/SeekMi-Technologies/Ola_bot/tree/ola-dev), commit pending).

**Tests (backend/test/mcp/)**
- `iso1.test.js` (24 cases) — resolveActingAdmin validation/lookup/cache/TTL/AsyncLocalStorage
- `iso2.test.js` (6 cases) — buildReq admin priority resolution
- `iso3.test.js` (5 cases) — real-stack cross-tenant isolation E2E (admin A creates customer → admin B can't see it)
- `iso4.test.js` (9 cases) — `decideActingAdmin` header decision E2E with real Mongo
- `olaController.chat.test.js` (+2 cases) — X-Ola-Acting-As header propagation

**Real-stack regression**: 96/96 backend jest green; 28/28 nanobot pytest (companion); zyd E2E verified askola with `zhangyuandongnb@gmail.com` no longer surfaces admin@admin.com data.

## Design notes

- **Back-compat preserved**: missing X-Acting-As header → fallback to systemAdmin. Keeps existing direct-curl tooling working. Future strict mode tracked in #192.
- **Cache TTL = 5min** with env override. Admin disable/remove takes effect within the window without MCP restart. Inline justification + boundary tests in iso1.test.js.
- **System tools** (`salesperson.lookup_by_email`, `health.*`) remain unscoped (no acting-as required) — they're the chicken-and-egg primitives needed BEFORE acting-as can be resolved (used by EM5 email channel).

## Test plan

- [x] `cd backend && npx jest` → 9 suites / 96 tests green
- [x] `cd ../nanobot && .venv/bin/python -m pytest tests/agent/test_mcp_acting_as.py tests/test_api_acting_as.py -v` → 28 green (companion repo)
- [x] Real E2E: zyd logged in as `zhangyuandongnb@gmail.com` and asked "看一下我的全部客户" → "没有找到任何客户记录" (was previously leaking admin@admin.com data)
- [x] Affirmative E2E: created a customer, queried again → only that customer visible

## Companion change

Nanobot side (per-call X-Acting-As injection via httpx event_hooks + ContextVar) ships separately to [Ola_bot ola-dev](https://github.com/SeekMi-Technologies/Ola_bot/tree/ola-dev). Both must be deployed together for the askola path to use the new header.

## Follow-ups (not in this PR)

- #192 cleanup admin@admin.com placeholder (P3, deferred)
- Strict-mode flag `MCP_REQUIRE_ACTING_AS=true` to close fallback path entirely once all channels are wired (open after EM5 email channel lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)