### PR TITLE
Closes #98 — LLMUsage MongoDB collection for per-Ask-Ola-turn token spend telemetry.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,12 @@ task.md
 # Python bytecode cache from scripts/ harnesses
 scripts/__pycache__/
 
+# OpenAI nanobot config (contains ${OPENAI_API_KEY} placeholder — local only)
+ola/nanobot.config.openai.template.json
+
+# Cursor: local fingerprint for scripts/sync-npm-deps.sh --if-changed
+.cursor/.npm-deps-fingerprint
+
 # User-uploaded files — keep seed only
 backend/src/public/uploads/setting/*
 !backend/src/public/uploads/setting/company-logo.png

--- a/backend/src/constants/llmPricing.js
+++ b/backend/src/constants/llmPricing.js
@@ -1,0 +1,76 @@
+// Hardcoded LLM provider pricing table for cost estimation in LLMUsage records
+// (Ola issue #98). Update PRICING_VERSION whenever any number here changes;
+// historical LLMUsage rows snapshot the version that was active when they
+// were written so we never silently re-cost old records.
+//
+// Re-verify quarterly. TODO(ziyue): re-verify pricing 2026-Q3, by 2026-08-01
+//
+// Money math here intentionally bypasses helpers.calculate.* because that
+// helper hard-codes currency.js precision-2 (USD cents) — fine for invoice
+// line items but it truncates token-rate values like $0.25/1M to zero.
+// We use currency.js directly with precision 10 to keep the spirit of the
+// "no native + - * for money" project rule while preserving sub-cent
+// precision needed for token costs.
+
+const currency = require('currency.js');
+
+const COST_PRECISION = 10;
+const cur = (v) => currency(v, { precision: COST_PRECISION });
+
+const PRICING_VERSION = '2026-04-28';
+
+// USD per 1,000,000 tokens. Prices are Standard tier, paid (text input).
+// Source: https://ai.google.dev/gemini-api/docs/pricing (fetched 2026-04-28)
+//
+// `cached` is the context-caching read rate when the provider reports cache
+// hits in usage.cached_tokens. Set to 0 for providers/models without caching
+// — calcCost() will then bill cached tokens at the regular input rate via
+// the (input - cached) split.
+const PRICING = {
+  // The current default Ask Ola model — see ola/nanobot.config.template.json.
+  'gemini:gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.50, cached: 0.025 },
+  'gemini:gemini-2.5-flash':              { input: 0.30, output: 2.50, cached: 0.03 },
+  'gemini:gemini-2.5-flash-lite':         { input: 0.10, output: 0.40, cached: 0.01 },
+
+  // Likely-future-tested models — verify these against the provider's pricing
+  // page before relying on the costUsd they produce. Marked here so an
+  // unexpected provider/model combo at least produces a non-zero estimate
+  // instead of silently falling through to costUsd=0.
+  'openai:gpt-4o-mini':                   { input: 0.15, output: 0.60, cached: 0.075 },
+  'openai:gpt-4o':                        { input: 2.50, output: 10.00, cached: 1.25 },
+  'anthropic:claude-3-5-haiku-latest':    { input: 0.80, output: 4.00, cached: 0.08 },
+  'anthropic:claude-sonnet-4-5':          { input: 3.00, output: 15.00, cached: 0.30 },
+};
+
+// Compute USD cost for one LLM turn given token counts.
+//   provider/model — keys into PRICING via `${provider}:${model}`
+//   inputTokens   — sum of provider-reported prompt_tokens across the turn
+//   outputTokens  — sum of provider-reported completion_tokens across the turn
+//   cachedTokens  — sum of cache-hit input tokens (default 0)
+// Returns Number (USD), 0 when the model is not in PRICING (with a one-shot
+// console.warn so the gap is visible in logs but doesn't blow up the request).
+function calcCost(provider, model, { inputTokens, outputTokens, cachedTokens = 0 }) {
+  const key = `${provider}:${model}`;
+  const p = PRICING[key];
+  if (!p) {
+    console.warn(`[LLMPricing] unknown model ${key}, costUsd=0; add to llmPricing.js`);
+    return 0;
+  }
+  const inTok = Math.max(0, Number(inputTokens) || 0);
+  const outTok = Math.max(0, Number(outputTokens) || 0);
+  const cachedTok = Math.max(0, Math.min(Number(cachedTokens) || 0, inTok));
+  const billableInTok = inTok - cachedTok;
+
+  // perToken rates: dollar / 1M tokens.
+  const perInputToken = cur(p.input).divide(1_000_000);
+  const perOutputToken = cur(p.output).divide(1_000_000);
+  const perCachedToken = cur(p.cached || 0).divide(1_000_000);
+
+  const inCost = perInputToken.multiply(billableInTok);
+  const outCost = perOutputToken.multiply(outTok);
+  const cacheCost = perCachedToken.multiply(cachedTok);
+
+  return inCost.add(outCost).add(cacheCost).value;
+}
+
+module.exports = { PRICING_VERSION, PRICING, calcCost };

--- a/backend/src/controllers/appControllers/llmUsageController/index.js
+++ b/backend/src/controllers/appControllers/llmUsageController/index.js
@@ -1,0 +1,25 @@
+const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
+const recordUsage = require('./recordUsage');
+
+const methods = createCRUDController('LlmUsage');
+
+// LLMUsage records are written exclusively by the system (olaController/chat.js
+// after each Ask Ola turn). Block external mutation through the auto-generated
+// CRUD routes — read-only access is via list/read/summary, which back the
+// admin token dashboard (#99 / future).
+const denyWrite = (req, res) =>
+  res.status(403).json({
+    success: false,
+    result: null,
+    message: 'LLMUsage 写入仅限系统内部',
+  });
+
+methods.create = denyWrite;
+methods.update = denyWrite;
+methods.delete = denyWrite;
+
+// Internal-only function (not a route handler) — exposed on the controller
+// object so olaController can require it without poking at file paths.
+methods.recordUsage = recordUsage;
+
+module.exports = methods;

--- a/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
+++ b/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
@@ -1,27 +1,26 @@
 const mongoose = require('mongoose');
 
-const { calcCost, PRICING_VERSION } = require('@/constants/llmPricing');
+const { calcCost, PRICING, PRICING_VERSION } = require('@/constants/llmPricing');
 
 // Resolved lazily so this module can be required at boot before
 // models/utils/index.js has finished registering all mongoose models.
 const lazyModel = () => mongoose.model('LlmUsage');
 
-// Defaults reflect the current Ask Ola configuration (see
-// ola/nanobot.config.template.json `agents.defaults`). They can be overridden
-// per-request once nanobot starts surfacing per-call provider/model in the
-// usage SSE frame; for now NanoBot uses one model per process so a static
-// default is correct.
-const NANOBOT_PROVIDER = process.env.NANOBOT_PROVIDER || 'gemini';
-const NANOBOT_MODEL = process.env.NANOBOT_MODEL || 'gemini-3.1-flash-lite-preview';
-
 // Persist one LLMUsage document. Always returns a Promise so the caller can
 // `.catch()` if they want, but never throws — internally fail-silent so SSE
 // finalizers can fire-and-forget without risking the user's response.
 //
-// Skip rules (returns without inserting):
-//   - usage is missing / not an object → nanobot didn't surface real numbers
-//     (e.g. legacy nanobot version, mocked path, error during streaming)
-//   - totalTokens is 0 → no LLM call actually happened (rare; safety net)
+// Skip rules (return without inserting):
+//   - usage missing / not an object → nanobot didn't surface a frame at all
+//   - usage.provider or usage.model missing → wire-contract violation; do NOT
+//     fill defaults (would mask a nanobot rollback). Surfaced via console.error
+//     so the missing field is visible in logs.
+//   - totalTokens === 0 → no real LLM call (rare safety net)
+//
+// Errored row (insert with errored=true, costUsd=0):
+//   - PRICING table has no entry for `${provider}:${model}` → token data is
+//     still recorded for usage analytics, but cost is 0 and errored flag is
+//     raised so the dashboard can surface a "needs pricing" signal.
 async function recordUsage({
   userId,
   session,
@@ -34,6 +33,13 @@ async function recordUsage({
   if (!usage || typeof usage !== 'object') return;
   if (!session || !session._id) return;
 
+  const provider = typeof usage.provider === 'string' && usage.provider ? usage.provider : null;
+  const model = typeof usage.model === 'string' && usage.model ? usage.model : null;
+  if (!provider || !model) {
+    console.error('[LLMUsage] frame missing provider/model — skipping persist');
+    return;
+  }
+
   const inputTokens = Number(usage.prompt_tokens || 0);
   const outputTokens = Number(usage.completion_tokens || 0);
   const totalTokens = Number(usage.total_tokens || inputTokens + outputTokens);
@@ -42,8 +48,18 @@ async function recordUsage({
 
   if (totalTokens === 0) return;
 
+  const pricingKey = `${provider}:${model}`;
+  const pricingKnown = Object.prototype.hasOwnProperty.call(PRICING, pricingKey);
+  let unknownPricing = false;
+  if (!pricingKnown) {
+    console.error(
+      `[LLMUsage] unknown pricing for ${pricingKey} — recorded with costUsd=0 errored=true`,
+    );
+    unknownPricing = true;
+  }
+
   try {
-    const costUsd = calcCost(NANOBOT_PROVIDER, NANOBOT_MODEL, {
+    const costUsd = calcCost(provider, model, {
       inputTokens,
       outputTokens,
       cachedTokens,
@@ -57,8 +73,8 @@ async function recordUsage({
       nanobotSessionId: session.nanobotSessionId,
       requestId,
       channel: 'ask-ola',
-      provider: NANOBOT_PROVIDER,
-      model: NANOBOT_MODEL,
+      provider,
+      model,
       inputTokens,
       outputTokens,
       totalTokens,
@@ -67,7 +83,7 @@ async function recordUsage({
       costUsd,
       pricingVersion: PRICING_VERSION,
       latencyMs: Number(latencyMs) || 0,
-      errored: !!errored,
+      errored: !!errored || unknownPricing,
       createdBy: userId,
     });
   } catch (err) {

--- a/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
+++ b/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
@@ -1,0 +1,81 @@
+const mongoose = require('mongoose');
+
+const { calcCost, PRICING_VERSION } = require('@/constants/llmPricing');
+
+// Resolved lazily so this module can be required at boot before
+// models/utils/index.js has finished registering all mongoose models.
+const lazyModel = () => mongoose.model('LlmUsage');
+
+// Defaults reflect the current Ask Ola configuration (see
+// ola/nanobot.config.template.json `agents.defaults`). They can be overridden
+// per-request once nanobot starts surfacing per-call provider/model in the
+// usage SSE frame; for now NanoBot uses one model per process so a static
+// default is correct.
+const NANOBOT_PROVIDER = process.env.NANOBOT_PROVIDER || 'gemini';
+const NANOBOT_MODEL = process.env.NANOBOT_MODEL || 'gemini-3.1-flash-lite-preview';
+
+// Persist one LLMUsage document. Always returns a Promise so the caller can
+// `.catch()` if they want, but never throws — internally fail-silent so SSE
+// finalizers can fire-and-forget without risking the user's response.
+//
+// Skip rules (returns without inserting):
+//   - usage is missing / not an object → nanobot didn't surface real numbers
+//     (e.g. legacy nanobot version, mocked path, error during streaming)
+//   - totalTokens is 0 → no LLM call actually happened (rare; safety net)
+async function recordUsage({
+  userId,
+  session,
+  messageId = null,
+  usage,
+  latencyMs,
+  requestId,
+  errored = false,
+}) {
+  if (!usage || typeof usage !== 'object') return;
+  if (!session || !session._id) return;
+
+  const inputTokens = Number(usage.prompt_tokens || 0);
+  const outputTokens = Number(usage.completion_tokens || 0);
+  const totalTokens = Number(usage.total_tokens || inputTokens + outputTokens);
+  const cachedTokens = Number(usage.cached_tokens || 0);
+  const iterations = Number(usage.iterations || 1);
+
+  if (totalTokens === 0) return;
+
+  try {
+    const costUsd = calcCost(NANOBOT_PROVIDER, NANOBOT_MODEL, {
+      inputTokens,
+      outputTokens,
+      cachedTokens,
+    });
+
+    const LlmUsage = lazyModel();
+    await LlmUsage.create({
+      userId,
+      sessionId: session._id,
+      messageId,
+      nanobotSessionId: session.nanobotSessionId,
+      requestId,
+      channel: 'ask-ola',
+      provider: NANOBOT_PROVIDER,
+      model: NANOBOT_MODEL,
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      cachedTokens,
+      iterations,
+      costUsd,
+      pricingVersion: PRICING_VERSION,
+      latencyMs: Number(latencyMs) || 0,
+      errored: !!errored,
+      createdBy: userId,
+    });
+  } catch (err) {
+    // Never let cost-tracking failure poison the user request. Surface in
+    // logs so we notice if writes start systematically dropping (e.g. mongo
+    // connection pool exhausted under load).
+    console.error('[LLMUsage] persist failed:', err && err.message);
+  }
+}
+
+module.exports = recordUsage;

--- a/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
+++ b/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
@@ -29,6 +29,7 @@ async function recordUsage({
   latencyMs,
   requestId,
   errored = false,
+  channel = 'ask-ola',
 }) {
   if (!usage || typeof usage !== 'object') return;
   if (!session || !session._id) return;
@@ -72,7 +73,7 @@ async function recordUsage({
       messageId,
       nanobotSessionId: session.nanobotSessionId,
       requestId,
-      channel: 'ask-ola',
+      channel,
       provider,
       model,
       inputTokens,

--- a/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
+++ b/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
@@ -89,7 +89,7 @@ async function recordUsage({
     // Never let cost-tracking failure poison the user request. Surface in
     // logs so we notice if writes start systematically dropping (e.g. mongo
     // connection pool exhausted under load).
-    console.error('[LLMUsage] persist failed:', err && err.message);
+    console.error('[LLMUsage] persist failed:', err.message);
   }
 }
 

--- a/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
+++ b/backend/src/controllers/appControllers/llmUsageController/recordUsage.js
@@ -60,11 +60,9 @@ async function recordUsage({
   }
 
   try {
-    const costUsd = calcCost(provider, model, {
-      inputTokens,
-      outputTokens,
-      cachedTokens,
-    });
+    const costUsd = unknownPricing
+      ? 0
+      : calcCost(provider, model, { inputTokens, outputTokens, cachedTokens });
 
     const LlmUsage = lazyModel();
     await LlmUsage.create({

--- a/backend/src/controllers/appControllers/olaController/chat.js
+++ b/backend/src/controllers/appControllers/olaController/chat.js
@@ -73,10 +73,12 @@ function makeSSEParser(onFrame) {
 }
 
 // ---------------------------------------------------------------------------
-// Auto-title (unchanged from prior implementation, just relocated).
+// Auto-title — non-streaming /v1/chat/completions call. Token spend is tracked
+// under channel='ask-ola-autotitle' so the dashboard can split user-facing
+// chat cost from incidental LLM costs (Ola CRM #98 C5).
 // ---------------------------------------------------------------------------
 
-function generateTitle(session, messages) {
+function generateTitle(session, messages, userId) {
   const conversation = messages
     .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
     .join('\n');
@@ -91,20 +93,40 @@ function generateTitle(session, messages) {
     headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) },
     timeout: 30000,
   };
+  const titleStartTs = Date.now();
+  const titleRequestId = uuidv4();
   const titleReq = http.request(options, (titleRes) => {
     let data = '';
     titleRes.on('data', (chunk) => { data += chunk; });
     titleRes.on('end', () => {
+      let parsed;
       try {
-        const parsed = JSON.parse(data);
-        const title = parsed.choices?.[0]?.message?.content?.trim();
-        if (title && title.length > 0 && title.length <= 100) {
-          ChatSession.findByIdAndUpdate(session._id, { title, updated: Date.now() }).catch((err) => {
-            console.error(`[AutoTitle] Failed to update session ${session._id}:`, err.message);
-          });
-        }
+        parsed = JSON.parse(data);
       } catch (err) {
         console.error(`[AutoTitle] Failed to parse title response for session ${session._id}:`, err.message);
+        return;
+      }
+      const title = parsed?.choices?.[0]?.message?.content?.trim();
+      if (title && title.length > 0 && title.length <= 100) {
+        ChatSession.findByIdAndUpdate(session._id, { title, updated: Date.now() }).catch((err) => {
+          console.error(`[AutoTitle] Failed to update session ${session._id}:`, err.message);
+        });
+      }
+      // Record auto-title token spend under its own channel so the dashboard
+      // can split it from user-visible chat cost. Fire-and-forget; recordUsage
+      // is fail-silent. Only fires when nanobot supplied a real usage payload
+      // with provider/model — if the response was malformed or pre-N4 nanobot
+      // (no real usage), recordUsage's wire-contract check skips silently.
+      if (userId && parsed && typeof parsed.usage === 'object') {
+        recordUsage({
+          userId,
+          session,
+          messageId: null,
+          usage: parsed.usage,
+          latencyMs: Date.now() - titleStartTs,
+          requestId: titleRequestId,
+          channel: 'ask-ola-autotitle',
+        });
       }
     });
   });
@@ -115,14 +137,14 @@ function generateTitle(session, messages) {
   titleReq.end();
 }
 
-function maybeAutoTitle(session, userMessage, assistantContent) {
+function maybeAutoTitle(session, userMessage, assistantContent, userId) {
   if (session.title !== 'New Chat') return;
   ChatMessage.countDocuments({ sessionId: session._id, removed: false })
     .then((count) => {
       if (count >= 4) {
         return ChatMessage.find({ sessionId: session._id, removed: false })
           .sort({ created: 1 }).lean()
-          .then((msgs) => generateTitle(session, msgs));
+          .then((msgs) => generateTitle(session, msgs, userId));
       }
     })
     .catch((err) => console.error(`[AutoTitle] count/find failed for session ${session._id}:`, err.message));
@@ -312,7 +334,7 @@ const chat = async (req, res) => {
               errored: upstreamErrored,
             });
           }
-          return maybeAutoTitle(session, message.trim(), streamedText);
+          return maybeAutoTitle(session, message.trim(), streamedText, userId);
         })
         .catch((err) => {
           console.error(
@@ -405,3 +427,6 @@ const chat = async (req, res) => {
 };
 
 module.exports = chat;
+// Internal helpers exported for unit testing (Ola CRM #98 C5 — auto-title
+// usage tracking). Not part of the public chat controller surface.
+module.exports.__test__ = { generateTitle, maybeAutoTitle };

--- a/backend/src/controllers/appControllers/olaController/chat.js
+++ b/backend/src/controllers/appControllers/olaController/chat.js
@@ -23,10 +23,6 @@ function nanobotEndpoint() {
 // ---------------------------------------------------------------------------
 
 function writeSSE(res, eventName, data) {
-  // No backpressure handling: res.write() can return false on a full TCP
-  // send buffer, but for a single chat session with short SSE frames the
-  // queue stays small. If we ever fan out one stream to many slow clients,
-  // revisit (likely use res.flush() + drain event).
   res.write(`event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`);
 }
 
@@ -193,10 +189,6 @@ const chat = async (req, res) => {
   res.setHeader('X-Accel-Buffering', 'no'); // hint to nginx not to buffer
   res.flushHeaders();
 
-  // Accumulators for stream-end persistence + final `done` frame payload.
-  // Each step's `ts` is reserved for future relative-timing UI (e.g. "step 2
-  // took 320ms"); not yet rendered, but persisted so we don't have to
-  // backfill schema later. Drop only if we decide that surface stays out.
   const thinkingSteps = []; // [{label, ts}] — drives thinking_trace block
   const finalToolEvents = []; // phase==='end' payloads → toolEventsToBlocks → widgets
   let streamedText = '';
@@ -236,11 +228,7 @@ const chat = async (req, res) => {
       'Content-Type': 'application/json',
       'Content-Length': Buffer.byteLength(proxyPayload),
       'Accept': 'text/event-stream',
-      // ISO5c (issue #185): pass logged-in admin._id so nanobot's MCP HTTP
-      // calls inject X-Acting-As; MCP server then scopes business tools to
-      // this admin instead of falling back to systemAdmin. End-to-end:
-      //   browser cookie → req.admin._id → here → nanobot api/server.py
-      //   → set_acting_as → contextvar → mcp.py event_hook → MCP server
+      // X-Acting-As scopes MCP business tools to logged-in admin (#185)
       'X-Ola-Acting-As': userId.toString(),
     },
     timeout: NANOBOT_TIMEOUT_MS,

--- a/backend/src/controllers/appControllers/olaController/chat.js
+++ b/backend/src/controllers/appControllers/olaController/chat.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { v4: uuidv4 } = require('uuid');
 const { toolEventsToBlocks } = require('./toolResultToBlocks');
 const { labelFor, STAGE_LABELS } = require('./thinkingLabels');
+const recordUsage = require('@/controllers/appControllers/llmUsageController/recordUsage');
 
 const ChatSession = mongoose.model('ChatSession');
 const ChatMessage = mongoose.model('ChatMessage');
@@ -179,6 +180,13 @@ const chat = async (req, res) => {
   let streamedText = '';
   let upstreamFinished = false;
   let upstreamErrored = false;
+  // Captured usage frame from NanoBot's SSE stream (Ola issue #98). Stays null
+  // when running against an older nanobot that doesn't emit `event: usage` —
+  // recordUsage() short-circuits on null so the chat path stays functional.
+  let capturedUsage = null;
+  // Per-request trace ids — used for log correlation + LLMUsage.requestId.
+  const requestId = uuidv4();
+  const startTs = Date.now();
 
   // Per-salesperson language directive prepended to user content. SOUL.md
   // teaches the agent to honor [SESSION_LANG=xx] as an overriding system
@@ -232,6 +240,14 @@ const chat = async (req, res) => {
       }
       return;
     }
+    if (eventName === 'usage') {
+      // Real per-turn token counts from NanoBot (Ola issue #98). Capture only
+      // — write to LLMUsage happens in finishStream() so it cannot delay the
+      // user-visible SSE response. Older nanobot versions never send this
+      // frame; capturedUsage stays null and recordUsage skips silently.
+      try { capturedUsage = JSON.parse(dataStr); } catch { /* drop malformed */ }
+      return;
+    }
     // Default event = OpenAI chat.completion.chunk
     if (dataStr === '[DONE]') return;
     let chunk;
@@ -258,7 +274,10 @@ const chat = async (req, res) => {
     writeSSE(res, 'done', { sessionId: session._id, blocks });
     res.end();
 
-    // Fire-and-forget persistence.
+    // Fire-and-forget persistence. ChatMessage and LLMUsage are independent
+    // writes (no shared lock, no upsert on a hot doc) — running them in
+    // parallel keeps the post-stream tail short and avoids any write
+    // serializing on the other.
     if (streamedText.length > 0 || blocks.length > 0) {
       ChatMessage.insertMany([
         {
@@ -276,13 +295,56 @@ const chat = async (req, res) => {
           createdBy: userId,
         },
       ])
-        .then(() => maybeAutoTitle(session, message.trim(), streamedText))
+        .then((docs) => {
+          // Plumb the assistant message _id into the LLMUsage row so the
+          // dashboard can deep-link cost → original message. Best-effort:
+          // if docs[1] is missing for any reason, recordUsage tolerates
+          // null messageId.
+          const assistantMsgId = docs && docs[1] && docs[1]._id;
+          if (capturedUsage) {
+            recordUsage({
+              userId,
+              session,
+              messageId: assistantMsgId || null,
+              usage: capturedUsage,
+              latencyMs: Date.now() - startTs,
+              requestId,
+              errored: upstreamErrored,
+            });
+          }
+          return maybeAutoTitle(session, message.trim(), streamedText);
+        })
         .catch((err) => {
           console.error(
             `[ChatMessage] Persist failed for session ${session._id}:`,
             err.message,
           );
+          // ChatMessage persist failed — still record LLMUsage so cost
+          // tracking isn't lost. messageId stays null.
+          if (capturedUsage) {
+            recordUsage({
+              userId,
+              session,
+              messageId: null,
+              usage: capturedUsage,
+              latencyMs: Date.now() - startTs,
+              requestId,
+              errored: true,
+            });
+          }
         });
+    } else if (capturedUsage) {
+      // No content to persist (rare — empty stream) but we still saw a usage
+      // frame, so a real LLM call happened. Track it.
+      recordUsage({
+        userId,
+        session,
+        messageId: null,
+        usage: capturedUsage,
+        latencyMs: Date.now() - startTs,
+        requestId,
+        errored: upstreamErrored,
+      });
     }
   };
 

--- a/backend/src/controllers/appControllers/olaController/chat.js
+++ b/backend/src/controllers/appControllers/olaController/chat.js
@@ -263,11 +263,12 @@ const chat = async (req, res) => {
       return;
     }
     if (eventName === 'usage') {
-      // Real per-turn token counts from NanoBot (Ola issue #98). Capture only
-      // — write to LLMUsage happens in finishStream() so it cannot delay the
-      // user-visible SSE response. Older nanobot versions never send this
-      // frame; capturedUsage stays null and recordUsage skips silently.
-      try { capturedUsage = JSON.parse(dataStr); } catch { /* drop malformed */ }
+      // Per-turn token counts from NanoBot (#98). Captured here, written in finishStream so SSE isn't delayed.
+      try {
+        capturedUsage = JSON.parse(dataStr);
+      } catch (e) {
+        console.warn('[askola] malformed event:usage frame dropped:', dataStr);
+      }
       return;
     }
     // Default event = OpenAI chat.completion.chunk

--- a/backend/src/middlewares/internalAuth.js
+++ b/backend/src/middlewares/internalAuth.js
@@ -1,0 +1,33 @@
+const rawEmails = process.env.INTERNAL_DASHBOARD_EMAILS;
+
+const allowSet = new Set(
+  (rawEmails || '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean)
+);
+
+if (allowSet.size === 0) {
+  throw new Error(
+    'INTERNAL_DASHBOARD_EMAILS not configured — internal dashboard refuses to start without an explicit allowlist'
+  );
+}
+
+module.exports = function internalAuth(req, res, next) {
+  const email = req.admin && req.admin.email && String(req.admin.email).toLowerCase();
+  if (!email) {
+    return res.status(401).json({
+      success: false,
+      result: null,
+      message: 'Authentication required',
+    });
+  }
+  if (!allowSet.has(email)) {
+    return res.status(403).json({
+      success: false,
+      result: null,
+      message: 'Internal access denied',
+    });
+  }
+  return next();
+};

--- a/backend/src/models/appModels/LlmUsage.js
+++ b/backend/src/models/appModels/LlmUsage.js
@@ -40,9 +40,13 @@ const schema = new mongoose.Schema({
   // application logs so we can match a record to a specific HTTP request.
   requestId: { type: String, required: true },
 
-  // Channel where the turn originated. 'ask-ola' for the Ask Ola web UI;
-  // future: 'whatsapp', 'wechat', 'email'. Indexed because dashboard splits
-  // by channel.
+  // Channel where the turn originated. Indexed because the dashboard splits
+  // cost by channel. Allowed values (no enum constraint — additive over time):
+  //   'ask-ola'             — user-facing Ask Ola web chat (the main path)
+  //   'ask-ola-autotitle'   — incidental non-streaming LLM call that
+  //                           generates the conversation title at turn 4+
+  //                           (#98 C5; usually small Gemini-flash-lite spend)
+  //   'whatsapp' / 'wechat' / 'email'  — planned channels (not wired yet)
   channel: { type: String, default: 'ask-ola', index: true },
   // LLM provider as nanobot reports it ('gemini' / 'openai' / 'anthropic').
   provider: { type: String, required: true },

--- a/backend/src/models/appModels/LlmUsage.js
+++ b/backend/src/models/appModels/LlmUsage.js
@@ -1,0 +1,96 @@
+const mongoose = require('mongoose');
+
+// Per-turn LLM call telemetry — populated by olaController/chat.js after each
+// Ask Ola SSE stream completes (Ola issue #98). One document per user message
+// → assistant response cycle, regardless of how many internal LLM calls
+// nanobot needed (tool dispatch + finalization etc.) — those are summed into
+// inputTokens/outputTokens and counted in `iterations`.
+//
+// Writes are fire-and-forget from the SSE finalizer; never block the user
+// response on persistence here.
+const schema = new mongoose.Schema({
+  removed: { type: Boolean, default: false },
+  enabled: { type: Boolean, default: true },
+
+  // Who asked. Required because the dashboard segments by user.
+  userId: {
+    type: mongoose.Schema.ObjectId,
+    ref: 'Admin',
+    required: true,
+    index: true,
+  },
+  // Which Ask Ola conversation this turn belongs to.
+  sessionId: {
+    type: mongoose.Schema.ObjectId,
+    ref: 'ChatSession',
+    required: true,
+  },
+  // Optional pointer to the assistant ChatMessage that this usage covers.
+  // Set when olaController/chat.js can plumb the inserted message _id back;
+  // null when the message persist failed or hasn't completed yet.
+  messageId: {
+    type: mongoose.Schema.ObjectId,
+    ref: 'ChatMessage',
+    default: null,
+  },
+  // Cross-repo trace key (matches NanoBot's session_key). Useful when
+  // diagnosing a cost spike — lets us correlate to nanobot logs.
+  nanobotSessionId: { type: String, required: true },
+  // Per-request UUID generated in olaController/chat.js — drops into
+  // application logs so we can match a record to a specific HTTP request.
+  requestId: { type: String, required: true },
+
+  // Channel where the turn originated. 'ask-ola' for the Ask Ola web UI;
+  // future: 'whatsapp', 'wechat', 'email'. Indexed because dashboard splits
+  // by channel.
+  channel: { type: String, default: 'ask-ola', index: true },
+  // LLM provider as nanobot reports it ('gemini' / 'openai' / 'anthropic').
+  provider: { type: String, required: true },
+  // Model identifier as nanobot reports it.
+  model: { type: String, required: true },
+
+  // Token counts as reported by the provider's usage field, summed across
+  // all internal LLM calls in this one Ask Ola turn.
+  inputTokens: { type: Number, required: true },
+  outputTokens: { type: Number, required: true },
+  totalTokens: { type: Number, required: true },
+  // Cached input tokens (provider-reported cache hits — reduce billable
+  // input). Stored separately so we can show savings on the dashboard.
+  cachedTokens: { type: Number, default: 0 },
+  // Number of LLM provider calls in this turn (1 = direct answer; >=2 means
+  // tool calls + finalization). Sourced from runner.AgentRunResult.
+  iterations: { type: Number, default: 1 },
+
+  // Estimated cost in USD using the pricing snapshot recorded in
+  // pricingVersion. Float math is acceptable here because token rates are
+  // sub-cent per token (currency.js precision-2 truncates these to 0); the
+  // pricing module uses currency.js with explicit precision-10 internally.
+  costUsd: { type: Number, required: true },
+  // Pricing table version that was active when costUsd was computed (e.g.
+  // '2026-04-28'). When prices change, we bump PRICING_VERSION rather than
+  // back-fill historical records.
+  pricingVersion: { type: String, required: true },
+
+  latencyMs: { type: Number, required: true },
+  // True when the SSE upstream errored — keep the record so we still see
+  // wasted token spend on failed turns.
+  errored: { type: Boolean, default: false },
+
+  createdBy: { type: mongoose.Schema.ObjectId, ref: 'Admin' },
+  created: { type: Date, default: Date.now },
+  updated: { type: Date, default: Date.now },
+}, {
+  // Pin the collection to a single canonical name (no mongoose pluralization)
+  // so the verification command from issue #98 — `db.llmusage.find(...)` —
+  // works as written, and so future Atlas dashboards don't have to guess.
+  collection: 'llmusage',
+});
+
+// Per-user latest-first lookup — the dashboard's primary access pattern.
+schema.index({ userId: 1, created: -1 });
+// Time-bucketed aggregation across all users (cost over time, etc.).
+schema.index({ created: -1 });
+// Per-channel slice for breaking out Ask Ola vs WhatsApp vs Email cost.
+schema.index({ channel: 1, created: -1 });
+
+module.exports = mongoose.model('LlmUsage', schema);

--- a/backend/src/routes/appRoutes/appApi.js
+++ b/backend/src/routes/appRoutes/appApi.js
@@ -63,4 +63,10 @@ router.route('/ola/session/delete/:id').delete(catchErrors(olaController['sessio
 router.route('/ola/session/rename/:id').patch(catchErrors(olaController['sessionRename']));
 router.route('/ola/session/messages/:id').get(catchErrors(olaController['sessionMessages']));
 
+// Internal developer dashboard — gated by email allowlist (issue #220 D1).
+// Routes for individual panels are registered in subsequent items (D3-D8).
+const internalAuth = require('@/middlewares/internalAuth');
+const internalDashboardRouter = express.Router();
+router.use('/internal/dashboard', internalAuth, internalDashboardRouter);
+
 module.exports = router;

--- a/backend/test/integration/test_internal_dashboard_gate.sh
+++ b/backend/test/integration/test_internal_dashboard_gate.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Real-stack integration test for the internal dashboard email-allowlist gate
+# (Ola CRM issue #220 D1).
+#
+# Mirrors the unit layer (backend/test/internalAuth.test.js) but hits the full
+# Express middleware chain to catch wiring regressions the unit layer cannot
+# see — specifically that internalAuth runs after isValidAuthToken and before
+# the internalDashboardRouter, that req.admin.email is correctly populated by
+# the upstream auth middleware, and that the empty router falls through to
+# errorHandlers.notFound (404) rather than the gate (403).
+#
+# Prerequisites:
+#   - Backend started with INTERNAL_DASHBOARD_EMAILS containing admin@admin.com
+#     for the "in list" path:
+#       INTERNAL_DASHBOARD_EMAILS='admin@admin.com' npm --prefix backend run dev
+#   - Mongo reachable (Atlas via backend/.env DATABASE)
+#   - Test admin: admin@admin.com / admin123
+#
+# Usage:
+#   bash backend/test/integration/test_internal_dashboard_gate.sh
+#
+# Exit code: 0 if all assertions PASS, 1 if any FAIL.
+#
+# Assertions (3, follow Ola "second call after protocol entry + negative case"
+# rule from feedback_acceptance_criteria_depth.md):
+#   1. Protocol entry — no cookie → 401 (isValidAuthToken intercepts)
+#   2. Protocol entry — login → 200 + cookie issued
+#   3. Second call after entry — protected gate path with valid cookie + email
+#      in allowlist → 404 (router empty, proves auth+gate both passed without
+#      collapsing into 403)
+#
+# The 403 (email NOT in list) path is covered by the jest unit layer, since
+# reproducing it here would require a second backend with a different
+# INTERNAL_DASHBOARD_EMAILS value.
+
+set -u
+
+BACKEND="${BACKEND_URL:-http://localhost:8888}"
+EMAIL="admin@admin.com"
+PASSWORD="admin123"
+COOKIE_JAR="$(mktemp)"
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_status() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS  $name (HTTP $actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $name (expected HTTP $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== T1: GET /api/internal/dashboard/anything without cookie (expect 401) ==="
+T1_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BACKEND/api/internal/dashboard/anything")
+assert_status "no cookie -> 401" "401" "$T1_STATUS"
+
+echo
+echo "=== T2: POST /api/login admin@admin.com (expect 200 + cookie) ==="
+LOGIN_BODY=$(curl -s -c "$COOKIE_JAR" -o /tmp/d1_login_body.json -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+  "$BACKEND/api/login")
+assert_status "login -> 200" "200" "$LOGIN_BODY"
+if ! grep -q '"success":true' /tmp/d1_login_body.json; then
+  echo "  FAIL  login body did not contain success:true"
+  FAIL=$((FAIL + 1))
+fi
+rm -f /tmp/d1_login_body.json
+
+echo
+echo "=== T3: GET /api/internal/dashboard/anything with cookie (admin in list, expect 404) ==="
+T3_STATUS=$(curl -s -b "$COOKIE_JAR" -o /tmp/d1_t3_body.json -w "%{http_code}" \
+  "$BACKEND/api/internal/dashboard/anything")
+assert_status "cookie + in list -> 404 (router empty)" "404" "$T3_STATUS"
+# Defensive: 403 here would mean the gate rejected an in-list admin. Surface it loudly.
+if grep -q "Internal access denied" /tmp/d1_t3_body.json; then
+  echo "  FAIL  body shows 'Internal access denied' — admin@admin.com not in INTERNAL_DASHBOARD_EMAILS?"
+  FAIL=$((FAIL + 1))
+fi
+rm -f /tmp/d1_t3_body.json
+
+echo
+echo "=== Summary: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/backend/test/integration/test_llm_usage.sh
+++ b/backend/test/integration/test_llm_usage.sh
@@ -239,6 +239,67 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Scenario 6 — 2-turn session triggers auto-title (channel=ask-ola-autotitle)
+# ---------------------------------------------------------------------------
+#
+# maybeAutoTitle fires on the 2nd turn (count of ChatMessage docs >= 4 = 2 turns
+# × 2 docs/turn). The auto-title call is non-streaming → response.usage drives
+# a 5th LlmUsage row with channel='ask-ola-autotitle'.
+
+echo
+echo "==> Scenario 6: 2-turn session triggers auto-title (#98 C5)"
+# Baseline: count rows with the ask-ola-autotitle channel BEFORE the test
+S6_LIST_BEFORE="$WORKDIR/s6_before.json"
+curl -s -o "$S6_LIST_BEFORE" "$BACKEND/api/llmusage/list?items=100" -b "$COOKIE_JAR"
+BASE6_AT=$(grep -o '"channel":"ask-ola-autotitle"' "$S6_LIST_BEFORE" | wc -l | tr -d ' ')
+
+# Turn 1 — new session, capture sessionId from the SSE done frame
+S6_T1="$WORKDIR/s6_t1.sse"
+curl -sN -X POST "$BACKEND/api/ola/chat" \
+  -H 'Content-Type: application/json' \
+  -b "$COOKIE_JAR" \
+  --max-time 60 \
+  -d '{"message":"hello, what merchandise do you have?"}' \
+  > "$S6_T1" 2>&1
+
+# Extract sessionId from `data: {"sessionId":"...","blocks":[...]}` frame
+S6_SESSION_ID=$(grep -o '"sessionId":"[a-f0-9]\{20,\}"' "$S6_T1" | head -1 | sed 's/"sessionId":"\(.*\)"/\1/')
+
+if [[ -z "$S6_SESSION_ID" ]]; then
+  red "    FAIL — could not extract sessionId from turn 1 SSE response"
+  cat "$S6_T1" | tail -5
+  FAILS=$((FAILS + 1))
+else
+  # Turn 2 — same session, this is the trigger boundary for autotitle
+  curl -sN -X POST "$BACKEND/api/ola/chat" \
+    -H 'Content-Type: application/json' \
+    -b "$COOKIE_JAR" \
+    --max-time 60 \
+    -d "{\"message\":\"thanks, anything stainless?\",\"sessionId\":\"$S6_SESSION_ID\"}" \
+    > "$WORKDIR/s6_t2.sse" 2>&1
+
+  # Auto-title is fire-and-forget: ChatMessage.insertMany finishes, then
+  # maybeAutoTitle queries count, then generateTitle does a non-stream call
+  # to nanobot, then recordUsage writes the row. Allow generous wait.
+  sleep 6
+
+  S6_LIST_AFTER="$WORKDIR/s6_after.json"
+  curl -s -o "$S6_LIST_AFTER" "$BACKEND/api/llmusage/list?items=100" -b "$COOKIE_JAR"
+  AFTER6_AT=$(grep -o '"channel":"ask-ola-autotitle"' "$S6_LIST_AFTER" | wc -l | tr -d ' ')
+
+  if [[ $AFTER6_AT -gt $BASE6_AT ]]; then
+    green "    PASS — auto-title row appeared (ask-ola-autotitle: $BASE6_AT → $AFTER6_AT)"
+    PASSES=$((PASSES + 1))
+  else
+    red "    FAIL — no new ask-ola-autotitle row (before=$BASE6_AT after=$AFTER6_AT)"
+    echo "    sessionId was: $S6_SESSION_ID"
+    echo "    last 3 lines of after-list:"
+    tail -3 "$S6_LIST_AFTER"
+    FAILS=$((FAILS + 1))
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/backend/test/integration/test_llm_usage.sh
+++ b/backend/test/integration/test_llm_usage.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Real-stack integration test for LLMUsage telemetry (Ola CRM issue #98).
+#
+# Mirrors test_ola_chat_sse.sh but verifies the data-collection side: a real
+# Ask Ola turn against the running stack must produce a real LLMUsage row in
+# Mongo with correct token counts, iteration count, and a non-zero costUsd.
+#
+# Unlike the jest layer (backend/test/llmUsage.chat.test.js, fake NanoBot)
+# this hits the FULL stack: CRM backend → real NanoBot → real MCP → real
+# Mongo → real Gemini. Catches integration bugs the mock layer can't see —
+# specifically the SSE wire format round-trip between nanobot's _sse_usage()
+# and chat.js's `eventName === 'usage'` parser.
+#
+# Prerequisites:
+#   - Full dev stack running: bash ~/Documents/Work/SeekMi_Tech/Ola/start-dev.sh
+#   - Backend on 8888, NanoBot on 8900, Mongo accessible
+#   - Test admin: admin@admin.com / admin123
+#
+# Usage:
+#   bash backend/test/integration/test_llm_usage.sh
+#
+# Exit code: 0 if all scenarios PASS, 1 if any FAIL.
+#
+# Scenarios:
+#   1. Auth gate: /api/llmusage/list without cookie → 401
+#   2. denyWrite: POST /api/llmusage/create with valid cookie → 403 with
+#      Chinese message
+#   3. Read access: GET /api/llmusage/list with cookie → 200 + result array
+#      (initial may be empty depending on prior runs)
+#   4. End-to-end persistence: chat → wait → /api/llmusage/list shows new
+#      row with iterations >= 1 and costUsd > 0
+#   5. Tool-using turn → iterations >= 2 (validates the runner.llm_call_count
+#      plumbing through to the SSE usage frame)
+
+set -u
+
+BACKEND="${BACKEND_URL:-http://localhost:8888}"
+EMAIL="admin@admin.com"
+PASSWORD="admin123"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/ola-llmusage-XXXX")"
+COOKIE_JAR="$WORKDIR/cookies.txt"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASSES=0
+FAILS=0
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Pre-flight + login
+# ---------------------------------------------------------------------------
+
+echo "==> Pre-flight: backend reachable at $BACKEND?"
+if ! curl -sf -o /dev/null --max-time 5 "$BACKEND/health"; then
+  red "FAIL: cannot reach $BACKEND/health — is start-dev.sh running?"
+  exit 1
+fi
+green "    OK"
+
+echo "==> Login as $EMAIL to capture cookie"
+LOGIN_RESP="$WORKDIR/login.json"
+curl -s -X POST "$BACKEND/api/login" \
+  -H 'Content-Type: application/json' \
+  -c "$COOKIE_JAR" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+  > "$LOGIN_RESP"
+
+if ! grep -q '"success":true' "$LOGIN_RESP"; then
+  red "FAIL: login failed — see $LOGIN_RESP"
+  cat "$LOGIN_RESP"
+  exit 1
+fi
+if ! grep -q 'token' "$COOKIE_JAR"; then
+  red "FAIL: no 'token' cookie in jar"
+  exit 1
+fi
+green "    OK (cookie set)"
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — auth gate
+# ---------------------------------------------------------------------------
+
+echo
+echo "==> Scenario 1: /api/llmusage/list without cookie → 401"
+S1_STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BACKEND/api/llmusage/list")
+if [[ "$S1_STATUS" == "401" ]]; then
+  green "    PASS — got 401 as expected"
+  PASSES=$((PASSES + 1))
+else
+  red "    FAIL — got HTTP $S1_STATUS, expected 401"
+  FAILS=$((FAILS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — denyWrite (system-internal collection)
+# ---------------------------------------------------------------------------
+
+echo
+echo "==> Scenario 2: POST /api/llmusage/create with admin cookie → 403"
+S2_BODY="$WORKDIR/s2.json"
+S2_STATUS=$(curl -s -o "$S2_BODY" -w '%{http_code}' -X POST "$BACKEND/api/llmusage/create" \
+  -H 'Content-Type: application/json' \
+  -b "$COOKIE_JAR" \
+  -d '{"userId":"abc","sessionId":"xyz","provider":"gemini","model":"x","inputTokens":1,"outputTokens":1,"totalTokens":2,"costUsd":0.001,"pricingVersion":"x","latencyMs":100,"nanobotSessionId":"x","requestId":"x"}')
+if [[ "$S2_STATUS" == "403" ]] \
+   && grep -q '"success":false' "$S2_BODY" \
+   && grep -q 'LLMUsage 写入仅限系统内部' "$S2_BODY"; then
+  green "    PASS — got 403 with the documented Chinese message"
+  PASSES=$((PASSES + 1))
+else
+  red "    FAIL — got HTTP $S2_STATUS, body:"
+  cat "$S2_BODY"
+  FAILS=$((FAILS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — read path is accessible (for the future dashboard)
+# ---------------------------------------------------------------------------
+
+echo
+echo "==> Scenario 3: GET /api/llmusage/list with cookie → 200 + result array"
+S3_BODY="$WORKDIR/s3.json"
+S3_STATUS=$(curl -s -o "$S3_BODY" -w '%{http_code}' "$BACKEND/api/llmusage/list" \
+  -b "$COOKIE_JAR")
+if [[ "$S3_STATUS" == "200" ]] && grep -q '"success":true' "$S3_BODY" \
+   && grep -q '"result":' "$S3_BODY"; then
+  green "    PASS — list endpoint returns success envelope"
+  PASSES=$((PASSES + 1))
+else
+  red "    FAIL — got HTTP $S3_STATUS, body:"
+  cat "$S3_BODY"
+  FAILS=$((FAILS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — chat → LLMUsage row written
+# ---------------------------------------------------------------------------
+
+# Capture a baseline list pagination header so we can detect a NEW row.
+echo
+echo "==> Scenario 4: chat turn produces a new LLMUsage row with costUsd > 0"
+S4_BASELINE="$WORKDIR/s4_baseline.json"
+curl -s -o "$S4_BASELINE" "$BACKEND/api/llmusage/list?items=1" -b "$COOKIE_JAR"
+BASELINE_TOTAL=$(grep -o '"count":[0-9]*' "$S4_BASELINE" | head -1 | grep -o '[0-9]*' || echo 0)
+echo "    baseline llmusage count: $BASELINE_TOTAL"
+
+# Send a pure-text chat (deterministic, no tool calls; iterations should be 1).
+S4_SSE="$WORKDIR/s4.sse"
+curl -sN -X POST "$BACKEND/api/ola/chat" \
+  -H 'Content-Type: application/json' \
+  -b "$COOKIE_JAR" \
+  --max-time 90 \
+  -d '{"message":"Reply with the single word: pong. Do not call any tools."}' \
+  > "$S4_SSE" 2>&1
+
+if ! grep -q '^event: done' "$S4_SSE"; then
+  red "    FAIL — chat did not produce a done frame; full SSE: $S4_SSE"
+  FAILS=$((FAILS + 1))
+else
+  # LLMUsage write is fire-and-forget. Allow up to 3s to settle.
+  echo "    chat returned, waiting for fire-and-forget LLMUsage write..."
+  sleep 3
+  S4_AFTER="$WORKDIR/s4_after.json"
+  curl -s -o "$S4_AFTER" "$BACKEND/api/llmusage/list?items=1" -b "$COOKIE_JAR"
+  AFTER_TOTAL=$(grep -o '"count":[0-9]*' "$S4_AFTER" | head -1 | grep -o '[0-9]*' || echo 0)
+  echo "    after-chat llmusage count: $AFTER_TOTAL"
+
+  if [[ $AFTER_TOTAL -le $BASELINE_TOTAL ]]; then
+    red "    FAIL — count did not increase (baseline=$BASELINE_TOTAL, after=$AFTER_TOTAL)"
+    cat "$S4_AFTER"
+    FAILS=$((FAILS + 1))
+  else
+    # Inspect the newest row.
+    INPUT_TOKENS=$(grep -o '"inputTokens":[0-9]*' "$S4_AFTER" | head -1 | grep -o '[0-9]*')
+    OUTPUT_TOKENS=$(grep -o '"outputTokens":[0-9]*' "$S4_AFTER" | head -1 | grep -o '[0-9]*')
+    COST_USD=$(grep -o '"costUsd":[0-9.eE+-]*' "$S4_AFTER" | head -1 | sed 's/"costUsd"://')
+    ITERATIONS=$(grep -o '"iterations":[0-9]*' "$S4_AFTER" | head -1 | grep -o '[0-9]*')
+
+    if [[ -n "$INPUT_TOKENS" && "$INPUT_TOKENS" -gt 0 ]] \
+       && [[ -n "$OUTPUT_TOKENS" && "$OUTPUT_TOKENS" -gt 0 ]] \
+       && [[ -n "$COST_USD" ]] \
+       && awk "BEGIN{exit !($COST_USD > 0)}" \
+       && [[ "$ITERATIONS" -ge 1 ]]; then
+      green "    PASS — new row: input=$INPUT_TOKENS output=$OUTPUT_TOKENS iterations=$ITERATIONS cost=\$$COST_USD"
+      PASSES=$((PASSES + 1))
+    else
+      red "    FAIL — newest row missing/invalid: input=$INPUT_TOKENS output=$OUTPUT_TOKENS iterations=$ITERATIONS cost=$COST_USD"
+      cat "$S4_AFTER"
+      FAILS=$((FAILS + 1))
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — tool-using turn → iterations >= 2
+# ---------------------------------------------------------------------------
+
+echo
+echo "==> Scenario 5: tool-using chat → LLMUsage row with iterations >= 2"
+S5_BASELINE="$WORKDIR/s5_baseline.json"
+curl -s -o "$S5_BASELINE" "$BACKEND/api/llmusage/list?items=1" -b "$COOKIE_JAR"
+BASE5_TOTAL=$(grep -o '"count":[0-9]*' "$S5_BASELINE" | head -1 | grep -o '[0-9]*' || echo 0)
+
+S5_SSE="$WORKDIR/s5.sse"
+curl -sN -X POST "$BACKEND/api/ola/chat" \
+  -H 'Content-Type: application/json' \
+  -b "$COOKIE_JAR" \
+  --max-time 90 \
+  -d '{"message":"Please use the merch.search tool to look up products containing the word stainless. Then summarize what you found in one sentence."}' \
+  > "$S5_SSE" 2>&1
+
+if ! grep -q '^event: done' "$S5_SSE"; then
+  red "    FAIL — tool-using chat did not produce a done frame"
+  FAILS=$((FAILS + 1))
+else
+  sleep 3
+  S5_AFTER="$WORKDIR/s5_after.json"
+  curl -s -o "$S5_AFTER" "$BACKEND/api/llmusage/list?items=1" -b "$COOKIE_JAR"
+  AFTER5_TOTAL=$(grep -o '"count":[0-9]*' "$S5_AFTER" | head -1 | grep -o '[0-9]*' || echo 0)
+  ITER5=$(grep -o '"iterations":[0-9]*' "$S5_AFTER" | head -1 | grep -o '[0-9]*')
+
+  if [[ $AFTER5_TOTAL -le $BASE5_TOTAL ]]; then
+    red "    FAIL — no new row after tool-using chat"
+    FAILS=$((FAILS + 1))
+  elif [[ -z "$ITER5" || "$ITER5" -lt 2 ]]; then
+    red "    FAIL — iterations=$ITER5 (expected >= 2 for a tool-using turn)"
+    cat "$S5_AFTER"
+    FAILS=$((FAILS + 1))
+  else
+    green "    PASS — tool-using turn recorded iterations=$ITER5 (>= 2)"
+    PASSES=$((PASSES + 1))
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+echo "==================================================================="
+if [[ $FAILS -eq 0 ]]; then
+  green "ALL $PASSES SCENARIOS PASSED"
+  exit 0
+else
+  red "FAILED: $FAILS scenario(s) failed, $PASSES passed"
+  echo "Artifacts kept at $WORKDIR (manual inspection)"
+  trap - EXIT
+  exit 1
+fi

--- a/backend/test/integration/test_llm_usage.sh
+++ b/backend/test/integration/test_llm_usage.sh
@@ -120,13 +120,17 @@ fi
 # ---------------------------------------------------------------------------
 
 echo
-echo "==> Scenario 3: GET /api/llmusage/list with cookie → 200 + result array"
+echo "==> Scenario 3: GET /api/llmusage/list with cookie → 2xx + success envelope"
+# Note: Ola CRM's createCRUDController.paginatedList returns HTTP 203
+# ("Non-Authoritative Information") with success:true when the collection is
+# empty — see backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js:57.
+# So we accept 200 (has rows) OR 203 (empty), both are documented success states.
 S3_BODY="$WORKDIR/s3.json"
 S3_STATUS=$(curl -s -o "$S3_BODY" -w '%{http_code}' "$BACKEND/api/llmusage/list" \
   -b "$COOKIE_JAR")
-if [[ "$S3_STATUS" == "200" ]] && grep -q '"success":true' "$S3_BODY" \
+if [[ "$S3_STATUS" =~ ^20[03]$ ]] && grep -q '"success":true' "$S3_BODY" \
    && grep -q '"result":' "$S3_BODY"; then
-  green "    PASS — list endpoint returns success envelope"
+  green "    PASS — list endpoint returns success envelope (HTTP $S3_STATUS)"
   PASSES=$((PASSES + 1))
 else
   red "    FAIL — got HTTP $S3_STATUS, body:"

--- a/backend/test/internalAuth.test.js
+++ b/backend/test/internalAuth.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for internalAuth middleware (Ola issue #220 D1).
+ *
+ * Covers:
+ *   1. Module load throws when INTERNAL_DASHBOARD_EMAILS is missing
+ *   2. Module load throws when env exists but parses to empty (whitespace/commas only)
+ *   3. Middleware returns 401 when req.admin is missing (auth chain prerequisite)
+ *   4. Middleware returns 403 when admin email is not in allowlist
+ *   5. Middleware calls next() when admin email is in allowlist (case-insensitive)
+ *
+ * Each test uses jest.isolateModules + manual env juggling to re-evaluate the
+ * module's top-level allowSet from a clean state.
+ */
+
+const ENV_KEY = 'INTERNAL_DASHBOARD_EMAILS';
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function loadFresh() {
+  let mod;
+  jest.isolateModules(() => {
+    mod = require('@/middlewares/internalAuth');
+  });
+  return mod;
+}
+
+describe('internalAuth middleware', () => {
+  const originalEnv = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalEnv;
+    }
+  });
+
+  test('throws when INTERNAL_DASHBOARD_EMAILS env is missing', () => {
+    delete process.env[ENV_KEY];
+    expect(loadFresh).toThrow(/INTERNAL_DASHBOARD_EMAILS not configured/);
+  });
+
+  test('throws when INTERNAL_DASHBOARD_EMAILS parses to empty after trim', () => {
+    process.env[ENV_KEY] = ' , ,  ,';
+    expect(loadFresh).toThrow(/INTERNAL_DASHBOARD_EMAILS not configured/);
+  });
+
+  test('returns 401 when req.admin is missing', () => {
+    process.env[ENV_KEY] = 'a@x.com,b@x.com';
+    const internalAuth = loadFresh();
+    const req = {};
+    const res = mockRes();
+    const next = jest.fn();
+
+    internalAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      result: null,
+      message: 'Authentication required',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 when admin email is not in allowlist', () => {
+    process.env[ENV_KEY] = 'a@x.com,b@x.com';
+    const internalAuth = loadFresh();
+    const req = { admin: { email: 'evil@x.com' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    internalAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      result: null,
+      message: 'Internal access denied',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('calls next() when admin email matches allowlist (case-insensitive)', () => {
+    process.env[ENV_KEY] = 'A@X.COM, b@x.com ';
+    const internalAuth = loadFresh();
+    const req = { admin: { email: 'a@x.com' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    internalAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/llmPricing.test.js
+++ b/backend/test/llmPricing.test.js
@@ -1,0 +1,164 @@
+/**
+ * Tests for constants/llmPricing.js — token cost calculation table (#98).
+ *
+ * Pure function tests — no DB / express needed. The math has to handle
+ * sub-cent token rates that helpers.calculate (currency.js precision-2)
+ * would silently truncate to zero, so we test small-magnitude precision
+ * explicitly.
+ */
+
+const { calcCost, PRICING, PRICING_VERSION } = require('@/constants/llmPricing');
+
+describe('llmPricing — module exports', () => {
+  test('PRICING_VERSION is a YYYY-MM-DD string snapshot', () => {
+    expect(PRICING_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('every pricing entry has positive input/output rates', () => {
+    for (const [key, p] of Object.entries(PRICING)) {
+      expect(p.input).toBeGreaterThan(0);
+      expect(p.output).toBeGreaterThan(0);
+      expect(p.cached).toBeGreaterThanOrEqual(0);
+      // Sanity: cached <= input (provider would never charge MORE for cache hits).
+      expect(p.cached).toBeLessThanOrEqual(p.input);
+      // Sanity: output >= input (output is invariably more expensive in 2025+
+      // pricing models — flag if a future entry violates this so we re-check).
+      expect(p.output).toBeGreaterThanOrEqual(p.input);
+    }
+  });
+
+  test('default Ask Ola model is in PRICING (matches ola/nanobot.config.template.json)', () => {
+    // toHaveProperty parses '.' as a nesting separator, which mangles
+    // 'gemini:gemini-3.1-flash-lite-preview' (the 3.1 becomes a sub-path).
+    // Use array form to pass a literal key with dots.
+    expect(PRICING).toHaveProperty(['gemini:gemini-3.1-flash-lite-preview']);
+  });
+});
+
+describe('llmPricing — calcCost happy path', () => {
+  test('1000 input + 500 output Gemini 3.1 Flash-Lite Preview = $0.001', () => {
+    // Spot-check: 1000 × $0.25/1M + 500 × $1.50/1M = $0.00025 + $0.00075 = $0.001
+    const cost = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+    expect(cost).toBeCloseTo(0.001, 10);
+  });
+
+  test('cached tokens reduce billable input cost', () => {
+    const baseline = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 1000,
+      outputTokens: 500,
+      cachedTokens: 0,
+    });
+    const withCache = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 1000,
+      outputTokens: 500,
+      cachedTokens: 800,
+    });
+    expect(withCache).toBeLessThan(baseline);
+    // Specific math: (1000-800)*$0.25/1M + 500*$1.50/1M + 800*$0.025/1M
+    //              = 0.00005      + 0.00075       + 0.00002 = 0.00082
+    expect(withCache).toBeCloseTo(0.00082, 10);
+  });
+
+  test('zero output and zero cache returns input-only cost', () => {
+    const cost = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 4000,
+      outputTokens: 0,
+    });
+    // 4000 × $0.25/1M = $0.001
+    expect(cost).toBeCloseTo(0.001, 10);
+  });
+
+  test('precision survives 1 token (sub-cent territory that helpers.calculate would zero out)', () => {
+    // 1 input token at $0.25/1M = $0.00000025. helpers.calculate.* uses
+    // currency.js precision-2 and would round this to $0.00 — this regression
+    // test confirms our explicit precision-10 path keeps the value alive.
+    const cost = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 1,
+      outputTokens: 0,
+    });
+    expect(cost).toBeGreaterThan(0);
+    expect(cost).toBeCloseTo(0.00000025, 12);
+  });
+});
+
+describe('llmPricing — calcCost edge cases', () => {
+  test('unknown provider:model returns 0 (with warn, not throw)', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const cost = calcCost('xai', 'grok-not-real', {
+        inputTokens: 100,
+        outputTokens: 100,
+      });
+      expect(cost).toBe(0);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('xai:grok-not-real')
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('non-numeric tokens coerce to 0 (defensive — never NaN)', () => {
+    const cost = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 'abc',
+      outputTokens: null,
+      cachedTokens: undefined,
+    });
+    expect(cost).toBe(0);
+  });
+
+  test('negative tokens floor at 0 (do not produce negative cost)', () => {
+    const cost = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: -500,
+      outputTokens: -100,
+    });
+    expect(cost).toBe(0);
+  });
+
+  test('cachedTokens > inputTokens caps at inputTokens (cannot have more cache hits than input)', () => {
+    // Defensive: if a buggy provider report shows cached > input, we should
+    // not bill negative input. Cap and proceed.
+    const cost = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 100,
+      outputTokens: 0,
+      cachedTokens: 500, // larger than input
+    });
+    // Effective billable input = 0, all input went through cache rate.
+    // 100 × $0.025/1M = $0.0000025
+    expect(cost).toBeCloseTo(0.0000025, 12);
+  });
+
+  test('all zero tokens returns exactly 0', () => {
+    expect(
+      calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedTokens: 0,
+      })
+    ).toBe(0);
+  });
+});
+
+describe('llmPricing — large-scale realism', () => {
+  test('100k input + 20k output Gemini Flash gives ~$0.08 (sanity check vs napkin math)', () => {
+    // gemini-2.5-flash: input $0.30/1M, output $2.50/1M
+    // 100000 × 0.30/1M + 20000 × 2.50/1M = 0.03 + 0.05 = 0.08
+    const cost = calcCost('gemini', 'gemini-2.5-flash', {
+      inputTokens: 100_000,
+      outputTokens: 20_000,
+    });
+    expect(cost).toBeCloseTo(0.08, 6);
+  });
+
+  test('1M tokens Gemini Flash-Lite is sub-dollar (Ask Ola realistic upper bound)', () => {
+    // 1M input + 1M output × Flash-Lite = $0.25 + $1.50 = $1.75
+    const cost = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(1.75, 8);
+  });
+});

--- a/backend/test/llmUsage.autotitle.test.js
+++ b/backend/test/llmUsage.autotitle.test.js
@@ -1,0 +1,245 @@
+/**
+ * Unit test for olaController/chat.js auto-title LLMUsage capture
+ * (Ola CRM #98 C5).
+ *
+ * generateTitle() makes a non-streaming /v1/chat/completions call to
+ * nanobot for a short conversation summary. Token spend on that call
+ * should be persisted with channel='ask-ola-autotitle' so the dashboard
+ * can split it from user-facing chat cost.
+ *
+ * Pattern: spawn a fake nanobot HTTP server on a unique port (18902 to
+ * avoid collision with llmUsage.chat.test.js's 18901), let it serve a
+ * canned non-streaming OpenAI response with a `usage` object that
+ * mirrors what real nanobot/api/server.py:_chat_completion_response
+ * returns post-N4. Then call generateTitle directly and assert a single
+ * LlmUsage row appears with the correct channel.
+ */
+
+const path = require('path');
+const http = require('http');
+const mongoose = require('mongoose');
+const { globSync } = require('glob');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+const adminId = new mongoose.Types.ObjectId();
+const FAKE_NANOBOT_PORT = 18902;
+
+const FRAME_USAGE = {
+  provider: 'gemini',
+  model: 'gemini-3.1-flash-lite-preview',
+  prompt_tokens: 240,
+  completion_tokens: 12,
+  total_tokens: 252,
+  cached_tokens: 0,
+  iterations: 1,
+};
+
+let mongo;
+let fakeNanoBot;
+let nanoBotResponder = null;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+
+  process.env.NANOBOT_HOST = '127.0.0.1';
+  process.env.NANOBOT_PORT = String(FAKE_NANOBOT_PORT);
+
+  fakeNanoBot = http.createServer((req, res) => {
+    if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        if (typeof nanoBotResponder === 'function') {
+          nanoBotResponder(req, res, body);
+        } else {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: { message: 'No responder set' } }));
+        }
+      });
+    } else {
+      res.statusCode = 404;
+      res.end();
+    }
+  });
+  await new Promise((resolve) => fakeNanoBot.listen(FAKE_NANOBOT_PORT, '127.0.0.1', resolve));
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => setTimeout(r, 300));
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+  if (fakeNanoBot) await new Promise((resolve) => fakeNanoBot.close(resolve));
+});
+
+beforeEach(async () => {
+  nanoBotResponder = null;
+  for (const name of ['ChatSession', 'LlmUsage']) {
+    if (mongoose.models[name]) await mongoose.models[name].deleteMany({});
+  }
+});
+
+async function waitForRow(channel, timeoutMs = 1500) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const c = await mongoose.model('LlmUsage').countDocuments({ channel });
+    if (c > 0) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+describe('generateTitle — auto-title LLMUsage capture (#98 C5)', () => {
+  test('non-streaming response usage → LlmUsage row with channel=ask-ola-autotitle', async () => {
+    nanoBotResponder = (_req, res, _body) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        id: 'chatcmpl-fake-title',
+        object: 'chat.completion',
+        model: 'gemini-3.1-flash-lite-preview',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Order Status Inquiry' },
+          finish_reason: 'stop',
+        }],
+        usage: FRAME_USAGE,
+      }));
+    };
+
+    const ChatSession = mongoose.model('ChatSession');
+    const session = await ChatSession.create({
+      userId: adminId,
+      nanobotSessionId: 'user:test:conv:title-1',
+      title: 'New Chat',
+      createdBy: adminId,
+    });
+
+    const { __test__ } = require(
+      path.join(BACKEND_ROOT, 'src/controllers/appControllers/olaController/chat')
+    );
+    __test__.generateTitle(session, [
+      { role: 'user', content: 'where is my order?' },
+      { role: 'assistant', content: 'order Q-1234 ships tomorrow' },
+    ], adminId);
+
+    await waitForRow('ask-ola-autotitle');
+
+    const rows = await mongoose.model('LlmUsage').find({}).lean();
+    expect(rows).toHaveLength(1);
+    const r = rows[0];
+    expect(r.channel).toBe('ask-ola-autotitle');
+    expect(r.userId.toString()).toBe(adminId.toString());
+    expect(r.sessionId.toString()).toBe(session._id.toString());
+    expect(r.provider).toBe('gemini');
+    expect(r.model).toBe('gemini-3.1-flash-lite-preview');
+    expect(r.inputTokens).toBe(240);
+    expect(r.outputTokens).toBe(12);
+    expect(r.totalTokens).toBe(252);
+    expect(r.iterations).toBe(1);
+    expect(r.costUsd).toBeGreaterThan(0);
+    expect(r.requestId).toBeTruthy();
+    expect(r.messageId).toBeNull();
+  });
+
+  test('non-streaming response WITHOUT usage → no LlmUsage row (legacy nanobot)', async () => {
+    nanoBotResponder = (_req, res, _body) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      // Pre-N4 nanobot: response body does not include `usage` field at all
+      res.end(JSON.stringify({
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Some Title' },
+          finish_reason: 'stop',
+        }],
+      }));
+    };
+
+    const ChatSession = mongoose.model('ChatSession');
+    const session = await ChatSession.create({
+      userId: adminId,
+      nanobotSessionId: 'user:test:conv:title-2',
+      title: 'New Chat',
+      createdBy: adminId,
+    });
+
+    const { __test__ } = require(
+      path.join(BACKEND_ROOT, 'src/controllers/appControllers/olaController/chat')
+    );
+    __test__.generateTitle(session, [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+    ], adminId);
+
+    // Wait briefly to confirm no row materializes
+    await new Promise((r) => setTimeout(r, 400));
+    expect(await mongoose.model('LlmUsage').countDocuments({})).toBe(0);
+  });
+
+  test('non-streaming response with zero-usage placeholder → no LlmUsage row', async () => {
+    // Pre-N4 nanobot's hardcoded {0,0,0} placeholder must be skipped
+    // (totalTokens=0 short-circuit in recordUsage).
+    nanoBotResponder = (_req, res, _body) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        choices: [{ index: 0, message: { role: 'assistant', content: 'T' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      }));
+    };
+
+    const ChatSession = mongoose.model('ChatSession');
+    const session = await ChatSession.create({
+      userId: adminId,
+      nanobotSessionId: 'user:test:conv:title-3',
+      title: 'New Chat',
+      createdBy: adminId,
+    });
+
+    const { __test__ } = require(
+      path.join(BACKEND_ROOT, 'src/controllers/appControllers/olaController/chat')
+    );
+    __test__.generateTitle(session, [{ role: 'user', content: 'q' }], adminId);
+
+    await new Promise((r) => setTimeout(r, 400));
+    expect(await mongoose.model('LlmUsage').countDocuments({})).toBe(0);
+  });
+
+  test('non-streaming response usage missing provider → no LlmUsage row, console.error fires', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    nanoBotResponder = (_req, res, _body) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      // usage exists but lacks provider — wire-contract violation
+      res.end(JSON.stringify({
+        choices: [{ index: 0, message: { role: 'assistant', content: 'T' }, finish_reason: 'stop' }],
+        usage: { model: 'gemini-flash', prompt_tokens: 100, completion_tokens: 10, total_tokens: 110 },
+      }));
+    };
+
+    const ChatSession = mongoose.model('ChatSession');
+    const session = await ChatSession.create({
+      userId: adminId,
+      nanobotSessionId: 'user:test:conv:title-4',
+      title: 'New Chat',
+      createdBy: adminId,
+    });
+
+    const { __test__ } = require(
+      path.join(BACKEND_ROOT, 'src/controllers/appControllers/olaController/chat')
+    );
+    __test__.generateTitle(session, [{ role: 'user', content: 'q' }], adminId);
+
+    await new Promise((r) => setTimeout(r, 400));
+    expect(await mongoose.model('LlmUsage').countDocuments({})).toBe(0);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('frame missing provider/model'),
+    );
+    errSpy.mockRestore();
+  });
+});

--- a/backend/test/llmUsage.chat.test.js
+++ b/backend/test/llmUsage.chat.test.js
@@ -108,10 +108,24 @@ function nanoTextChunk(content) {
   };
   return `data: ${JSON.stringify(payload)}\n\n`;
 }
+// =============================================================================
+// WIRE CONTRACT — keep in lockstep with nanobot/api/server.py:_sse_usage
+// =============================================================================
+// This MUST mirror what real nanobot emits 1:1. If schema drifts, the real-
+// stack integration test (backend/test/integration/test_llm_usage.sh) will
+// fail and silently let bad rows land in mongo. Don't mock around it; fix
+// either side until the contract holds.
+// Required keys: provider, model, prompt_tokens, completion_tokens,
+// total_tokens, iterations. Optional: cached_tokens (default 0).
+const FRAME_META = {
+  provider: 'gemini',
+  model: 'gemini-3.1-flash-lite-preview',
+};
 function nanoUsageFrame(usage) {
-  // Matches _sse_usage in nanobot/api/server.py — flat object, "iterations"
-  // sibling field. CRM olaController/chat.js stores the entire JSON dict.
-  return `event: usage\ndata: ${JSON.stringify(usage)}\n\n`;
+  // Spreads FRAME_META so every test gets the wire-required provider/model
+  // unless it's explicitly testing a missing/empty case (in which case it
+  // should pass an object that overrides them).
+  return `event: usage\ndata: ${JSON.stringify({ ...FRAME_META, ...usage })}\n\n`;
 }
 const NANO_DONE = `data: [DONE]\n\n`;
 
@@ -337,6 +351,36 @@ describe('chat — graceful fallback when NanoBot does not emit usage', () => {
     const r = await mongoose.model('LlmUsage').findOne({}).lean();
     expect(r).toBeTruthy();
     expect(r.totalTokens).toBe(150);
+  });
+
+  test('frame missing provider field → no LLMUsage row, console.error fires', async () => {
+    // Wire-contract enforcement (#98 C3): a malformed frame missing the
+    // required `provider` field is rejected by recordUsage, so no row lands
+    // in mongo. This guards against silently writing rows with default
+    // provider values when nanobot ever rolls back to a version that
+    // doesn't emit the field.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('reply'));
+      // Bypass the FRAME_META spread by constructing the frame directly.
+      res.write(`event: usage\ndata: ${JSON.stringify({
+        model: 'gemini-3.1-flash-lite-preview',  // provider intentionally missing
+        prompt_tokens: 100, completion_tokens: 50, total_tokens: 150, iterations: 1,
+      })}\n\n`);
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await mongoose.model('LlmUsage').countDocuments({})).toBe(0);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('frame missing provider/model'),
+    );
+    errSpy.mockRestore();
   });
 });
 

--- a/backend/test/llmUsage.chat.test.js
+++ b/backend/test/llmUsage.chat.test.js
@@ -1,0 +1,404 @@
+/**
+ * Integration tests for olaController/chat.js LLMUsage capture (Ola issue #98).
+ *
+ * Mirrors the exact pattern of olaController.chat.test.js — fake NanoBot
+ * HTTP server on port 18901 (different from chat.test's 18900 so they could
+ * run in parallel; jest runs serially by default, but the separate port is
+ * defensive). Sends SSE responses that include or omit `event: usage` frames
+ * and verifies that:
+ *   - chat.js parses the usage frame correctly
+ *   - finishStream triggers a fire-and-forget recordUsage call
+ *   - LLMUsage rows in mongo match expectations
+ *   - Missing / malformed usage frames don't break the chat path (legacy
+ *     nanobot compatibility)
+ *
+ * Unit tests for the pricing math and recordUsage skip rules live in
+ *   backend/test/llmPricing.test.js
+ *   backend/test/llmUsageController.test.js
+ *
+ * End-to-end real-stack tests (cookie + real NanoBot + Gemini) live at
+ *   backend/test/integration/test_llm_usage.sh
+ */
+
+const path = require('path');
+const http = require('http');
+const express = require('express');
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { globSync } = require('glob');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+const adminId = new mongoose.Types.ObjectId();
+const FAKE_NANOBOT_PORT = 18901;
+
+let mongo;
+let fakeNanoBot;
+let nanoBotResponder = null;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+
+  process.env.NANOBOT_HOST = '127.0.0.1';
+  process.env.NANOBOT_PORT = String(FAKE_NANOBOT_PORT);
+
+  fakeNanoBot = http.createServer((req, res) => {
+    if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        if (typeof nanoBotResponder === 'function') {
+          nanoBotResponder(req, res);
+        } else {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: { message: 'No responder set' } }));
+        }
+      });
+    } else {
+      res.statusCode = 404;
+      res.end();
+    }
+  });
+  await new Promise((resolve) => fakeNanoBot.listen(FAKE_NANOBOT_PORT, '127.0.0.1', resolve));
+}, 120000);
+
+afterAll(async () => {
+  // Wait for fire-and-forget LLMUsage / ChatMessage writes to settle before
+  // tearing mongo down (otherwise their .catch logs noise).
+  await new Promise((r) => setTimeout(r, 300));
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+  if (fakeNanoBot) await new Promise((resolve) => fakeNanoBot.close(resolve));
+});
+
+beforeEach(async () => {
+  nanoBotResponder = null;
+  for (const name of ['ChatSession', 'ChatMessage', 'LlmUsage']) {
+    if (mongoose.models[name]) await mongoose.models[name].deleteMany({});
+  }
+});
+
+function buildChatApp() {
+  const chat = require(
+    path.join(BACKEND_ROOT, 'src/controllers/appControllers/olaController/chat')
+  );
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.admin = { _id: adminId };
+    next();
+  });
+  app.post('/api/ola/chat', (req, res) => chat(req, res));
+  return app;
+}
+
+// SSE frame helpers — mirror what nanobot/api/server.py produces.
+function nanoTextChunk(content) {
+  const payload = {
+    id: 'chatcmpl-test',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'm',
+    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+  };
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+function nanoUsageFrame(usage) {
+  // Matches _sse_usage in nanobot/api/server.py — flat object, "iterations"
+  // sibling field. CRM olaController/chat.js stores the entire JSON dict.
+  return `event: usage\ndata: ${JSON.stringify(usage)}\n\n`;
+}
+const NANO_DONE = `data: [DONE]\n\n`;
+
+function startSSE(res) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+}
+
+// Wait for fire-and-forget writes (recordUsage + ChatMessage.insertMany run
+// in parallel after the response stream ends).
+async function waitForWrites(timeoutMs = 1000) {
+  await new Promise((r) => setTimeout(r, 100));
+  // Poll every 50ms until LlmUsage has at least 1 row OR timeout. This avoids
+  // flaky waits — we only proceed once mongo actually saw the write, or
+  // confirmed it's not coming.
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const c = await mongoose.model('LlmUsage').countDocuments({});
+    if (c > 0) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+// ===========================================================================
+// Happy path — usage frame → LLMUsage row written
+// ===========================================================================
+
+describe('chat — captures NanoBot usage frame and persists to LLMUsage', () => {
+  test('usage SSE frame triggers a fire-and-forget LLMUsage write with all fields', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('Hello'));
+      res.write(nanoTextChunk(' world'));
+      res.write(nanoUsageFrame({
+        prompt_tokens: 1234,
+        completion_tokens: 567,
+        total_tokens: 1801,
+        cached_tokens: 50,
+        iterations: 1,
+      }));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    expect(res.status).toBe(200);
+
+    await waitForWrites();
+    const LlmUsage = mongoose.model('LlmUsage');
+    const rows = await LlmUsage.find({}).lean();
+    expect(rows).toHaveLength(1);
+    const r = rows[0];
+    expect(r.userId.toString()).toBe(adminId.toString());
+    expect(r.inputTokens).toBe(1234);
+    expect(r.outputTokens).toBe(567);
+    expect(r.totalTokens).toBe(1801);
+    expect(r.cachedTokens).toBe(50);
+    expect(r.iterations).toBe(1);
+    expect(r.errored).toBe(false);
+    expect(r.costUsd).toBeGreaterThan(0);
+    expect(r.channel).toBe('ask-ola');
+    expect(r.provider).toBe('gemini');
+    expect(r.model).toBe('gemini-3.1-flash-lite-preview');
+    expect(r.requestId).toBeTruthy();
+    expect(r.nanobotSessionId).toBeTruthy();
+    expect(r.latencyMs).toBeGreaterThanOrEqual(0);
+    // messageId should be plumbed from the inserted assistant ChatMessage.
+    expect(r.messageId).toBeTruthy();
+  });
+
+  test('messageId on LLMUsage row matches the assistant ChatMessage _id', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('Reply'));
+      res.write(nanoUsageFrame({
+        prompt_tokens: 500, completion_tokens: 100, total_tokens: 600, iterations: 1,
+      }));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    await request(app).post('/api/ola/chat').send({ message: 'q' });
+    await waitForWrites();
+
+    const ChatMessage = mongoose.model('ChatMessage');
+    const LlmUsage = mongoose.model('LlmUsage');
+    const assistantMsg = await ChatMessage.findOne({ role: 'assistant' }).lean();
+    const usageRow = await LlmUsage.findOne({}).lean();
+
+    expect(assistantMsg).toBeTruthy();
+    expect(usageRow.messageId.toString()).toBe(assistantMsg._id.toString());
+  });
+
+  test('iterations >= 2 is preserved on a tool-using turn', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(`event: tool_event\ndata: ${JSON.stringify({
+        version: 1, phase: 'start', call_id: 'c1',
+        name: 'mcp_ola_crm_quote.create', arguments: {},
+      })}\n\n`);
+      res.write(`event: tool_event\ndata: ${JSON.stringify({
+        version: 1, phase: 'end', call_id: 'c1',
+        name: 'mcp_ola_crm_quote.create',
+        result: '{"ok":true,"data":{"_id":"abc","number":"Q-1"}}',
+      })}\n\n`);
+      res.write(nanoTextChunk('Done'));
+      res.write(nanoUsageFrame({
+        prompt_tokens: 5000, completion_tokens: 800, total_tokens: 5800, iterations: 2,
+      }));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    await request(app).post('/api/ola/chat').send({ message: 'create a quote' });
+    await waitForWrites();
+
+    const r = await mongoose.model('LlmUsage').findOne({}).lean();
+    expect(r.iterations).toBe(2);
+  });
+
+  test('two consecutive chats produce two LLMUsage rows with independent requestIds', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('a'));
+      res.write(nanoUsageFrame({
+        prompt_tokens: 10, completion_tokens: 5, total_tokens: 15, iterations: 1,
+      }));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    await request(app).post('/api/ola/chat').send({ message: 'one' });
+    await waitForWrites();
+    await request(app).post('/api/ola/chat').send({ message: 'two' });
+    await waitForWrites(2000);
+
+    const rows = await mongoose.model('LlmUsage').find({}).lean();
+    expect(rows).toHaveLength(2);
+    const ids = rows.map((r) => r.requestId);
+    expect(new Set(ids).size).toBe(2); // unique
+  });
+});
+
+// ===========================================================================
+// Cross-version compatibility — graceful degradation
+// ===========================================================================
+
+describe('chat — graceful fallback when NanoBot does not emit usage', () => {
+  test('legacy NanoBot (no event:usage) → chat succeeds, NO LLMUsage row written', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('legacy reply'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    expect(res.status).toBe(200);
+
+    // Wait briefly for any potential write attempt, then confirm no row.
+    await new Promise((r) => setTimeout(r, 300));
+    const count = await mongoose.model('LlmUsage').countDocuments({});
+    expect(count).toBe(0);
+
+    // Chat persistence must still happen on this path (verifies the legacy
+    // fallback only affects telemetry, not the user-visible behavior).
+    const msgCount = await mongoose.model('ChatMessage').countDocuments({});
+    expect(msgCount).toBe(2);
+  });
+
+  test('malformed usage frame JSON → chat succeeds, NO LLMUsage row, no crash', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('reply'));
+      // Bad JSON in the data line. chat.js should JSON.parse → catch → no-op.
+      res.write(`event: usage\ndata: {not valid json\n\n`);
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await mongoose.model('LlmUsage').countDocuments({})).toBe(0);
+  });
+
+  test('usage frame with totalTokens=0 → no LLMUsage row (no real LLM call)', async () => {
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoTextChunk('cached fallback'));
+      res.write(nanoUsageFrame({
+        prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, iterations: 0,
+      }));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    const res = await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await mongoose.model('LlmUsage').countDocuments({})).toBe(0);
+  });
+
+  test('usage frame BEFORE [DONE] but AFTER text → still captured', async () => {
+    // Production NanoBot emits usage right before [DONE]. This test
+    // confirms ordering doesn't depend on whether usage comes mid-stream.
+    nanoBotResponder = (_req, res) => {
+      startSSE(res);
+      res.write(nanoUsageFrame({
+        prompt_tokens: 100, completion_tokens: 50, total_tokens: 150, iterations: 1,
+      }));
+      res.write(nanoTextChunk('ok'));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    await request(app).post('/api/ola/chat').send({ message: 'hi' });
+    await waitForWrites();
+
+    const r = await mongoose.model('LlmUsage').findOne({}).lean();
+    expect(r).toBeTruthy();
+    expect(r.totalTokens).toBe(150);
+  });
+});
+
+// ===========================================================================
+// Error path — upstream NanoBot 5xx must NOT write LLMUsage (no real LLM call)
+// ===========================================================================
+
+describe('chat — upstream errors suppress LLMUsage writes', () => {
+  test('NanoBot returns 503 → no LLMUsage row (no real LLM cost incurred)', async () => {
+    nanoBotResponder = (_req, res) => {
+      res.statusCode = 503;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: { message: 'busy' } }));
+    };
+    const app = buildChatApp();
+    await request(app).post('/api/ola/chat').send({ message: 'hi' });
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await mongoose.model('LlmUsage').countDocuments({})).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Concurrency safety — no cross-request bleed (issue #98 motivation)
+// ===========================================================================
+
+describe('chat — concurrent requests do not cross-pollute usage data', () => {
+  test('two parallel chats with different usage values both write correct rows', async () => {
+    // Each request gets its own usage values. The whole reason we threaded
+    // on_run_complete through nanobot's loop instead of relying on the
+    // shared self._last_usage was to make this case correct. If shared state
+    // bled, both rows might end up with the same numbers.
+    let callCount = 0;
+    nanoBotResponder = (_req, res) => {
+      const myCall = ++callCount;
+      startSSE(res);
+      res.write(nanoTextChunk(`response-${myCall}`));
+      res.write(nanoUsageFrame({
+        prompt_tokens: myCall * 1000,
+        completion_tokens: myCall * 100,
+        total_tokens: myCall * 1100,
+        iterations: 1,
+      }));
+      res.write(NANO_DONE);
+      res.end();
+    };
+    const app = buildChatApp();
+    await Promise.all([
+      request(app).post('/api/ola/chat').send({ message: 'one' }),
+      request(app).post('/api/ola/chat').send({ message: 'two' }),
+    ]);
+    await waitForWrites(2500);
+    // Allow a beat for the second insert.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const rows = await mongoose.model('LlmUsage').find({}).sort({ inputTokens: 1 }).lean();
+    expect(rows).toHaveLength(2);
+    expect(rows[0].inputTokens).toBe(1000);
+    expect(rows[0].outputTokens).toBe(100);
+    expect(rows[1].inputTokens).toBe(2000);
+    expect(rows[1].outputTokens).toBe(200);
+    // requestIds must differ (independent uuid per request).
+    expect(rows[0].requestId).not.toBe(rows[1].requestId);
+  });
+});

--- a/backend/test/llmUsageController.test.js
+++ b/backend/test/llmUsageController.test.js
@@ -128,6 +128,15 @@ const userId = new mongoose.Types.ObjectId();
 const sessionId = new mongoose.Types.ObjectId();
 const session = { _id: sessionId, nanobotSessionId: 'user:test:conv:abc' };
 
+// Default wire-frame metadata. Mirrors what nanobot/api/server.py:_sse_usage
+// emits for the current Ask Ola configuration. Tests spread this into their
+// usage objects so the recordUsage hard-fail-on-missing-provider/model
+// (Ola CRM #98) doesn't fire on happy-path cases.
+const FRAME_META = {
+  provider: 'gemini',
+  model: 'gemini-3.1-flash-lite-preview',
+};
+
 describe('recordUsage — happy path', () => {
   test('persists a complete LlmUsage doc with computed costUsd > 0', async () => {
     await recordUsage({
@@ -135,6 +144,7 @@ describe('recordUsage — happy path', () => {
       session,
       messageId: null,
       usage: {
+        ...FRAME_META,
         prompt_tokens: 1500,
         completion_tokens: 400,
         total_tokens: 1900,
@@ -172,7 +182,7 @@ describe('recordUsage — happy path', () => {
       userId,
       session,
       messageId,
-      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      usage: { ...FRAME_META, prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
       latencyMs: 200,
       requestId: 'req-msg-id',
     });
@@ -184,7 +194,7 @@ describe('recordUsage — happy path', () => {
     await recordUsage({
       userId,
       session,
-      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      usage: { ...FRAME_META, prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
       latencyMs: 100,
       requestId: 'req-errored',
       errored: true,
@@ -197,7 +207,7 @@ describe('recordUsage — happy path', () => {
     await recordUsage({
       userId,
       session,
-      usage: { prompt_tokens: 200, completion_tokens: 80 }, // no total_tokens
+      usage: { ...FRAME_META, prompt_tokens: 200, completion_tokens: 80 }, // no total_tokens
       latencyMs: 50,
       requestId: 'req-total-derived',
     });
@@ -210,7 +220,7 @@ describe('recordUsage — happy path', () => {
       userId,
       session,
       usage: {
-        prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
+        ...FRAME_META, prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
         // no iterations
       },
       latencyMs: 50,
@@ -247,7 +257,7 @@ describe('recordUsage — skip rules (no-op, no row written)', () => {
     await recordUsage({
       userId,
       session,
-      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      usage: { ...FRAME_META, prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
       latencyMs: 50,
       requestId: 'skip-zero-total',
     });
@@ -258,7 +268,7 @@ describe('recordUsage — skip rules (no-op, no row written)', () => {
     await recordUsage({
       userId,
       session: null,
-      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      usage: { ...FRAME_META, prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
       latencyMs: 100,
       requestId: 'skip-no-session',
     });
@@ -288,7 +298,7 @@ describe('recordUsage — fail-silent on persistence errors', () => {
       await recordUsage({
         userId: 'not-an-id',
         session,
-        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        usage: { ...FRAME_META, prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
         latencyMs: 100,
         requestId: 'fail-cast',
       });
@@ -312,6 +322,7 @@ describe('recordUsage — costUsd reflects llmPricing.calcCost', () => {
       userId,
       session,
       usage: {
+        ...FRAME_META,
         prompt_tokens: 2_000,
         completion_tokens: 800,
         total_tokens: 2_800,
@@ -325,5 +336,128 @@ describe('recordUsage — costUsd reflects llmPricing.calcCost', () => {
       inputTokens: 2_000, outputTokens: 800, cachedTokens: 500,
     });
     expect(r.costUsd).toBeCloseTo(expected, 12);
+  });
+});
+
+// ===========================================================================
+// Wire-contract enforcement — provider/model come from the frame, not env.
+// Hard-fail on missing fields; errored=true on unknown pricing.
+// (Ola CRM #98 N4 / decisions §3 — no silent error)
+// ===========================================================================
+
+describe('recordUsage — wire schema enforcement (#98)', () => {
+  test('missing provider in frame → no row written, console.error fires', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await recordUsage({
+      userId,
+      session,
+      usage: {
+        // provider intentionally absent
+        model: 'gemini-3.1-flash-lite-preview',
+        prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
+      },
+      latencyMs: 100,
+      requestId: 'reject-no-provider',
+    });
+    expect(await LlmUsage.countDocuments({ requestId: 'reject-no-provider' })).toBe(0);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('frame missing provider/model'),
+    );
+    errSpy.mockRestore();
+  });
+
+  test('missing model in frame → no row written, console.error fires', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await recordUsage({
+      userId,
+      session,
+      usage: {
+        provider: 'gemini',
+        // model intentionally absent
+        prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
+      },
+      latencyMs: 100,
+      requestId: 'reject-no-model',
+    });
+    expect(await LlmUsage.countDocuments({ requestId: 'reject-no-model' })).toBe(0);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('frame missing provider/model'),
+    );
+    errSpy.mockRestore();
+  });
+
+  test('empty-string provider treated as missing → skip', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await recordUsage({
+      userId,
+      session,
+      usage: {
+        provider: '',
+        model: 'gemini-3.1-flash-lite-preview',
+        prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
+      },
+      latencyMs: 100,
+      requestId: 'reject-empty-provider',
+    });
+    expect(await LlmUsage.countDocuments({ requestId: 'reject-empty-provider' })).toBe(0);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  test('unknown provider:model → 1 row written with errored=true, costUsd=0', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await recordUsage({
+      userId,
+      session,
+      usage: {
+        provider: 'fakeprovider',
+        model: 'unknown-model-2099',
+        prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
+      },
+      latencyMs: 100,
+      requestId: 'unknown-pricing',
+    });
+    const r = await LlmUsage.findOne({ requestId: 'unknown-pricing' }).lean();
+    expect(r).not.toBeNull();
+    expect(r.errored).toBe(true);
+    expect(r.costUsd).toBe(0);
+    expect(r.provider).toBe('fakeprovider');
+    expect(r.model).toBe('unknown-model-2099');
+    // Token counts still preserved for analytics
+    expect(r.inputTokens).toBe(100);
+    expect(r.outputTokens).toBe(50);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unknown pricing for fakeprovider:unknown-model-2099'),
+    );
+    errSpy.mockRestore();
+  });
+
+  test('frame provider/model are used verbatim — env vars are ignored', async () => {
+    // Set env vars to obviously-wrong values; frame should win.
+    const origProvider = process.env.NANOBOT_PROVIDER;
+    const origModel = process.env.NANOBOT_MODEL;
+    process.env.NANOBOT_PROVIDER = 'WRONG_PROVIDER_FROM_ENV';
+    process.env.NANOBOT_MODEL = 'wrong-model-from-env';
+    try {
+      await recordUsage({
+        userId,
+        session,
+        usage: {
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
+        },
+        latencyMs: 100,
+        requestId: 'env-ignored',
+      });
+      const r = await LlmUsage.findOne({ requestId: 'env-ignored' }).lean();
+      expect(r.provider).toBe('openai');
+      expect(r.model).toBe('gpt-4o-mini');
+      expect(r.errored).toBe(false); // openai:gpt-4o-mini is in PRICING table
+      expect(r.costUsd).toBeGreaterThan(0);
+    } finally {
+      process.env.NANOBOT_PROVIDER = origProvider;
+      process.env.NANOBOT_MODEL = origModel;
+    }
   });
 });

--- a/backend/test/llmUsageController.test.js
+++ b/backend/test/llmUsageController.test.js
@@ -1,0 +1,329 @@
+/**
+ * Tests for llmUsageController (Ola issue #98).
+ *
+ * Covers:
+ *   1. denyWrite — create/update/delete return 403 with the documented Chinese
+ *      message (LLMUsage rows are system-internal; external mutation is not
+ *      allowed even with admin auth).
+ *   2. recordUsage — internal helper invoked by olaController/chat.js after
+ *      each Ask Ola turn:
+ *        - Happy path persists a complete LlmUsage doc with computed costUsd
+ *        - Skips quietly on null/empty usage, totalTokens=0
+ *        - Survives mongo write errors silently (fail-silent — never throws)
+ *
+ * Pattern mirrors paginatedList.test.js: mongodb-memory-server + mongoose
+ * model autoload. No HTTP layer needed for denyWrite (we call the controller
+ * methods directly with a stub res), keeping these tests fast (<200ms each).
+ */
+
+const path = require('path');
+const { globSync } = require('glob');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+
+let mongo;
+let llmController;
+let recordUsage;
+let LlmUsage;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+
+  llmController = require(
+    path.join(BACKEND_ROOT, 'src/controllers/appControllers/llmUsageController')
+  );
+  recordUsage = require(
+    path.join(BACKEND_ROOT, 'src/controllers/appControllers/llmUsageController/recordUsage')
+  );
+  LlmUsage = mongoose.model('LlmUsage');
+}, 120000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  await LlmUsage.deleteMany({});
+});
+
+// Stub Express res with status() + json() chainable. Captures the call so we
+// can assert on it.
+function stubRes() {
+  const res = {
+    _status: null,
+    _body: null,
+    status(s) { this._status = s; return this; },
+    json(b) { this._body = b; return this; },
+  };
+  return res;
+}
+
+// ===========================================================================
+// denyWrite — create / update / delete must return 403 even from admin
+// ===========================================================================
+
+describe('llmUsageController — denyWrite (system-internal collection)', () => {
+  test('controller exports the standard CRUD method set + recordUsage', () => {
+    const expected = [
+      'create', 'read', 'update', 'delete',
+      'list', 'listAll', 'search', 'filter', 'summary',
+      'recordUsage',
+    ].sort();
+    expect(Object.keys(llmController).sort()).toEqual(expected);
+  });
+
+  test('create returns 403 with success:false and Chinese message', () => {
+    const res = stubRes();
+    llmController.create({}, res);
+    expect(res._status).toBe(403);
+    expect(res._body.success).toBe(false);
+    expect(res._body.result).toBeNull();
+    expect(res._body.message).toBe('LLMUsage 写入仅限系统内部');
+  });
+
+  test('update returns 403 — same envelope as create', () => {
+    const res = stubRes();
+    llmController.update({}, res);
+    expect(res._status).toBe(403);
+    expect(res._body.success).toBe(false);
+    expect(res._body.message).toBe('LLMUsage 写入仅限系统内部');
+  });
+
+  test('delete returns 403 — even with a valid ObjectId', () => {
+    const res = stubRes();
+    llmController.delete(
+      { params: { id: new mongoose.Types.ObjectId().toString() } },
+      res
+    );
+    expect(res._status).toBe(403);
+    expect(res._body.success).toBe(false);
+  });
+
+  test('read/list/listAll/summary are NOT blocked (will be wired to dashboard)', () => {
+    // We just confirm they are functions (the real implementations come from
+    // createCRUDController and are tested separately). If denyWrite ever
+    // accidentally clobbers a read path, this catches it.
+    expect(typeof llmController.read).toBe('function');
+    expect(typeof llmController.list).toBe('function');
+    expect(typeof llmController.listAll).toBe('function');
+    expect(typeof llmController.summary).toBe('function');
+    expect(typeof llmController.search).toBe('function');
+    expect(typeof llmController.filter).toBe('function');
+  });
+});
+
+// ===========================================================================
+// recordUsage — the internal write path
+// ===========================================================================
+
+const userId = new mongoose.Types.ObjectId();
+const sessionId = new mongoose.Types.ObjectId();
+const session = { _id: sessionId, nanobotSessionId: 'user:test:conv:abc' };
+
+describe('recordUsage — happy path', () => {
+  test('persists a complete LlmUsage doc with computed costUsd > 0', async () => {
+    await recordUsage({
+      userId,
+      session,
+      messageId: null,
+      usage: {
+        prompt_tokens: 1500,
+        completion_tokens: 400,
+        total_tokens: 1900,
+        cached_tokens: 100,
+        iterations: 2,
+      },
+      latencyMs: 1234,
+      requestId: 'req-test-001',
+      errored: false,
+    });
+
+    const docs = await LlmUsage.find({ requestId: 'req-test-001' }).lean();
+    expect(docs).toHaveLength(1);
+    const r = docs[0];
+    expect(r.userId.toString()).toBe(userId.toString());
+    expect(r.sessionId.toString()).toBe(sessionId.toString());
+    expect(r.nanobotSessionId).toBe('user:test:conv:abc');
+    expect(r.channel).toBe('ask-ola');
+    expect(r.provider).toBe('gemini');
+    expect(r.model).toBe('gemini-3.1-flash-lite-preview');
+    expect(r.inputTokens).toBe(1500);
+    expect(r.outputTokens).toBe(400);
+    expect(r.totalTokens).toBe(1900);
+    expect(r.cachedTokens).toBe(100);
+    expect(r.iterations).toBe(2);
+    expect(r.costUsd).toBeGreaterThan(0);
+    expect(r.latencyMs).toBe(1234);
+    expect(r.errored).toBe(false);
+    expect(r.pricingVersion).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('messageId is plumbed through when provided', async () => {
+    const messageId = new mongoose.Types.ObjectId();
+    await recordUsage({
+      userId,
+      session,
+      messageId,
+      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      latencyMs: 200,
+      requestId: 'req-msg-id',
+    });
+    const r = await LlmUsage.findOne({ requestId: 'req-msg-id' }).lean();
+    expect(r.messageId.toString()).toBe(messageId.toString());
+  });
+
+  test('errored=true persists alongside the otherwise-valid usage', async () => {
+    await recordUsage({
+      userId,
+      session,
+      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      latencyMs: 100,
+      requestId: 'req-errored',
+      errored: true,
+    });
+    const r = await LlmUsage.findOne({ requestId: 'req-errored' }).lean();
+    expect(r.errored).toBe(true);
+  });
+
+  test('totalTokens defaults to inputTokens + outputTokens when provider omits it', async () => {
+    await recordUsage({
+      userId,
+      session,
+      usage: { prompt_tokens: 200, completion_tokens: 80 }, // no total_tokens
+      latencyMs: 50,
+      requestId: 'req-total-derived',
+    });
+    const r = await LlmUsage.findOne({ requestId: 'req-total-derived' }).lean();
+    expect(r.totalTokens).toBe(280);
+  });
+
+  test('iterations defaults to 1 when nanobot omits it (legacy callers)', async () => {
+    await recordUsage({
+      userId,
+      session,
+      usage: {
+        prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
+        // no iterations
+      },
+      latencyMs: 50,
+      requestId: 'req-iter-default',
+    });
+    const r = await LlmUsage.findOne({ requestId: 'req-iter-default' }).lean();
+    expect(r.iterations).toBe(1);
+  });
+});
+
+describe('recordUsage — skip rules (no-op, no row written)', () => {
+  test('null usage → skips silently', async () => {
+    await recordUsage({
+      userId, session, usage: null, latencyMs: 100, requestId: 'skip-null',
+    });
+    expect(await LlmUsage.countDocuments({ requestId: 'skip-null' })).toBe(0);
+  });
+
+  test('undefined usage → skips silently', async () => {
+    await recordUsage({
+      userId, session, latencyMs: 100, requestId: 'skip-undef',
+    });
+    expect(await LlmUsage.countDocuments({ requestId: 'skip-undef' })).toBe(0);
+  });
+
+  test('empty object usage → skips silently', async () => {
+    await recordUsage({
+      userId, session, usage: {}, latencyMs: 100, requestId: 'skip-empty',
+    });
+    expect(await LlmUsage.countDocuments({ requestId: 'skip-empty' })).toBe(0);
+  });
+
+  test('totalTokens=0 → skips (safety net for "no real LLM call happened")', async () => {
+    await recordUsage({
+      userId,
+      session,
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      latencyMs: 50,
+      requestId: 'skip-zero-total',
+    });
+    expect(await LlmUsage.countDocuments({ requestId: 'skip-zero-total' })).toBe(0);
+  });
+
+  test('missing session → skips (cannot reference a turn without session id)', async () => {
+    await recordUsage({
+      userId,
+      session: null,
+      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      latencyMs: 100,
+      requestId: 'skip-no-session',
+    });
+    expect(await LlmUsage.countDocuments({ requestId: 'skip-no-session' })).toBe(0);
+  });
+
+  test('non-object usage (e.g. string) → skips silently, no throw', async () => {
+    let threw = false;
+    try {
+      await recordUsage({
+        userId, session, usage: 'garbage', latencyMs: 100, requestId: 'skip-str',
+      });
+    } catch { threw = true; }
+    expect(threw).toBe(false);
+    expect(await LlmUsage.countDocuments({ requestId: 'skip-str' })).toBe(0);
+  });
+});
+
+describe('recordUsage — fail-silent on persistence errors', () => {
+  test('mongo write error is swallowed (logged via console.error, not thrown)', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Force schema validation to fail by passing a malformed userId
+    // (LlmUsage.userId is required + ObjectId-typed; passing the literal
+    // string "not-an-id" makes Mongoose CastError out at create time).
+    let threw = false;
+    try {
+      await recordUsage({
+        userId: 'not-an-id',
+        session,
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        latencyMs: 100,
+        requestId: 'fail-cast',
+      });
+    } catch { threw = true; }
+    errSpy.mockRestore();
+
+    expect(threw).toBe(false);
+    expect(await LlmUsage.countDocuments({ requestId: 'fail-cast' })).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Cost-calculation correctness reaches the persisted row
+// ===========================================================================
+
+describe('recordUsage — costUsd reflects llmPricing.calcCost', () => {
+  test('costUsd matches the pure-function calculation for the same inputs', async () => {
+    const { calcCost } = require('@/constants/llmPricing');
+
+    await recordUsage({
+      userId,
+      session,
+      usage: {
+        prompt_tokens: 2_000,
+        completion_tokens: 800,
+        total_tokens: 2_800,
+        cached_tokens: 500,
+      },
+      latencyMs: 500,
+      requestId: 'cost-match',
+    });
+    const r = await LlmUsage.findOne({ requestId: 'cost-match' }).lean();
+    const expected = calcCost('gemini', 'gemini-3.1-flash-lite-preview', {
+      inputTokens: 2_000, outputTokens: 800, cachedTokens: 500,
+    });
+    expect(r.costUsd).toBeCloseTo(expected, 12);
+  });
+});

--- a/frontend/src/utils/isInternalUser.js
+++ b/frontend/src/utils/isInternalUser.js
@@ -1,0 +1,13 @@
+const rawEmails = import.meta.env.VITE_INTERNAL_DASHBOARD_EMAILS || '';
+
+const allowSet = new Set(
+  rawEmails
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean)
+);
+
+export default function isInternalUser(currentAdmin) {
+  if (!currentAdmin || !currentAdmin.email) return false;
+  return allowSet.has(String(currentAdmin.email).toLowerCase());
+}

--- a/frontend/src/utils/isInternalUser.test.js
+++ b/frontend/src/utils/isInternalUser.test.js
@@ -1,0 +1,43 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+describe('isInternalUser', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  test('returns true for email in allowlist', async () => {
+    vi.stubEnv('VITE_INTERNAL_DASHBOARD_EMAILS', 'a@x.com,b@x.com');
+    const { default: isInternalUser } = await import('./isInternalUser.js');
+    expect(isInternalUser({ email: 'a@x.com' })).toBe(true);
+    expect(isInternalUser({ email: 'b@x.com' })).toBe(true);
+  });
+
+  test('returns false for email not in allowlist', async () => {
+    vi.stubEnv('VITE_INTERNAL_DASHBOARD_EMAILS', 'a@x.com');
+    const { default: isInternalUser } = await import('./isInternalUser.js');
+    expect(isInternalUser({ email: 'b@x.com' })).toBe(false);
+  });
+
+  test('returns false for null/undefined/missing email', async () => {
+    vi.stubEnv('VITE_INTERNAL_DASHBOARD_EMAILS', 'a@x.com');
+    const { default: isInternalUser } = await import('./isInternalUser.js');
+    expect(isInternalUser(null)).toBe(false);
+    expect(isInternalUser(undefined)).toBe(false);
+    expect(isInternalUser({})).toBe(false);
+    expect(isInternalUser({ email: '' })).toBe(false);
+  });
+
+  test('matches case-insensitively', async () => {
+    vi.stubEnv('VITE_INTERNAL_DASHBOARD_EMAILS', 'A@X.COM, B@X.COM ');
+    const { default: isInternalUser } = await import('./isInternalUser.js');
+    expect(isInternalUser({ email: 'a@x.com' })).toBe(true);
+    expect(isInternalUser({ email: 'B@X.com' })).toBe(true);
+  });
+
+  test('fails closed when env is unset', async () => {
+    vi.stubEnv('VITE_INTERNAL_DASHBOARD_EMAILS', '');
+    const { default: isInternalUser } = await import('./isInternalUser.js');
+    expect(isInternalUser({ email: 'anyone@x.com' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

A previous attempt (`c9895e6 feat(askola): track LLMUsage per chat turn`) shipped the CRM half of the wire but depended on nanobot emitting `event: usage` SSE frames that nanobot never actually emitted (silent fail in production: 0 rows in mongo). This PR closes that gap with a coordinated two-repo fix.

**nanobot half (lives in ola-dev, see SeekMi-Technologies/Ola_bot — pushed atomically with this PR)**
- N1: `iterations` counter on `AgentRunResult`
- N2: `_last_usage` rebuilt as 7-field flat dict (provider/model/prompt_tokens/completion_tokens/total_tokens/cached_tokens/iterations)
- N3: streaming path emits `event: usage` SSE frame at end of every turn
- N4: non-streaming path surfaces real usage in response body (auto-title path uses this)

**CRM half (this PR)**
- C2: `recordUsage.js` reads provider/model/iterations from frame; hard-fails (skip + console.error) on missing fields; flags errored=true on unknown pricing instead of silent costUsd=0
- C3: jest fake nanobot frame mirrors real wire schema 1:1 with explicit doc-comment binding to `_sse_usage`
- C4: `test_llm_usage.sh` real-stack e2e accepts HTTP 203 (Ola CRM's empty-collection convention)
- C5: auto-title (non-streaming generateTitle call) tracked under `channel='ask-ola-autotitle'`

## Wire contract (locked between repos)

```
event: usage
data: {"provider":"gemini",
       "model":"gemini-3.1-flash-lite-preview",
       "prompt_tokens":1234,
       "completion_tokens":567,
       "total_tokens":1801,
       "cached_tokens":120,
       "iterations":2}
```

Frame ordering: `text* → tool_event* → usage → finish_chunk → [DONE]`

## Verification

- **CRM jest**: 179/179 pass (15 test suites including 3 new LLMUsage suites)
- **nanobot pytest**: 2332/2332 pass, 0 regression (4 new test files, 23 new cases)
- **Real-stack e2e** (`backend/test/integration/test_llm_usage.sh`): 6/6 scenarios pass
  - auth gate (401 unauth) ✓
  - denyWrite (403 + Chinese message) ✓
  - read endpoint (200/203) ✓
  - chat → row written, cost=$0.001-0.003, iterations=1 ✓
  - tool-using turn iterations≥2 ✓
  - 2-turn session triggers auto-title (ask-ola-autotitle row) ✓
- **Browser smoke test** (real Ask Ola UI): 5 conversations × 411k tokens = $0.032 cost recorded with full per-row provider/model/cached/iterations attribution; Gemini context caching observed reducing cost 67% across multi-turn sessions

## Decisions confirmed during /spec PLAN

1. Atomic two-repo deploy (nanobot ola-dev pushed in same window)
2. Auto-title scope included; channel='ask-ola-autotitle'
3. Unknown provider:model → `errored:true` + costUsd=0 + console.error (preserves token data, dashboard can flag)
4. Wire schema includes cached_tokens (gemini reports it natively)
5. Iterations counter does NOT bump on `_request_finalization_retry` (same logical turn)

## Out-of-scope findings (file separately if needed)

- Agent loop sometimes hits max_iterations=40 on simplified-Chinese product searches (e.g. "不锈钢"), incurring ~$0.025/turn. Wire still captures it correctly (iterations=40 surfaces accurately) but agent decision-making is a separate issue.
- `paginatedList` filters by `createdBy: req.admin._id` so owner-role can't see other users' rows. Future dashboard design needs to decide if owner gets view-all.
- `errored` flag dual-meaning: set by both LLM-stream-error and ChatMessage-persist-fail paths. Could split if dashboard needs to distinguish.

## Test plan
- [ ] Reviewer pulls branch, runs `npx jest --runInBand` → 179/179 green
- [ ] Reviewer reads `backend/src/controllers/appControllers/llmUsageController/recordUsage.js` for hard-fail / errored policy semantics
- [ ] Reviewer reads `backend/src/controllers/appControllers/olaController/chat.js` C5 auto-title block (lines around generateTitle)
- [ ] Atomic deploy with nanobot ola-dev SHA `8fd041b1` (containing N1-N4)