### PR TITLE
feat(ola): product versioning v1.5.0 + bilingual release log

### DIFF
--- a/frontend/src/pages/Settings/Settings.jsx
+++ b/frontend/src/pages/Settings/Settings.jsx
@@ -20,6 +20,7 @@ import {
 } from '@ant-design/icons';
 
 import useLanguage from '@/locale/useLanguage';
+import { VERSION } from '@/version';
 
 import SettingsProfile from './SettingsProfile';
 // === MVP-HIDDEN: 以下 Settings 子页面本轮不需要 ===
@@ -185,6 +186,7 @@ export default function Settings() {
               <LogoutOutlined />
               <span>Log Out</span>
             </button>
+            <div className="settings-sidebar-version">Ola v{VERSION}</div>
           </div>
         </div>
 

--- a/frontend/src/style/partials/settings.css
+++ b/frontend/src/style/partials/settings.css
@@ -3446,3 +3446,12 @@
   background: #fdfdfd;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.02);
 }
+
+.settings-sidebar-version {
+  margin-top: 10px;
+  text-align: center;
+  font-size: 11px;
+  color: #999;
+  letter-spacing: 0.3px;
+  user-select: none;
+}

--- a/frontend/src/version.js
+++ b/frontend/src/version.js
@@ -1,0 +1,2 @@
+export const VERSION = '1.5.0';
+export const RELEASED_AT = '2026-05-06';

--- a/ola/CHANGELOG.md
+++ b/ola/CHANGELOG.md
@@ -1,0 +1,96 @@
+# Ola — Release Log / 发布日志
+
+**Ola is the AI sales agent for foreign-trade businesses.** Lead to Quote, in Minutes.
+**Ola 是给外贸团队用的 AI 销售助手——从 Lead 到 Quote，几分钟搞定。**
+
+This log captures the changes a salesperson, a customer, or a partner would actually feel. Engineering-only changes are intentionally omitted.
+本日志只记录销售、客户、合作方能感受到的变化，纯工程改动不收录。
+
+The current version is shown inside the product under **Settings → sidebar footer**.
+当前版本号能在产品里直接看到：**Settings → 左侧边栏底部**。
+
+---
+
+## v1.5.0 — 2026-05-06
+
+**Email becomes a Lead-to-Quote channel.**
+
+- **Send Ola your inquiries.** Email or forward any customer inquiry to **`ola@olatech.ai`**. Ola reads it, identifies the products, and runs the Lead-to-Quote loop end-to-end. No copy-paste, no switching tabs.
+- **Quote PDF, in the chat.** Ask Ola can hand back a customer-ready Quote PDF directly in the conversation — one click to download and send.
+- **Account-scoped by default.** Every Ola action runs in the context of the salesperson who sent the request — the safety guarantee that makes the email channel and shared workspaces possible.
+
+**邮件成为 Lead-to-Quote 的新入口。**
+
+- **把询盘直接发给 Ola。** 给 **`ola@olatech.ai`** 发邮件，或者把客户的询盘转过去，Ola 会读邮件、认产品、把 Lead-to-Quote 一路跑完。不用复制粘贴，也不用切窗口。
+- **Quote PDF 当场给你。** Ask Ola 在对话里就能生成可发客户的 Quote PDF——下载好就能发出去。
+- **每个销售各管各的数据。** Ola 每次动作都按发起请求的销售身份来执行——所以邮件通道和团队共用都不会串号。
+
+---
+
+## v1.4.0 — 2026-05-02
+
+**Bilingual, per salesperson.**
+
+- **Each salesperson picks their language.** Ask Ola, quote drafts, and product copy switch between English and 中文 based on the salesperson's preference. Customer-facing output (a Quote PDF, an email reply) follows along.
+- **English-first by default** — matching Ola's foreign-trade customer base.
+
+**中英双语，每个销售用自己的语言。**
+
+- **跟着销售本人的语言切。** Ask Ola、Quote 草稿、产品文案都在英文和中文之间走；最后发给客户的 Quote PDF 和邮件回复也跟着走。
+- **默认英文优先**——外贸场景里 Ola 的用户大多面向英文客户。
+
+---
+
+## v1.3.0 — 2026-04-27
+
+**Lead-to-Quote, in plain sight.**
+
+- **You see Ola think.** Ask Ola streams its reasoning and tool calls live — searching merchandise, drafting a quote, pulling customer history — so the salesperson knows exactly what's happening before the reply lands.
+- **Quote preview in the chat.** A drafted quote shows up inline with a one-click PDF download. Hand it straight to the customer.
+
+**Lead-to-Quote，全程可见。**
+
+- **看 Ola 现场思考。** Ask Ola 把推理过程和工具调用都实时展开——查商品、起草 Quote、翻客户历史——结果出来之前你就知道它在做什么。
+- **Quote 在对话里直接预览。** 起草好的 Quote 就在对话里，一键下载 PDF，直接发给客户。
+
+---
+
+## v1.2.0 — 2026-04-20
+
+**A new home.**
+
+- **Ola is now live at `app.olatech.ai`.**
+- **Faster product entry.** Adding merchandise takes three required fields, not a long form — everything else can be filled in later.
+
+**换新家。**
+
+- **Ola 正式搬到 `app.olatech.ai`。**
+- **加商品更快。** 必填只剩三个字段，不再是一张长表，其它的之后再补。
+
+---
+
+## v1.1.0 — 2026-04-19
+
+**Brand identity.**
+
+- **Lead to Quote, in Minutes.** Login and onboarding lead with Ola's positioning and the new logo — the product's promise is visible from the first screen.
+
+**品牌正式亮相。**
+
+- **Lead to Quote, in Minutes。** 登录和注册的第一屏就是 Ola 的定位和新 logo——产品要做什么，第一眼就看到。
+
+---
+
+## v1.0.0 — 2026-04-19
+
+**Ola goes live.**
+
+- **The Lead-to-Quote loop, end-to-end.** A customer sends a WhatsApp inquiry. Ola extracts the product needs, matches them against your merchandise catalog, and helps the salesperson draft a Quote — leaving the price for the salesperson to fill. Ola never invents prices.
+- **Quote PDF, branded and ready to send.** Generated with your company logo, scoped to the salesperson's account, and formatted for a customer.
+- **Ask Ola, your sales agent.** A chat assistant powered by an internal AI runtime — the foundation that v1.1 through v1.5 build on.
+
+**Ola 正式上线。**
+
+- **Lead-to-Quote 全链路打通。** 客户在 WhatsApp 发来询盘，Ola 抽产品需求、匹配商品库、帮销售起草 Quote——价格留给销售自己填，Ola 不编价格。
+- **可直接发客户的 Quote PDF。** 自动带公司 logo，按销售账号隔离，开出来就能发。
+- **Ask Ola——你的销售 Agent。** 内部 AI 驱动的对话助手——v1.1 到 v1.5 都建在这上面。


### PR DESCRIPTION
## Summary

Establishes Ola's external versioning system, ships **v1.5.0** as the first user-visible version, and lands a bilingual (EN / 中文) release log walking back to v1.0.0.

## Changes

- **`frontend/src/version.js`** — single source of truth: `VERSION='1.5.0'`, `RELEASED_AT='2026-05-06'`.
- **Settings sidebar footer** — renders `Ola v1.5.0` under the Log Out button so customers and the team can see the live version.
- **`ola/CHANGELOG.md`** — bilingual feature-focused release log v1.0.0 → v1.5.0, agent-positioning throughout (Ola = AI sales agent for foreign-trade, never CRM/ERP). Written for LinkedIn / VCs / partners — engineering-only changes intentionally omitted.
- **v1.5 framing correction:** salesperson sends or forwards customer inquiries to `ola@olatech.ai` (not Ola monitoring inboxes).

## Versioning scheme

| Version | Date | Theme |
|---|---|---|
| v1.0.0 | 2026-04-19 | Ola goes live (Lead-to-Quote loop end-to-end) |
| v1.1.0 | 2026-04-19 | Brand identity — Lead to Quote, in Minutes |
| v1.2.0 | 2026-04-20 | A new home — `app.olatech.ai` |
| v1.3.0 | 2026-04-27 | Lead-to-Quote, in plain sight (live thinking + in-chat preview) |
| v1.4.0 | 2026-05-02 | Bilingual, per salesperson |
| **v1.5.0** | **2026-05-06** | **Email becomes a Lead-to-Quote channel** |

## To bump going forward

1. Edit `frontend/src/version.js` (`VERSION` + `RELEASED_AT`).
2. Add a new section to `ola/CHANGELOG.md`.
3. Settings footer updates automatically.

## Test plan

- [x] `cd frontend && npm run build` passes (verified locally, 2.89s)
- [x] Pre-commit code review checklist passed
- [ ] Visual check: Settings page sidebar shows `Ola v1.5.0` under Log Out

🤖 Generated with [Claude Code](https://claude.com/claude-code)