### PR TITLE
fix(askola): widget rendering for quote.read/update/search + quote.update PATCH semantics

### DIFF
--- a/backend/src/controllers/appControllers/olaController/thinkingLabels.js
+++ b/backend/src/controllers/appControllers/olaController/thinkingLabels.js
@@ -32,10 +32,14 @@ const TOOL_LABELS = {
   'merch.update':    'Ola is updating product info...',
 
   // Quote
-  'quote.search':    'Ola is searching quotes...',
-  'quote.read':      'Ola is loading quote...',
-  'quote.create':    'Ola is drafting your quote...',
-  'quote.update':    'Ola is updating quote...',
+  'quote.search':           'Ola is searching quotes...',
+  'quote.read':             'Ola is loading quote...',
+  'quote.create':           'Ola is drafting your quote...',
+  'quote.update':           'Ola is updating quote...',
+  'quote.generate_pdf_url': 'Ola is preparing the PDF link...',
+
+  // Salesperson (system-scope; mainly invoked by email channel)
+  'salesperson.lookup_by_email': 'Ola is identifying the salesperson...',
 };
 
 // Tools that should NOT surface a thinking step to the end user.

--- a/backend/src/controllers/appControllers/olaController/toolResultToBlocks.js
+++ b/backend/src/controllers/appControllers/olaController/toolResultToBlocks.js
@@ -72,8 +72,38 @@ function quoteCreateToBlocks(quote) {
   ];
 }
 
+// quote.search returns {found, results[]} envelope (see mcp/tools/crud/quote.js).
+// Renders a lightweight list (no per-row PDF) — user picks one, agent then
+// calls quote.read which routes through quoteCreateToBlocks for full preview.
+function quoteSearchToBlocks(data) {
+  if (!data || data.found !== true) return [];
+  const results = Array.isArray(data.results) ? data.results : [];
+  if (results.length === 0) return [];
+
+  return [
+    {
+      type: 'widget',
+      widgetType: 'quote_list',
+      data: {
+        results: results.map((q) => ({
+          quoteId: q._id,
+          quoteNumber: q.number || '',
+          client: (q.client && q.client.name) || '-',
+          date: q.date,
+          total: q.total,
+          currency: q.currency || 'USD',
+          status: q.status || 'draft',
+        })),
+      },
+    },
+  ];
+}
+
 const TOOL_BLOCK_PRODUCERS = {
   'quote.create': quoteCreateToBlocks,
+  'quote.read': quoteCreateToBlocks,
+  'quote.update': quoteCreateToBlocks,
+  'quote.search': quoteSearchToBlocks,
 };
 
 function toolEventToBlocks(event) {
@@ -85,11 +115,36 @@ function toolEventToBlocks(event) {
   return producer ? producer(envelope.data) : [];
 }
 
+// Dedupe widget+file blocks within one assistant turn so multi-tool flows
+// (e.g. agent reads then updates the same quote, or searches then reads)
+// don't stack visually identical previews. Strategy: walk blocks in order,
+// remember the LAST index of each (widgetType, quoteId) for widgets and
+// each url for files, then keep only those last occurrences.
+//
+// Search widgets carry no quoteId — they dedupe on widgetType alone, so a
+// repeated quote.search in the same turn keeps the latest list.
+function dedupeBlocks(blocks) {
+  const lastIdx = new Map();
+  const keyOf = (b) => {
+    if (b.type === 'widget') return `widget:${b.widgetType}:${(b.data && b.data.quoteId) || ''}`;
+    if (b.type === 'file') return `file:${b.url}`;
+    return null;
+  };
+  blocks.forEach((b, i) => {
+    const k = keyOf(b);
+    if (k !== null) lastIdx.set(k, i);
+  });
+  return blocks.filter((b, i) => {
+    const k = keyOf(b);
+    return k === null || lastIdx.get(k) === i;
+  });
+}
+
 function toolEventsToBlocks(events) {
   if (!Array.isArray(events)) return [];
   const out = [];
   for (const ev of events) out.push(...toolEventToBlocks(ev));
-  return out;
+  return dedupeBlocks(out);
 }
 
 module.exports = {

--- a/backend/src/mcp/tools/crud/quote.js
+++ b/backend/src/mcp/tools/crud/quote.js
@@ -193,13 +193,13 @@ const create = {
 const update = {
   name: 'quote.update',
   description:
-    'Update a quote by id. Caller must pass the FULL quote body (items, currency, etc) — this is a replace-style update enforced by the controller. The Agent should typically read first, modify, then update.',
+    'Partial update of a quote by id (PATCH semantics). Only the fields you pass are changed; everything else is preserved from the current persisted quote. The Agent does NOT need to re-pass number / date / status / expiredDate / client / currency / items unless they are actually being changed. Items is array-replacement: if you pass items, you pass the FULL new list.',
   inputSchema: {
     id: z.string().min(1),
-    client: z.string().min(1),
-    currency: z.enum(['USD', 'CNY']),
+    client: z.string().min(1).optional(),
+    currency: z.enum(['USD', 'CNY']).optional(),
     exchangeRate: z.number().positive().optional(),
-    items: z.array(ItemShape).min(1),
+    items: z.array(ItemShape).min(1).optional(),
     status: z.string().optional(),
     notes: z.array(z.string()).optional(),
     termsOfDelivery: z.array(z.string()).optional(),
@@ -219,35 +219,78 @@ const update = {
         message: 'quote.update rejects `total` — totals are computed server-side',
       };
     }
-    let items = rest.items.map((it) => ({
-      itemName: it.itemName,
-      description: it.description || '',
-      quantity: it.quantity,
-      price: it.price == null ? 0 : it.price,
-      total: 0,
-      unit_en: it.unit_en || '',
-      unit_cn: it.unit_cn || '',
-    }));
-    const enrichResult = await enrichItemDescriptions(items);
-    items = enrichResult.items;
-    const warnings = enrichResult.warnings;
-    const now = new Date();
+
+    // PATCH: load the persisted quote first, merge only fields the agent
+    // actually passed. Bug history (issue #198): previously this handler used
+    // `||` against fresh defaults (number=defaultQuoteNumber(now), status='draft'…)
+    // so an agent omitting those fields silently got them rewritten.
+    const readRes = await runController(quoteController.read, { params: { id } });
+    if (!readRes.ok) return readRes;
+    const existing = readRes.data;
+
+    let items;
+    let warnings = [];
+    if (rest.items !== undefined) {
+      items = rest.items.map((it) => ({
+        itemName: it.itemName,
+        description: it.description || '',
+        quantity: it.quantity,
+        price: it.price == null ? 0 : it.price,
+        total: 0,
+        unit_en: it.unit_en || '',
+        unit_cn: it.unit_cn || '',
+      }));
+      const enrichResult = await enrichItemDescriptions(items);
+      items = enrichResult.items;
+      warnings = enrichResult.warnings;
+    } else {
+      items = (existing.items || []).map((it) => ({
+        itemName: it.itemName,
+        description: it.description || '',
+        quantity: it.quantity,
+        price: it.price,
+        total: it.total || 0,
+        unit_en: it.unit_en || '',
+        unit_cn: it.unit_cn || '',
+      }));
+    }
+
+    // Quote schema autopopulates `client` — existing.client is the populated
+    // Client doc, not a raw ObjectId. Pull the _id back out for the update.
+    const existingClientId =
+      existing.client && existing.client._id
+        ? String(existing.client._id)
+        : String(existing.client);
+
     const body = {
-      client: rest.client,
-      number: rest.number || defaultQuoteNumber(now),
-      year: rest.year || now.getFullYear(),
-      status: rest.status || 'draft',
-      date: rest.date || now,
-      expiredDate: rest.expiredDate || plusDays(now, 30),
-      currency: rest.currency,
+      client: rest.client !== undefined ? rest.client : existingClientId,
+      number: rest.number !== undefined ? rest.number : existing.number,
+      year: rest.year !== undefined ? rest.year : existing.year,
+      status: rest.status !== undefined ? rest.status : existing.status,
+      date: rest.date !== undefined ? rest.date : existing.date,
+      expiredDate: rest.expiredDate !== undefined ? rest.expiredDate : existing.expiredDate,
+      currency: rest.currency !== undefined ? rest.currency : existing.currency,
       items,
-      notes: rest.notes || [],
-      termsOfDelivery: rest.termsOfDelivery || [],
-      paymentTerms: rest.paymentTerms || [],
-      freight: rest.freight ?? 0,
-      discount: rest.discount ?? 0,
+      notes: rest.notes !== undefined ? rest.notes : (existing.notes || []),
+      termsOfDelivery:
+        rest.termsOfDelivery !== undefined ? rest.termsOfDelivery : (existing.termsOfDelivery || []),
+      paymentTerms:
+        rest.paymentTerms !== undefined ? rest.paymentTerms : (existing.paymentTerms || []),
+      freight: rest.freight !== undefined ? rest.freight : (existing.freight ?? 0),
+      discount: rest.discount !== undefined ? rest.discount : (existing.discount ?? 0),
     };
-    if (rest.exchangeRate !== undefined) body.exchangeRate = rest.exchangeRate;
+
+    // exchangeRate: prefer agent-passed value; else preserve existing only when
+    // currency hasn't changed (otherwise let controller B3 validation re-run
+    // with the right defaults — USD must be 1, CNY must be > 1 explicitly).
+    if (rest.exchangeRate !== undefined) {
+      body.exchangeRate = rest.exchangeRate;
+    } else if (rest.currency === undefined || rest.currency === existing.currency) {
+      if (existing.exchangeRate !== undefined && existing.exchangeRate !== null) {
+        body.exchangeRate = existing.exchangeRate;
+      }
+    }
+
     const result = await runController(quoteController.update, { params: { id }, body });
     if (result.ok && warnings.length > 0) {
       return { ...result, warnings };

--- a/backend/test/quote.update.test.js
+++ b/backend/test/quote.update.test.js
@@ -1,0 +1,372 @@
+/**
+ * Regression test for issue #198 — quote.update MCP tool PATCH semantics.
+ *
+ * Bug history (PR #193): the update handler built a fresh body with
+ * `rest.X || default` fallbacks, so an agent that omitted number/date/
+ * status/expiredDate silently got them rewritten with `now`/`+30d`/'draft'
+ * (e.g. a quote marked `sent` would demote back to `draft`; the quote
+ * number would be replaced by a fresh timestamp).
+ *
+ * Fix: PATCH semantics — handler reads the current persisted quote first,
+ * then merges only the fields the agent actually passed. Tests below cover
+ * both the regression (preservation) and the explicit-update path.
+ */
+
+const path = require('path');
+const { globSync } = require('glob');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+
+const { runWithContext } = require(path.join(BACKEND_ROOT, 'src/mcp/context'));
+
+let quoteTools;
+let mongo;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f)),
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  // eslint-disable-next-line global-require
+  quoteTools = require(path.join(BACKEND_ROOT, 'src/mcp/tools/crud/quote'));
+}, 120000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  for (const name of ['Admin', 'Quote', 'Merch', 'Client']) {
+    if (mongoose.models[name]) {
+      await mongoose.models[name].deleteMany({});
+    }
+  }
+});
+
+function findTool(name) {
+  return quoteTools.tools.find((t) => t.name === name);
+}
+
+async function makeAdmin() {
+  return mongoose.model('Admin').create({
+    email: 'patch-tester@example.com',
+    name: 'Patch',
+    surname: 'Tester',
+    role: 'admin',
+    enabled: true,
+    removed: false,
+  });
+}
+
+async function makeClient(createdBy) {
+  return mongoose.model('Client').create({
+    name: 'Acme Trading',
+    country: 'US',
+    createdBy,
+    enabled: true,
+    removed: false,
+  });
+}
+
+async function seedQuote(admin, client, overrides = {}) {
+  const Quote = mongoose.model('Quote');
+  const baseDate = new Date('2026-01-15T10:00:00Z');
+  const baseExpiry = new Date('2026-02-14T10:00:00Z');
+  return Quote.create({
+    number: 'Q-PRESERVE-ME',
+    year: 2026,
+    status: 'sent',
+    date: baseDate,
+    expiredDate: baseExpiry,
+    client: client._id,
+    createdBy: admin._id,
+    currency: 'USD',
+    exchangeRate: 1,
+    items: [
+      {
+        itemName: 'WIDGET-1',
+        description: 'Stainless widget',
+        quantity: 10,
+        price: 5,
+        total: 50,
+        unit_en: 'PCS',
+        unit_cn: '件',
+      },
+    ],
+    subTotal: 50,
+    total: 50,
+    notes: ['original note'],
+    termsOfDelivery: ['DDP'],
+    paymentTerms: ['net 30'],
+    freight: 0,
+    discount: 0,
+    ...overrides,
+  });
+}
+
+async function callUpdate(admin, payload) {
+  const update = findTool('quote.update');
+  return runWithContext(
+    { actingAdmin: admin, isSystemFallback: false },
+    async () => update.handler(payload),
+  );
+}
+
+describe('quote.update — PATCH semantics (issue #198)', () => {
+  test('omitting number/date/status/expiredDate preserves persisted values', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const quote = await seedQuote(admin, client);
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      items: [
+        {
+          itemName: 'WIDGET-1',
+          quantity: 20, // qty change only — agent wouldn't re-send number/status/etc
+          price: 5,
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+
+    const persisted = await mongoose.model('Quote').findById(quote._id).lean();
+    expect(persisted.number).toBe('Q-PRESERVE-ME');
+    expect(persisted.status).toBe('sent');
+    expect(persisted.date.toISOString()).toBe('2026-01-15T10:00:00.000Z');
+    expect(persisted.expiredDate.toISOString()).toBe('2026-02-14T10:00:00.000Z');
+    // total recomputed from new qty × price (controller authoritative)
+    expect(persisted.total).toBe(100);
+    expect(persisted.items[0].quantity).toBe(20);
+  });
+
+  test('omitting items keeps existing items intact and recomputes the same total', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const quote = await seedQuote(admin, client);
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      status: 'accepted',
+    });
+
+    expect(result.ok).toBe(true);
+
+    const persisted = await mongoose.model('Quote').findById(quote._id).lean();
+    expect(persisted.status).toBe('accepted');
+    expect(persisted.number).toBe('Q-PRESERVE-ME');
+    expect(persisted.items).toHaveLength(1);
+    expect(persisted.items[0].itemName).toBe('WIDGET-1');
+    expect(persisted.items[0].quantity).toBe(10);
+    expect(persisted.items[0].price).toBe(5);
+    expect(persisted.total).toBe(50);
+  });
+
+  test('explicit status update succeeds (does not block legitimate changes)', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const quote = await seedQuote(admin, client, { status: 'draft' });
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      status: 'sent',
+    });
+
+    expect(result.ok).toBe(true);
+    const persisted = await mongoose.model('Quote').findById(quote._id).lean();
+    expect(persisted.status).toBe('sent');
+  });
+
+  test('explicit number update succeeds (caller can rename the quote)', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const quote = await seedQuote(admin, client);
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      number: 'Q-MANUAL-RENAME-001',
+    });
+
+    expect(result.ok).toBe(true);
+    const persisted = await mongoose.model('Quote').findById(quote._id).lean();
+    expect(persisted.number).toBe('Q-MANUAL-RENAME-001');
+  });
+
+  test('non-existent id returns NOT_FOUND (does not silently create)', async () => {
+    const admin = await makeAdmin();
+    const fakeId = new mongoose.Types.ObjectId().toString();
+
+    const result = await callUpdate(admin, {
+      id: fakeId,
+      status: 'sent',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('NOT_FOUND');
+    // Critical: nothing got created as a side effect
+    expect(await mongoose.model('Quote').countDocuments()).toBe(0);
+  });
+
+  test('quote owned by another admin returns NOT_FOUND (acting-as isolation)', async () => {
+    const ownerAdmin = await makeAdmin();
+    const otherAdmin = await mongoose.model('Admin').create({
+      email: 'other@example.com',
+      name: 'Other',
+      surname: 'X',
+      role: 'admin',
+      enabled: true,
+      removed: false,
+    });
+    const client = await makeClient(ownerAdmin._id);
+    const quote = await seedQuote(ownerAdmin, client);
+
+    const result = await callUpdate(otherAdmin, {
+      id: String(quote._id),
+      status: 'declined',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('NOT_FOUND');
+    // Status untouched
+    const persisted = await mongoose.model('Quote').findById(quote._id).lean();
+    expect(persisted.status).toBe('sent');
+  });
+
+  test('passing `total` is rejected (server-computed only)', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const quote = await seedQuote(admin, client);
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      total: 9999,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('VALIDATION');
+    expect(result.message).toMatch(/total/);
+  });
+
+  test('CNY existing quote: omitting exchangeRate preserves the persisted rate', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const Quote = mongoose.model('Quote');
+    const quote = await Quote.create({
+      number: 'Q-CNY-001',
+      year: 2026,
+      status: 'sent',
+      date: new Date('2026-01-15'),
+      expiredDate: new Date('2026-02-14'),
+      client: client._id,
+      createdBy: admin._id,
+      currency: 'CNY',
+      exchangeRate: 7.2,
+      items: [
+        { itemName: 'W-1', quantity: 1, price: 100, total: 100, description: '' },
+      ],
+      subTotal: 100,
+      total: 100,
+    });
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      status: 'accepted',
+    });
+
+    expect(result.ok).toBe(true);
+    const persisted = await Quote.findById(quote._id).lean();
+    expect(persisted.exchangeRate).toBe(7.2);
+    expect(persisted.currency).toBe('CNY');
+  });
+
+  test('changing currency CNY → USD without explicit exchangeRate lets controller normalize to 1', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const Quote = mongoose.model('Quote');
+    const quote = await Quote.create({
+      number: 'Q-FLIP-001',
+      year: 2026,
+      status: 'draft',
+      date: new Date('2026-01-15'),
+      expiredDate: new Date('2026-02-14'),
+      client: client._id,
+      createdBy: admin._id,
+      currency: 'CNY',
+      exchangeRate: 7.2,
+      items: [
+        { itemName: 'W-1', quantity: 1, price: 100, total: 100, description: '' },
+      ],
+      subTotal: 100,
+      total: 100,
+    });
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      currency: 'USD',
+    });
+
+    expect(result.ok).toBe(true);
+    const persisted = await Quote.findById(quote._id).lean();
+    expect(persisted.currency).toBe('USD');
+    expect(persisted.exchangeRate).toBe(1);
+  });
+
+  test('changing currency USD → CNY without exchangeRate is rejected by controller', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const quote = await seedQuote(admin, client); // USD, exchangeRate 1
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      currency: 'CNY',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('VALIDATION');
+    expect(result.message).toMatch(/汇率/);
+    // Persisted record still USD
+    const persisted = await mongoose.model('Quote').findById(quote._id).lean();
+    expect(persisted.currency).toBe('USD');
+  });
+
+  test('item changes recompute total via helpers.calculate (qty × price)', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const quote = await seedQuote(admin, client);
+
+    const result = await callUpdate(admin, {
+      id: String(quote._id),
+      items: [
+        { itemName: 'WIDGET-1', quantity: 7, price: 12.5 },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    const persisted = await mongoose.model('Quote').findById(quote._id).lean();
+    expect(persisted.items[0].quantity).toBe(7);
+    expect(persisted.items[0].price).toBe(12.5);
+    expect(persisted.items[0].total).toBe(87.5);
+    expect(persisted.subTotal).toBe(87.5);
+    expect(persisted.total).toBe(87.5);
+  });
+
+  test('id-only patch is a no-op that still succeeds and preserves everything', async () => {
+    const admin = await makeAdmin();
+    const client = await makeClient(admin._id);
+    const quote = await seedQuote(admin, client);
+
+    const result = await callUpdate(admin, { id: String(quote._id) });
+
+    expect(result.ok).toBe(true);
+    const persisted = await mongoose.model('Quote').findById(quote._id).lean();
+    expect(persisted.number).toBe('Q-PRESERVE-ME');
+    expect(persisted.status).toBe('sent');
+    expect(persisted.total).toBe(50);
+    expect(persisted.items).toHaveLength(1);
+  });
+});

--- a/backend/test/thinkingLabels.test.js
+++ b/backend/test/thinkingLabels.test.js
@@ -13,13 +13,21 @@ const {
 } = require('@/controllers/appControllers/olaController/thinkingLabels');
 
 describe('thinkingLabels — TOOL_LABELS dictionary', () => {
-  test('covers all 12 v1 user-facing MCP tools', () => {
+  test('covers all v1 user-facing MCP tools + forward-looking entries (#170)', () => {
     const expected = [
       'customer.search', 'customer.read', 'customer.create', 'customer.update',
       'merch.search', 'merch.read', 'merch.create', 'merch.update',
       'quote.search', 'quote.read', 'quote.create', 'quote.update',
+      // Forward-looking: tools live on ZYD_FEAT, will activate when merged to dev
+      'quote.generate_pdf_url',
+      'salesperson.lookup_by_email',
     ];
     expect(Object.keys(TOOL_LABELS).sort()).toEqual(expected.sort());
+  });
+
+  test('forward-looking entries resolve to specific labels (not __unknown__ fallback)', () => {
+    expect(labelFor('mcp_ola_crm_quote.generate_pdf_url')).toBe('Ola is preparing the PDF link...');
+    expect(labelFor('mcp_ola_crm_salesperson.lookup_by_email')).toBe('Ola is identifying the salesperson...');
   });
 
   test('does NOT include health.ping (it is in SKIP_TOOLS)', () => {

--- a/backend/test/toolResultToBlocks.test.js
+++ b/backend/test/toolResultToBlocks.test.js
@@ -1,0 +1,225 @@
+// Tests for toolResultToBlocks.js — NanoBot tool_event → askola block
+// dispatcher (Issue #170 真修).
+//
+// quote.create / quote.read / quote.update — full preview widget + PDF block
+// quote.search — lightweight quote_list widget (no PDF; user expansion routes
+//   through quote.read for full detail)
+
+const {
+  toolEventToBlocks,
+  toolEventsToBlocks,
+  TOOL_BLOCK_PRODUCERS,
+} = require('@/controllers/appControllers/olaController/toolResultToBlocks');
+
+function makeEvent(toolName, data) {
+  return {
+    name: `mcp_ola_crm_${toolName}`,
+    phase: 'end',
+    result: JSON.stringify({ ok: true, data }),
+  };
+}
+
+const SAMPLE_QUOTE = {
+  _id: '6650abc1234567890abcdef0',
+  number: '25-001',
+  currency: 'USD',
+  subTotal: 100,
+  total: 110,
+  status: 'draft',
+  date: '2026-05-04T00:00:00.000Z',
+  client: { _id: 'cli1', name: 'Acme Trading' },
+  items: [
+    { itemName: 'WIDGET-1', description: 'Stainless widget', quantity: 10, unit_en: 'PCS', total: 100 },
+  ],
+};
+
+describe('TOOL_BLOCK_PRODUCERS dispatcher map', () => {
+  test('registers all 4 quote tools', () => {
+    expect(Object.keys(TOOL_BLOCK_PRODUCERS).sort()).toEqual([
+      'quote.create',
+      'quote.read',
+      'quote.search',
+      'quote.update',
+    ]);
+  });
+
+  test('quote.create / quote.read / quote.update share the same producer (full preview)', () => {
+    expect(TOOL_BLOCK_PRODUCERS['quote.create']).toBe(TOOL_BLOCK_PRODUCERS['quote.read']);
+    expect(TOOL_BLOCK_PRODUCERS['quote.create']).toBe(TOOL_BLOCK_PRODUCERS['quote.update']);
+  });
+});
+
+describe('quote.create — regression (must not change shape)', () => {
+  test('returns widget(quote_preview) + file(pdf)', () => {
+    const blocks = toolEventToBlocks(makeEvent('quote.create', SAMPLE_QUOTE));
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({
+      type: 'widget',
+      widgetType: 'quote_preview',
+      data: { quoteId: SAMPLE_QUOTE._id, quoteNumber: '25-001', currency: 'USD' },
+    });
+    expect(blocks[1]).toMatchObject({
+      type: 'file',
+      fileType: 'pdf',
+      filename: 'quote-25-001.pdf',
+      url: `/download/quote/quote-${SAMPLE_QUOTE._id}.pdf`,
+    });
+  });
+});
+
+describe('quote.read — full preview (same shape as create)', () => {
+  test('happy path returns widget + file', () => {
+    const blocks = toolEventToBlocks(makeEvent('quote.read', SAMPLE_QUOTE));
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].widgetType).toBe('quote_preview');
+    expect(blocks[1].type).toBe('file');
+  });
+
+  test('missing _id returns []', () => {
+    const blocks = toolEventToBlocks(makeEvent('quote.read', { number: '25-001' }));
+    expect(blocks).toEqual([]);
+  });
+});
+
+describe('quote.update — full preview', () => {
+  test('happy path returns widget + file', () => {
+    const blocks = toolEventToBlocks(makeEvent('quote.update', SAMPLE_QUOTE));
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].widgetType).toBe('quote_preview');
+  });
+});
+
+describe('quote.search — lightweight quote_list widget (no PDF)', () => {
+  test('found:true with N results → 1 widget block, N rows, no PDF', () => {
+    const data = {
+      found: true,
+      results: [
+        { ...SAMPLE_QUOTE, _id: 'q1', number: '25-001', total: 100 },
+        { ...SAMPLE_QUOTE, _id: 'q2', number: '25-023', total: 250.5 },
+        { ...SAMPLE_QUOTE, _id: 'q3', number: '25-123', total: 999 },
+      ],
+    };
+    const blocks = toolEventToBlocks(makeEvent('quote.search', data));
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: 'widget',
+      widgetType: 'quote_list',
+    });
+    expect(blocks[0].data.results).toHaveLength(3);
+    expect(blocks[0].data.results[0]).toMatchObject({
+      quoteId: 'q1',
+      quoteNumber: '25-001',
+      client: 'Acme Trading',
+      currency: 'USD',
+      status: 'draft',
+      total: 100,
+    });
+    // Critical: no `file` block — list view does NOT auto-render PDFs
+    expect(blocks.some((b) => b.type === 'file')).toBe(false);
+  });
+
+  test('found:false → []', () => {
+    const blocks = toolEventToBlocks(
+      makeEvent('quote.search', { found: false, message: 'No matching quote' })
+    );
+    expect(blocks).toEqual([]);
+  });
+
+  test('found:true but empty results → []', () => {
+    const blocks = toolEventToBlocks(makeEvent('quote.search', { found: true, results: [] }));
+    expect(blocks).toEqual([]);
+  });
+
+  test('malformed envelope (results not array) → [] without throwing', () => {
+    expect(() =>
+      toolEventToBlocks(makeEvent('quote.search', { found: true, results: 'oops' }))
+    ).not.toThrow();
+    const blocks = toolEventToBlocks(makeEvent('quote.search', { found: true, results: 'oops' }));
+    expect(blocks).toEqual([]);
+  });
+
+  test('null data → []', () => {
+    const blocks = toolEventToBlocks(makeEvent('quote.search', null));
+    expect(blocks).toEqual([]);
+  });
+
+  test('client unpopulated (no .name) falls back to "-"', () => {
+    const data = {
+      found: true,
+      results: [{ ...SAMPLE_QUOTE, client: 'cli1' }], // raw ObjectId, no autopopulate
+    };
+    const blocks = toolEventToBlocks(makeEvent('quote.search', data));
+    expect(blocks[0].data.results[0].client).toBe('-');
+  });
+});
+
+describe('toolEventsToBlocks — array dispatch', () => {
+  test('mixed events: search + read → list widget + preview widget + pdf', () => {
+    const events = [
+      makeEvent('quote.search', { found: true, results: [SAMPLE_QUOTE] }),
+      makeEvent('quote.read', SAMPLE_QUOTE),
+    ];
+    const blocks = toolEventsToBlocks(events);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].widgetType).toBe('quote_list');
+    expect(blocks[1].widgetType).toBe('quote_preview');
+    expect(blocks[2].type).toBe('file');
+  });
+
+  test('non-array input → []', () => {
+    expect(toolEventsToBlocks(null)).toEqual([]);
+    expect(toolEventsToBlocks('nope')).toEqual([]);
+  });
+});
+
+describe('toolEventsToBlocks — dedupe within one assistant turn', () => {
+  test('read then update on SAME quote_id → keep only the latest preview + pdf (update wins)', () => {
+    const before = { ...SAMPLE_QUOTE, total: 100 };
+    const after = { ...SAMPLE_QUOTE, total: 250 };
+    const blocks = toolEventsToBlocks([
+      makeEvent('quote.read', before),
+      makeEvent('quote.update', after),
+    ]);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].widgetType).toBe('quote_preview');
+    expect(blocks[0].data.total).toBe(250);
+    expect(blocks[1].type).toBe('file');
+  });
+
+  test('two quote.search calls in same turn → keep the latest list only', () => {
+    const blocks = toolEventsToBlocks([
+      makeEvent('quote.search', { found: true, results: [{ ...SAMPLE_QUOTE, _id: 'q1' }] }),
+      makeEvent('quote.search', {
+        found: true,
+        results: [
+          { ...SAMPLE_QUOTE, _id: 'q2' },
+          { ...SAMPLE_QUOTE, _id: 'q3' },
+        ],
+      }),
+    ]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].widgetType).toBe('quote_list');
+    expect(blocks[0].data.results.map((r) => r.quoteId)).toEqual(['q2', 'q3']);
+  });
+
+  test('different quote_ids in same turn → BOTH preserved (intentional, not dedupe target)', () => {
+    const blocks = toolEventsToBlocks([
+      makeEvent('quote.update', { ...SAMPLE_QUOTE, _id: 'qA', number: 'Q-A' }),
+      makeEvent('quote.create', { ...SAMPLE_QUOTE, _id: 'qB', number: 'Q-B' }),
+    ]);
+    expect(blocks.filter((b) => b.type === 'widget')).toHaveLength(2);
+    expect(blocks.filter((b) => b.type === 'file')).toHaveLength(2);
+  });
+
+  test('search → read same quote → list survives + preview wins (different widgetType)', () => {
+    const blocks = toolEventsToBlocks([
+      makeEvent('quote.search', { found: true, results: [SAMPLE_QUOTE] }),
+      makeEvent('quote.read', SAMPLE_QUOTE),
+      makeEvent('quote.read', SAMPLE_QUOTE),  // duplicate read
+    ]);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].widgetType).toBe('quote_list');
+    expect(blocks[1].widgetType).toBe('quote_preview');
+    expect(blocks[2].type).toBe('file');
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "react-redux": "^9.1.0",
         "react-router-dom": "^6.22.0",
         "redux": "^5.0.1",
+        "remark-gfm": "^4.0.1",
         "reselect": "^5.1.0",
         "shortid": "^2.2.16",
         "vite": "^5.1.4"
@@ -283,7 +284,6 @@
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
       "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -662,7 +662,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -711,7 +710,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1678,7 +1676,8 @@
       "resolved": "https://registry.npmmirror.com/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1799,7 +1798,6 @@
       "version": "18.2.41",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.41.tgz",
       "integrity": "sha512-CwOGr/PiLiNBxEBqpJ7fO3kocP/2SSuC9fpH5K7tusrg4xPSRT/193rzolYwQnTN02We/ATXKnb6GqA5w4fRxw==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1811,7 +1809,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
       "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1988,7 +1985,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2055,7 +2051,6 @@
       "version": "5.14.1",
       "resolved": "https://registry.npmjs.org/antd/-/antd-5.14.1.tgz",
       "integrity": "sha512-P0Bwt9NKSZqnEJ0QAyAb13ay34FjOKsz+KEp/ts+feYsynhUxF7/Ay6d1jS6ZcNpcs+JWTlLKO59YFZ3tX07wQ==",
-      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^7.0.2",
         "@ant-design/cssinjs": "^1.18.4",
@@ -2342,7 +2337,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -2840,7 +2834,8 @@
       "resolved": "https://registry.npmmirror.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.588",
@@ -3040,7 +3035,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4376,7 +4370,6 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -4568,6 +4561,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4580,6 +4574,44 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -4600,6 +4632,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4809,6 +4942,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -5549,7 +5803,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5631,6 +5884,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5646,6 +5900,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5658,7 +5913,8 @@
       "resolved": "https://registry.npmmirror.com/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6330,7 +6586,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6342,7 +6597,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -6402,7 +6656,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
       "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.3",
         "use-sync-external-store": "^1.0.0"
@@ -6480,8 +6733,7 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "peer": true
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6532,6 +6784,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmmirror.com/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -6559,6 +6829,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7522,7 +7807,6 @@
       "version": "5.2.11",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
       "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.20.1",
         "postcss": "^8.4.38",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-redux": "^9.1.0",
     "react-router-dom": "^6.22.0",
     "redux": "^5.0.1",
+    "remark-gfm": "^4.0.1",
     "reselect": "^5.1.0",
     "shortid": "^2.2.16",
     "vite": "^5.1.4"

--- a/frontend/src/components/AskOla/__tests__/QuoteListWidget.test.jsx
+++ b/frontend/src/components/AskOla/__tests__/QuoteListWidget.test.jsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+//
+// Tests for QuoteListWidget — the lightweight quote_list widget rendered
+// after quote.search MCP tool calls (Issue #170 真修).
+//
+// Per zyd's UX decision: list view shows summary only; user picks one and
+// agent calls quote.read for the full preview + PDF — so this widget
+// intentionally has NO onClick / no PDF block per row.
+
+import { describe, test, expect, afterEach, beforeAll } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import QuoteListWidget from '../widgets/QuoteListWidget';
+
+// jsdom does not implement matchMedia; AntD Table's responsive observer
+// touches it on mount. Stub before any render runs.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = (query) => ({
+      matches: false,
+      media: query,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+      onchange: null,
+    });
+  }
+});
+
+afterEach(cleanup);
+
+const SAMPLE_RESULTS = [
+  {
+    quoteId: 'q1',
+    quoteNumber: '25-001',
+    client: 'Acme Trading',
+    date: '2026-04-15T00:00:00.000Z',
+    total: 1234.5,
+    currency: 'USD',
+    status: 'draft',
+  },
+  {
+    quoteId: 'q2',
+    quoteNumber: '25-023',
+    client: 'Beijing Steel',
+    date: '2026-04-20T00:00:00.000Z',
+    total: 8888,
+    currency: 'CNY',
+    status: 'sent',
+  },
+  {
+    quoteId: 'q3',
+    quoteNumber: '25-123',
+    client: 'Shanghai Foods',
+    date: '2026-05-01T00:00:00.000Z',
+    total: 500,
+    currency: 'USD',
+    status: 'accepted',
+  },
+];
+
+describe('QuoteListWidget — render', () => {
+  test('renders N rows for N results, header shows count', () => {
+    const { getByText, getAllByText } = render(
+      <QuoteListWidget data={{ results: SAMPLE_RESULTS }} />
+    );
+    expect(getByText('Matching Quotes (3)')).toBeTruthy();
+    expect(getByText('25-001')).toBeTruthy();
+    expect(getByText('25-023')).toBeTruthy();
+    expect(getByText('25-123')).toBeTruthy();
+    // Customer column rendered
+    expect(getByText('Acme Trading')).toBeTruthy();
+    expect(getByText('Beijing Steel')).toBeTruthy();
+    // Status tags rendered (lowercase per Quote schema status enum)
+    expect(getAllByText('draft').length).toBeGreaterThan(0);
+  });
+
+  test('formats money with currency symbol (USD vs CNY)', () => {
+    const { getByText } = render(<QuoteListWidget data={{ results: SAMPLE_RESULTS }} />);
+    expect(getByText('$1234.50')).toBeTruthy();
+    expect(getByText('¥8888.00')).toBeTruthy();
+    expect(getByText('$500.00')).toBeTruthy();
+  });
+
+  test('formats date as YYYY-MM-DD', () => {
+    const { getByText } = render(<QuoteListWidget data={{ results: SAMPLE_RESULTS }} />);
+    expect(getByText('2026-04-15')).toBeTruthy();
+    expect(getByText('2026-04-20')).toBeTruthy();
+    expect(getByText('2026-05-01')).toBeTruthy();
+  });
+});
+
+describe('QuoteListWidget — edge cases', () => {
+  test('empty results array shows header (count 0) and empty table', () => {
+    const { getByText } = render(<QuoteListWidget data={{ results: [] }} />);
+    expect(getByText('Matching Quotes (0)')).toBeTruthy();
+    expect(getByText(/No data/i)).toBeTruthy();  // AntD Table empty placeholder
+  });
+
+  test('null / undefined data does not crash', () => {
+    expect(() => render(<QuoteListWidget data={null} />)).not.toThrow();
+    cleanup();
+    expect(() => render(<QuoteListWidget data={undefined} />)).not.toThrow();
+    cleanup();
+    expect(() => render(<QuoteListWidget data={{}} />)).not.toThrow();
+  });
+
+  test('malformed money values fall back to dash with currency symbol', () => {
+    const bad = [
+      { quoteId: 'qx', quoteNumber: '25-X', client: 'X', date: null, total: null, currency: 'USD', status: 'draft' },
+    ];
+    const { getByText } = render(<QuoteListWidget data={{ results: bad }} />);
+    expect(getByText('$-')).toBeTruthy();
+    expect(getByText('-')).toBeTruthy();  // date fallback
+  });
+});

--- a/frontend/src/components/AskOla/__tests__/TextBlock.test.jsx
+++ b/frontend/src/components/AskOla/__tests__/TextBlock.test.jsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+//
+// Tests for TextBlock — verifies remark-gfm autolinks bare URLs (Issue #170
+// 真修 Q170-4). Without remark-gfm, react-markdown only links explicit
+// markdown [text](url) / <url>; bare URL strings stayed as plain text and
+// the user could not click PDF download links the agent emitted.
+
+import { describe, test, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import TextBlock from '../blocks/TextBlock';
+
+afterEach(cleanup);
+
+describe('TextBlock — assistant mode (markdown)', () => {
+  test('linkifies a bare URL to <a href>', () => {
+    const { container } = render(
+      <TextBlock content="Your PDF is at http://localhost:8888/download/quote/quote-25-001.pdf" />
+    );
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor.getAttribute('href')).toBe('http://localhost:8888/download/quote/quote-25-001.pdf');
+  });
+
+  test('renders explicit [text](url) markdown links unchanged', () => {
+    const { container, getByText } = render(
+      <TextBlock content="Click [here](https://example.com/foo) to download." />
+    );
+    const anchor = container.querySelector('a[href="https://example.com/foo"]');
+    expect(anchor).not.toBeNull();
+    expect(getByText('here')).toBeTruthy();
+  });
+
+  test('linkifies https URL inside a sentence', () => {
+    const { container } = render(
+      <TextBlock content="See https://app.olatech.ai/api/quote/abc/pdf for the file." />
+    );
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor.getAttribute('href')).toBe('https://app.olatech.ai/api/quote/abc/pdf');
+  });
+});
+
+describe('TextBlock — user mode (plain, no markdown)', () => {
+  test('does NOT parse markdown when plain=true', () => {
+    const { container } = render(
+      <TextBlock content="See http://example.com/foo" plain />
+    );
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('http://example.com/foo');
+  });
+});

--- a/frontend/src/components/AskOla/blocks/TextBlock.jsx
+++ b/frontend/src/components/AskOla/blocks/TextBlock.jsx
@@ -1,4 +1,11 @@
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// remark-gfm: linkifies bare URLs (e.g. http://...) so tool-returned URLs
+// render as clickable <a> tags instead of plain text. Without it, only
+// markdown-formatted [text](url) and <url> autolinks become hyperlinks
+// — Gemini's hallucinated markdown URLs were blue, real tool URLs were not.
+const REMARK_PLUGINS = [remarkGfm];
 
 /**
  * Render a text block. For user messages we render plain pre-wrapped text
@@ -17,7 +24,7 @@ export default function TextBlock({ content, plain = false }) {
   }
   return (
     <div className="askola-block-text">
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{content}</ReactMarkdown>
     </div>
   );
 }

--- a/frontend/src/components/AskOla/blocks/WidgetBlock.jsx
+++ b/frontend/src/components/AskOla/blocks/WidgetBlock.jsx
@@ -1,10 +1,12 @@
 import MerchMatchWidget from '../widgets/MerchMatchWidget';
 import QuoteDraftWidget from '../widgets/QuoteDraftWidget';
+import QuoteListWidget from '../widgets/QuoteListWidget';
 import QuotePreviewWidget from '../widgets/QuotePreviewWidget';
 
 const WIDGET_MAP = {
   merch_match: MerchMatchWidget,
   quote_draft: QuoteDraftWidget,
+  quote_list: QuoteListWidget,
   quote_preview: QuotePreviewWidget,
 };
 

--- a/frontend/src/components/AskOla/widgets/QuoteListWidget.jsx
+++ b/frontend/src/components/AskOla/widgets/QuoteListWidget.jsx
@@ -1,0 +1,72 @@
+import { Table, Tag } from 'antd';
+import { UnorderedListOutlined } from '@ant-design/icons';
+
+const CURRENCY_SYMBOL = { USD: '$', CNY: '¥' };
+
+const STATUS_COLOR = {
+  draft: 'default',
+  pending: 'orange',
+  sent: 'blue',
+  declined: 'red',
+  accepted: 'green',
+  expired: 'volcano',
+};
+
+function formatMoney(amount, currency) {
+  const symbol = CURRENCY_SYMBOL[currency] ?? (currency || '');
+  if (amount == null || Number.isNaN(Number(amount))) return `${symbol}-`;
+  return `${symbol}${Number(amount).toFixed(2)}`;
+}
+
+function formatDate(value) {
+  if (!value) return '-';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '-';
+  return d.toISOString().slice(0, 10);
+}
+
+export default function QuoteListWidget({ data }) {
+  const results = Array.isArray(data?.results) ? data.results : [];
+
+  const columns = [
+    { title: 'Quote #', dataIndex: 'quoteNumber', key: 'quoteNumber', width: 110 },
+    { title: 'Customer', dataIndex: 'client', key: 'client', ellipsis: true },
+    {
+      title: 'Date',
+      dataIndex: 'date',
+      key: 'date',
+      width: 110,
+      render: (val) => formatDate(val),
+    },
+    {
+      title: 'Total',
+      dataIndex: 'total',
+      key: 'total',
+      width: 110,
+      render: (val, row) => formatMoney(val, row.currency),
+    },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      width: 100,
+      render: (val) => <Tag color={STATUS_COLOR[val] || 'default'}>{val || '-'}</Tag>,
+    },
+  ];
+
+  return (
+    <div className="askola-widget-card">
+      <div className="askola-widget-header">
+        <UnorderedListOutlined style={{ color: '#1890ff' }} />
+        <span>Matching Quotes ({results.length})</span>
+      </div>
+      <Table
+        dataSource={results}
+        columns={columns}
+        rowKey="quoteId"
+        pagination={false}
+        size="small"
+      />
+    </div>
+  );
+}

--- a/ola/nanobot-workspace/SOUL.md
+++ b/ola/nanobot-workspace/SOUL.md
@@ -152,6 +152,25 @@ quote en):
 - The only verbs I use are **review / 检查**, **save / 保存**,
   **edit / 修改**. Never **send / 发送 / 发出 / 发给客户**.
 
+### After quote.read / quote.search / quote.update — defer to the widget
+
+When I call `quote.read`, `quote.search`, or `quote.update`, the salesperson's
+UI **automatically renders the result** as a widget (preview card with line
+items, or a list of matching quotes). My text MUST NOT repeat the widget's
+contents — no enumerating items, no listing financials, no listing each
+matched quote.
+
+My text after these tools is **one sentence confirming the action** (these
+few-shot examples are English; SESSION_LANG=zh will translate them naturally):
+
+> quote.read   → "Loaded Q-2026XXXX."
+> quote.search → "Found N matching quotes."
+> quote.update → "Updated Q-2026XXXX, new total $XX,XXX."
+
+Warnings still print (per the rule above). But no markdown bullets, no
+re-listing items, no re-stating dates / clients / line counts — the widget
+already shows all of that.
+
 ## Lead-to-Quote — canonical flow
 
 1. Salesperson pastes the customer inquiry. I parse out the customer

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -120,6 +120,19 @@ cd "$CRM_DIR/backend"
 npx nodemon --watch src/mcp src/mcp/server.js > /tmp/ola-mcp.log 2>&1 &
 MCP_PID=$!
 
+# Wait for MCP to bind port before later check_port falsely flags FAILED
+echo -n "     Waiting for MCP..."
+for i in $(seq 1 15); do
+  if lsof -ti:8889 >/dev/null 2>&1; then
+    echo -e " ${GREEN}ok${NC}"
+    break
+  fi
+  sleep 1
+  if [ $i -eq 15 ]; then
+    echo -e " ${RED}timeout${NC}"
+  fi
+done
+
 # 3. NanoBot
 if [ -d "$NANOBOT_DIR" ]; then
   echo -e "${GREEN}[4/5] Starting NanoBot (port 8900)...${NC}"


### PR DESCRIPTION
## 改动内容

折两个相关 issue 进同一 PR（zyd 决策 — 在 #170 真修 E2E 中暴露了 #198）。

### #170 — askola UI 渲染一致性

- `TOOL_BLOCK_PRODUCERS` 注册 `quote.read` + `quote.update`（复用 `quoteCreateToBlocks` → 完整预览 widget + PDF block）和 `quote.search`（新 `quoteSearchToBlocks` → 轻量 `quote_list` widget，无 PDF）
- 新 `dedupeBlocks()`：按 `(widgetType, quoteId)` / `url` 去重，解决「同一 turn agent 先 read 后 update 同一 quote → 渲染 2 个相同 preview」
- 新 `QuoteListWidget` (AntD Table — Quote # / Customer / Date / Total / Status Tag)，注册进 `WIDGET_MAP`
- `SOUL.md` 加「After quote.read / search / update — defer to widget」规则
- `TextBlock.jsx` 接 `remark-gfm` → 裸 URL autolink（fix Gemini 偶尔 hallucinate URL 的可视混淆）
- `thinkingLabels.js` 加 `quote.generate_pdf_url` + `salesperson.lookup_by_email` 前瞻条目（ZYD_FEAT 的 email channel batch merge 后激活）

### #198 — quote.update P0 数据完整性

- handler 改为 PATCH 语义：先 `runController(quoteController.read)` 拿当前 quote，再合并 agent 真实传的字段；用 `!== undefined` 取代 `||` 防 falsy 误判
- Zod `inputSchema` 把 `client/currency/items` 也放宽 `optional`（真 PATCH 自洽）
- exchangeRate：currency 不变时保留 existing；currency 翻转时丢给 controller B3 重新校验
- 修前症状：agent「改下 widget qty 到 50」→ quote number 被改成新时间戳、status 从 `sent` 降级回 `draft`、expiredDate 重置 +30d

### 顺手：tooling

- `start-dev.sh`：MCP port 8889 nodemon spin-up race fix，避免 check_port 误报 FAILED

## 验证

- [x] 后端 jest **138/139** 全绿（`sseCompression.test.js` 1 个并发跑时 timeout flake，孤立跑 154ms 全过 — pre-existing）
  - 含新 `quote.update.test.js` **12/12**（PATCH 保留 / 显式更新 / NOT_FOUND / acting-as 隔离 / total reject / currency 翻转 / item recompute）
  - 含新 `toolResultToBlocks.test.js` **22/22**（dispatcher map + dedupe 4 场景）
- [x] 前端 vitest **37/37** 全绿（含 `QuoteListWidget.test.jsx` 6 + `TextBlock.test.jsx` 4 新增）
- [x] `npx vite build` clean (2.85s)
- [x] zyd 手测 askola E2E：read/update 不再创新 quote、widget dedupe 单 preview、quote_list 渲染正确（URL autolink 待 ZYD_FEAT merge 后另测，本 branch 无 `quote.generate_pdf_url` 工具）

## Branch policy 备注

本 PR 走 `ZYD_FIX`（非默认 `ZYD_FEAT`），在 #170 progress comment 已说明：从 `origin/dev @ 7229153` 拉出，规避与 `ZYD_FEAT` 上 4 commits ahead 的 email channel 工作冲突。

Closes #170
Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)