### PR TITLE
fix(#266): v1.7.0 audio pipeline — full environment-divergence fix (Bugs 1-6)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,6 +36,12 @@ NODE_ENV="development"
 OPENSSL_CONF="/dev/null"
 PUBLIC_SERVER_FILE="http://localhost:8888/"
 
+# #266 — environment gate. Local dev leaves this unset (or =dev). Production
+# Box1's backend/.env MUST set OLA_ENV=prod so start-dev.sh refuses to run
+# there (which would otherwise point local processes at the shared production
+# Atlas, polluting File.sourcePath with mac absolute paths). See start-dev.sh.
+# OLA_ENV="dev"
+
 # ------------------ Optional ------------------
 
 # Gotenberg (PDF rendering) — only needed when exporting Quote/Invoice PDFs.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,10 +2,14 @@ FROM node:20-alpine
 
 WORKDIR /usr/src/app
 
-# 安装中文字体，用于Gotenberg渲染PDF中的中文
+# 安装系统 deps:
+# - font-noto / font-noto-cjk: Gotenberg 渲染 PDF 中文
+# - ffmpeg: transcriptionWorker.js 把 >20MB 的音频压缩成 mono 16k MP3
+#   以 fit OpenAI gpt-4o-transcribe 的 25MB 上限 (#249 audio pipeline)
 RUN apk update && apk add --no-cache \
     font-noto \
-    font-noto-cjk
+    font-noto-cjk \
+    ffmpeg
 
 # 使用阿里云npm镜像
 RUN npm config set registry https://registry.npmmirror.com && \

--- a/backend/src/controllers/appControllers/fileController/getTranscript.js
+++ b/backend/src/controllers/appControllers/fileController/getTranscript.js
@@ -1,6 +1,8 @@
 const fs = require('fs').promises;
 const mongoose = require('mongoose');
 
+const { resolveUploadPath } = require('@/utils/uploadsPath');
+
 const FileModel = mongoose.model('File');
 const JobModel = mongoose.model('Job');
 
@@ -66,12 +68,26 @@ const getTranscript = async (req, res) => {
     });
   }
 
-  const sidecarPath = job.result?.sidecarPath;
-  if (!sidecarPath) {
+  const relativeSidecarPath = job.result?.sidecarPath;
+  if (!relativeSidecarPath) {
     return res.status(500).json({
       success: false,
       result: null,
       message: `Sidecar transcript 路径缺失 (${file.originalName}): job.result.sidecarPath empty`,
+    });
+  }
+  // #266: Job.result.sidecarPath stored as relative path; resolve to absolute
+  // for fs.readFile. resolveUploadPath() throws if the stored value is still
+  // absolute (un-migrated legacy doc) — that's intentional fail-fast, surfaces
+  // as a clear 500 instead of silently ENOENT on a wrong host's path.
+  let sidecarPath;
+  try {
+    sidecarPath = resolveUploadPath(relativeSidecarPath);
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      result: null,
+      message: `Sidecar transcript 路径无效 (${file.originalName}): ${err.message}`,
     });
   }
   let transcript;

--- a/backend/src/controllers/appControllers/fileController/upload.js
+++ b/backend/src/controllers/appControllers/fileController/upload.js
@@ -7,12 +7,10 @@ const mongoose = require('mongoose');
 
 const { uploadSchema, MAX_FILE_SIZE } = require('./schemaValidate');
 const transcribeWithOpenAI = require('@/jobs/transcriptionWorker');
+const { UPLOADS_DIR, resolveUploadPath } = require('@/utils/uploadsPath');
 
 const FileModel = mongoose.model('File');
 const JobModel = mongoose.model('Job');
-
-const UPLOADS_DIR =
-  process.env.UPLOADS_DIR || path.resolve(__dirname, '../../../../uploads');
 
 const multerHandler = multer({
   storage: multer.memoryStorage(),
@@ -106,12 +104,15 @@ const upload = async (req, res) => {
   const mm = String(now.getMonth() + 1).padStart(2, '0');
   const ext = safeExt(req.file.originalname);
   const uniqueName = `${uuidv4()}${ext}`;
-  const targetDir = path.join(UPLOADS_DIR, adminId, yyyy, mm);
-  const sourcePath = path.join(targetDir, uniqueName);
+  // #266: sourcePath stored RELATIVE to UPLOADS_DIR; absolute path resolved
+  // at read time via resolveUploadPath() so the doc stays host-portable.
+  const relativeSourcePath = path.join(adminId, yyyy, mm, uniqueName);
+  const absoluteSourcePath = resolveUploadPath(relativeSourcePath);
+  const targetDir = path.dirname(absoluteSourcePath);
 
   try {
     await fs.mkdir(targetDir, { recursive: true });
-    await fs.writeFile(sourcePath, req.file.buffer);
+    await fs.writeFile(absoluteSourcePath, req.file.buffer);
   } catch (err) {
     return res.status(500).json({
       success: false,
@@ -125,7 +126,7 @@ const upload = async (req, res) => {
     originalName: req.file.originalname,
     mimeType: req.file.mimetype,
     sizeBytes: req.file.size,
-    sourcePath,
+    sourcePath: relativeSourcePath,
     contentHash,
   });
 

--- a/backend/src/jobs/transcriptionWorker.js
+++ b/backend/src/jobs/transcriptionWorker.js
@@ -7,6 +7,8 @@ const FormData = require('form-data');
 const axios = require('axios');
 const mongoose = require('mongoose');
 
+const { resolveUploadPath } = require('@/utils/uploadsPath');
+
 const execFileAsync = promisify(execFile);
 
 const COMPRESSIBLE_EXTS = new Set(['.wav', '.flac', '.aiff', '.aac', '.m4a']);
@@ -94,9 +96,12 @@ async function transcribeWithOpenAI(fileDoc, jobDoc) {
   try {
     await Job.findByIdAndUpdate(jobDoc._id, { status: 'running', updated: Date.now() });
 
+    // #266: File.sourcePath is a relative path; resolve to absolute for ffmpeg
+    // / OpenAI calls but never store the absolute form back.
+    const absoluteSourcePath = resolveUploadPath(fileDoc.sourcePath);
     const audioPath = needsCompression(fileDoc)
-      ? (compressedPath = await compressToMp3(fileDoc.sourcePath))
-      : fileDoc.sourcePath;
+      ? (compressedPath = await compressToMp3(absoluteSourcePath))
+      : absoluteSourcePath;
 
     const payload = await callOpenAI(audioPath);
     const transcript = formatDiarizedJson(payload);
@@ -104,15 +109,18 @@ async function transcribeWithOpenAI(fileDoc, jobDoc) {
       throw new Error('OpenAI returned empty transcript');
     }
 
-    const sidecarPath = fileDoc.sourcePath + '.txt';
-    await fs.writeFile(sidecarPath, transcript, 'utf-8');
+    // Sidecar lives next to the source on disk but is recorded as a relative
+    // path in Job.result.sidecarPath (same portability invariant as #266).
+    const relativeSidecarPath = fileDoc.sourcePath + '.txt';
+    const absoluteSidecarPath = resolveUploadPath(relativeSidecarPath);
+    await fs.writeFile(absoluteSidecarPath, transcript, 'utf-8');
 
     const durationMs = Date.now() - startTs;
     const transcriptBytes = Buffer.byteLength(transcript, 'utf-8');
     await Job.findByIdAndUpdate(jobDoc._id, {
       status: 'done',
       result: {
-        sidecarPath,
+        sidecarPath: relativeSidecarPath,
         sizeBytes: transcriptBytes,
         durationMs,
       },

--- a/backend/src/models/appModels/File.js
+++ b/backend/src/models/appModels/File.js
@@ -28,6 +28,10 @@ const fileSchema = new mongoose.Schema({
     required: true,
     min: 0,
   },
+  // Path RELATIVE to UPLOADS_DIR (#266). Format: "<adminId>/YYYY/MM/<uuid>.ext".
+  // Resolved to absolute via utils/uploadsPath.resolveUploadPath() at read time
+  // so the doc stays host-portable across mac dev / Linux container / etc.
+  // Job.result.sidecarPath follows the same invariant.
   sourcePath: {
     type: String,
     required: true,

--- a/backend/src/setup/migrate-file-sourcepath-relative.js
+++ b/backend/src/setup/migrate-file-sourcepath-relative.js
@@ -1,0 +1,152 @@
+// One-shot migration for #266: convert absolute File.sourcePath and
+// Job.result.sidecarPath values to paths relative to UPLOADS_DIR.
+//
+// Usage (from backend/ working directory):
+//   node src/setup/migrate-file-sourcepath-relative.js              # dry-run (default, safe)
+//   node src/setup/migrate-file-sourcepath-relative.js --commit     # actually write
+//
+// Idempotent: already-relative docs are skipped. Unknown absolute prefixes
+// (paths neither under a known mac dev tree nor `/usr/src/app/uploads/`)
+// trigger WARN logs and are left untouched — human decision required.
+//
+// Prefixes recognized + stripped:
+//   /Users/<user>/.+/backend/uploads/   → mac dev (zyd / ziyue)
+//   /Users/<user>/.+/uploads/           → mac dev fallback
+//   /usr/src/app/uploads/               → Linux container
+
+require('module-alias/register');
+require('dotenv').config({ path: '.env' });
+require('dotenv').config({ path: '.env.local' });
+
+const path = require('path');
+const mongoose = require('mongoose');
+const { globSync } = require('glob');
+
+const MODE = process.argv.includes('--commit') ? 'commit' : 'dry-run';
+
+const PREFIX_PATTERNS = [
+  /^\/Users\/[^/]+\/.*?\/backend\/uploads\//,
+  /^\/Users\/[^/]+\/.*?\/uploads\//,
+  /^\/usr\/src\/app\/uploads\//,
+];
+
+function toRelative(absPath) {
+  if (!absPath || typeof absPath !== 'string') return { kind: 'invalid', value: absPath };
+  if (!path.isAbsolute(absPath)) return { kind: 'already-relative', value: absPath };
+  for (const pattern of PREFIX_PATTERNS) {
+    if (pattern.test(absPath)) {
+      return { kind: 'converted', value: absPath.replace(pattern, '') };
+    }
+  }
+  return { kind: 'unknown-prefix', value: absPath };
+}
+
+async function main() {
+  if (!process.env.DATABASE) {
+    console.error('CRITICAL: DATABASE env var not set. Run from backend/ with .env present.');
+    process.exit(1);
+  }
+  console.log(`[migrate] mode=${MODE} DATABASE=${process.env.DATABASE.replace(/:[^@]+@/, ':***@')}`);
+
+  await mongoose.connect(process.env.DATABASE);
+
+  // Autoload all models so File / Job are registered before we use them.
+  const BACKEND_ROOT = path.resolve(__dirname, '..');
+  globSync('models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+
+  const FileModel = mongoose.model('File');
+  const JobModel = mongoose.model('Job');
+
+  const stats = {
+    file: { total: 0, converted: 0, alreadyRelative: 0, unknownPrefix: 0, invalid: 0 },
+    job: { total: 0, converted: 0, alreadyRelative: 0, unknownPrefix: 0, invalid: 0 },
+  };
+
+  // --- File.sourcePath ---
+  const files = await FileModel.find({}).select('_id sourcePath').lean();
+  stats.file.total = files.length;
+  for (const f of files) {
+    const result = toRelative(f.sourcePath);
+    if (result.kind === 'already-relative') {
+      stats.file.alreadyRelative += 1;
+      continue;
+    }
+    if (result.kind === 'invalid') {
+      stats.file.invalid += 1;
+      console.warn(`[migrate] File ${f._id}: invalid sourcePath value:`, f.sourcePath);
+      continue;
+    }
+    if (result.kind === 'unknown-prefix') {
+      stats.file.unknownPrefix += 1;
+      console.warn(`[migrate] File ${f._id}: unknown absolute prefix, SKIPPED: ${f.sourcePath}`);
+      continue;
+    }
+    // converted
+    stats.file.converted += 1;
+    console.log(`[migrate] File ${f._id}: ${f.sourcePath} -> ${result.value}`);
+    if (MODE === 'commit') {
+      await FileModel.updateOne({ _id: f._id }, { $set: { sourcePath: result.value } });
+    }
+  }
+
+  // --- Job.result.sidecarPath (only transcription jobs have it) ---
+  const jobs = await JobModel.find({
+    type: 'transcription',
+    'result.sidecarPath': { $exists: true, $ne: null },
+  })
+    .select('_id result.sidecarPath')
+    .lean();
+  stats.job.total = jobs.length;
+  for (const j of jobs) {
+    const current = j.result?.sidecarPath;
+    const result = toRelative(current);
+    if (result.kind === 'already-relative') {
+      stats.job.alreadyRelative += 1;
+      continue;
+    }
+    if (result.kind === 'invalid') {
+      stats.job.invalid += 1;
+      console.warn(`[migrate] Job ${j._id}: invalid sidecarPath value:`, current);
+      continue;
+    }
+    if (result.kind === 'unknown-prefix') {
+      stats.job.unknownPrefix += 1;
+      console.warn(`[migrate] Job ${j._id}: unknown absolute prefix, SKIPPED: ${current}`);
+      continue;
+    }
+    stats.job.converted += 1;
+    console.log(`[migrate] Job ${j._id}: ${current} -> ${result.value}`);
+    if (MODE === 'commit') {
+      await JobModel.updateOne(
+        { _id: j._id },
+        { $set: { 'result.sidecarPath': result.value } }
+      );
+    }
+  }
+
+  console.log('');
+  console.log(`[migrate] === summary (mode=${MODE}) ===`);
+  console.log(`[migrate] File:  total=${stats.file.total} converted=${stats.file.converted} alreadyRelative=${stats.file.alreadyRelative} unknownPrefix=${stats.file.unknownPrefix} invalid=${stats.file.invalid}`);
+  console.log(`[migrate] Job:   total=${stats.job.total} converted=${stats.job.converted} alreadyRelative=${stats.job.alreadyRelative} unknownPrefix=${stats.job.unknownPrefix} invalid=${stats.job.invalid}`);
+  if (MODE === 'dry-run') {
+    console.log('[migrate] DRY-RUN — no writes performed. Re-run with --commit to apply.');
+  } else {
+    console.log('[migrate] COMMIT complete.');
+  }
+
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+// Only run if invoked directly via `node src/setup/migrate-...js`; export
+// pure helpers so jest can exercise them without touching DB.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[migrate] FATAL:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { toRelative, PREFIX_PATTERNS };

--- a/backend/src/utils/uploadsPath.js
+++ b/backend/src/utils/uploadsPath.js
@@ -1,0 +1,37 @@
+// Single source of truth for the audio uploads root + relative-path resolver.
+// Used by fileController/upload.js (write), jobs/transcriptionWorker.js (read +
+// sidecar write), and fileController/getTranscript.js (read).
+//
+// #266 architectural fix: File.sourcePath and Job.result.sidecarPath are now
+// stored as paths *relative to UPLOADS_DIR* (e.g. "<adminId>/2026/05/<uuid>.ext")
+// — never absolute. Previous design stored absolute paths in Mongo, which broke
+// the moment Atlas was shared between hosts (mac dev vs Linux container).
+//
+// UPLOADS_DIR resolution:
+//   - process.env.UPLOADS_DIR if set (prod containers can override)
+//   - otherwise repo-relative `<backend>/uploads`, computed from this file's
+//     location (`backend/src/utils/uploadsPath.js` → up 3 = `backend/`)
+//
+// docker-compose.yml mounts `crm-audio-uploads` named volume at
+// /usr/src/app/uploads in both backend + mcp containers, which matches the
+// default UPLOADS_DIR inside the container (no env override needed there).
+
+const path = require('path');
+
+const UPLOADS_DIR =
+  process.env.UPLOADS_DIR || path.resolve(__dirname, '../../uploads');
+
+function resolveUploadPath(relative) {
+  if (!relative || typeof relative !== 'string') {
+    throw new Error(`resolveUploadPath: relative path required, got ${relative}`);
+  }
+  if (path.isAbsolute(relative)) {
+    throw new Error(
+      `resolveUploadPath: expected relative path, got absolute "${relative}". ` +
+        `File.sourcePath / Job.result.sidecarPath must be relative to UPLOADS_DIR.`
+    );
+  }
+  return path.join(UPLOADS_DIR, relative);
+}
+
+module.exports = { UPLOADS_DIR, resolveUploadPath };

--- a/backend/test/file.getTranscript.test.js
+++ b/backend/test/file.getTranscript.test.js
@@ -29,6 +29,10 @@ const { MongoMemoryServer } = require('mongodb-memory-server');
 
 const BACKEND_ROOT = path.join(__dirname, '..');
 const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'get-transcript-test-'));
+// #266: getTranscript resolves Job.result.sidecarPath via UPLOADS_DIR; point
+// it at TMP_DIR before requiring the controller so resolveUploadPath() reads
+// the right root.
+process.env.UPLOADS_DIR = TMP_DIR;
 
 let mongo;
 const adminAId = new mongoose.Types.ObjectId();
@@ -70,19 +74,19 @@ function buildApp(adminId) {
 async function seedFileWithJob({ adminId, transcript = 'hello world transcript' }) {
   const File = mongoose.model('File');
   const Job = mongoose.model('Job');
-  const sourcePath = path.join(
-    TMP_DIR,
-    `${Date.now()}-${Math.random()}-audio.mp3`
-  );
-  fs.writeFileSync(sourcePath, Buffer.alloc(8, 0));
-  const sidecarPath = `${sourcePath}.txt`;
-  fs.writeFileSync(sidecarPath, transcript);
+  // #266: sourcePath / sidecarPath stored RELATIVE to UPLOADS_DIR (= TMP_DIR).
+  const relativeSourcePath = `${Date.now()}-${Math.random()}-audio.mp3`;
+  const relativeSidecarPath = `${relativeSourcePath}.txt`;
+  const absoluteSourcePath = path.join(TMP_DIR, relativeSourcePath);
+  const absoluteSidecarPath = path.join(TMP_DIR, relativeSidecarPath);
+  fs.writeFileSync(absoluteSourcePath, Buffer.alloc(8, 0));
+  fs.writeFileSync(absoluteSidecarPath, transcript);
   const file = await File.create({
     createdBy: adminId,
     originalName: 'audio.mp3',
     mimeType: 'audio/mpeg',
     sizeBytes: 8,
-    sourcePath,
+    sourcePath: relativeSourcePath,
   });
   const job = await Job.create({
     createdBy: adminId,
@@ -90,11 +94,11 @@ async function seedFileWithJob({ adminId, transcript = 'hello world transcript' 
     refModel: 'File',
     refId: file._id,
     status: 'done',
-    result: { sidecarPath, durationMs: 1234 },
+    result: { sidecarPath: relativeSidecarPath, durationMs: 1234 },
   });
   file.transcriptionJobId = job._id;
   await file.save();
-  return { file, job, sidecarPath };
+  return { file, job, relativeSidecarPath, absoluteSidecarPath };
 }
 
 describe('getTranscript multi-tenant isolation (PR #258 Ziyue review)', () => {
@@ -109,6 +113,43 @@ describe('getTranscript multi-tenant isolation (PR #258 Ziyue review)', () => {
     expect(res.body.success).toBe(true);
     expect(res.body.result.transcript).toBe('admin A own transcript content');
     expect(res.body.result.fileId.toString()).toBe(file._id.toString());
+  });
+
+  // #266 Item 2 — fail-fast case: a legacy doc with absolute sidecarPath
+  // (from before the migration) must produce a clear 500 instead of silently
+  // hitting a wrong-host filesystem path.
+  test('legacy absolute sidecarPath → 500 "路径无效" fail-fast (#266)', async () => {
+    const File = mongoose.model('File');
+    const Job = mongoose.model('Job');
+    // Write a real sidecar at an absolute location so this isn't an ENOENT
+    // — the absolute-path check must reject BEFORE fs.readFile is attempted.
+    const absoluteSidecarPath = path.join(TMP_DIR, 'legacy-absolute-sidecar.txt');
+    fs.writeFileSync(absoluteSidecarPath, 'should NOT be read');
+    const file = await File.create({
+      createdBy: adminAId,
+      originalName: 'legacy.mp3',
+      mimeType: 'audio/mpeg',
+      sizeBytes: 8,
+      sourcePath: 'legacy-relative.mp3',
+    });
+    const job = await Job.create({
+      createdBy: adminAId,
+      type: 'transcription',
+      refModel: 'File',
+      refId: file._id,
+      status: 'done',
+      result: { sidecarPath: absoluteSidecarPath, durationMs: 1 },
+    });
+    file.transcriptionJobId = job._id;
+    await file.save();
+
+    const res = await request(buildApp(adminAId))
+      .get(`/api/file/transcript/${file._id}`);
+
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toContain('路径无效');
+    expect(JSON.stringify(res.body)).not.toContain('should NOT be read');
   });
 
   test('cross-admin attack: A.File → B.Job → 500, no transcript leaked', async () => {

--- a/backend/test/file.upload.test.js
+++ b/backend/test/file.upload.test.js
@@ -103,11 +103,12 @@ describe('POST /api/file/create — happy path', () => {
     expect(doc).toBeTruthy();
     expect(doc.createdBy.toString()).toBe(adminAId.toString());
 
-    // Disk write — under tenant-scoped path
-    expect(doc.sourcePath.startsWith(TMP_UPLOADS)).toBe(true);
-    expect(doc.sourcePath).toContain(`/${adminAId.toString()}/`);
-    expect(fs.existsSync(doc.sourcePath)).toBe(true);
-    expect(fs.readFileSync(doc.sourcePath)).toEqual(fakeAudio);
+    // #266: sourcePath stored RELATIVE to UPLOADS_DIR (not absolute).
+    expect(path.isAbsolute(doc.sourcePath)).toBe(false);
+    expect(doc.sourcePath.startsWith(`${adminAId.toString()}/`)).toBe(true);
+    const absoluteSourcePath = path.join(TMP_UPLOADS, doc.sourcePath);
+    expect(fs.existsSync(absoluteSourcePath)).toBe(true);
+    expect(fs.readFileSync(absoluteSourcePath)).toEqual(fakeAudio);
   });
 });
 
@@ -276,8 +277,9 @@ describe('Disk path scope', () => {
 
     const FileModel = mongoose.model('File');
     const doc = await FileModel.findById(res.body.result._id);
-    const relative = path.relative(TMP_UPLOADS, doc.sourcePath);
-    const parts = relative.split(path.sep);
+    // #266: doc.sourcePath is already relative; split directly (no path.relative)
+    expect(path.isAbsolute(doc.sourcePath)).toBe(false);
+    const parts = doc.sourcePath.split(path.sep);
 
     expect(parts[0]).toBe(adminAId.toString());
     expect(parts[1]).toMatch(/^\d{4}$/); // YYYY

--- a/backend/test/file.upload.transcription.test.js
+++ b/backend/test/file.upload.transcription.test.js
@@ -33,6 +33,9 @@ const child_process = require('child_process');
 
 const BACKEND_ROOT = path.join(__dirname, '..');
 const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'transcribe-test-'));
+// #266: worker resolves File.sourcePath via UPLOADS_DIR; point it at TMP_DIR
+// before requiring the worker so resolveUploadPath() reads the right root.
+process.env.UPLOADS_DIR = TMP_DIR;
 const adminAId = new mongoose.Types.ObjectId();
 
 let mongo;
@@ -74,14 +77,16 @@ async function setupAudioFile({
   sizeBytes = 5_000_000,
   mimeType = 'audio/mpeg',
 } = {}) {
-  const sourcePath = path.join(TMP_DIR, `${Date.now()}-${Math.random()}-${name}`);
-  fs.writeFileSync(sourcePath, Buffer.alloc(Math.min(sizeBytes, 1024), 0));
+  // #266: sourcePath stored RELATIVE to TMP_DIR (= UPLOADS_DIR in this test).
+  const relativeSourcePath = `${Date.now()}-${Math.random()}-${name}`;
+  const absoluteSourcePath = path.join(TMP_DIR, relativeSourcePath);
+  fs.writeFileSync(absoluteSourcePath, Buffer.alloc(Math.min(sizeBytes, 1024), 0));
   const fileDoc = await File.create({
     createdBy: adminAId,
     originalName: name,
     mimeType,
     sizeBytes,
-    sourcePath,
+    sourcePath: relativeSourcePath,
   });
   const jobDoc = await Job.create({
     createdBy: adminAId,
@@ -89,7 +94,7 @@ async function setupAudioFile({
     refModel: 'File',
     refId: fileDoc._id,
   });
-  return { fileDoc, jobDoc, sourcePath };
+  return { fileDoc, jobDoc, relativeSourcePath, absoluteSourcePath };
 }
 
 test('1. Happy: small mp3 (no compress) → axios called, sidecar written, Job.done', async () => {
@@ -103,14 +108,15 @@ test('1. Happy: small mp3 (no compress) → axios called, sidecar written, Job.d
     },
   });
 
-  const { fileDoc, jobDoc, sourcePath } = await setupAudioFile({ sizeBytes: 5_000_000 });
+  const { fileDoc, jobDoc, relativeSourcePath, absoluteSourcePath } =
+    await setupAudioFile({ sizeBytes: 5_000_000 });
 
   await transcribeWithOpenAI(fileDoc, jobDoc);
 
   expect(child_process.execFile).not.toHaveBeenCalled();
   expect(axios.post).toHaveBeenCalledTimes(1);
 
-  const sidecar = fs.readFileSync(sourcePath + '.txt', 'utf-8');
+  const sidecar = fs.readFileSync(absoluteSourcePath + '.txt', 'utf-8');
   expect(sidecar).toContain('A 00:00');
   expect(sidecar).toContain('你好');
   expect(sidecar).toContain('B 00:03');
@@ -118,7 +124,10 @@ test('1. Happy: small mp3 (no compress) → axios called, sidecar written, Job.d
 
   const finalJob = await Job.findById(jobDoc._id);
   expect(finalJob.status).toBe('done');
-  expect(finalJob.result.sidecarPath).toBe(sourcePath + '.txt');
+  // #266: sidecarPath stored RELATIVE (matches relativeSourcePath + '.txt'),
+  // not absolute. Disk write uses the resolver under the hood.
+  expect(path.isAbsolute(finalJob.result.sidecarPath)).toBe(false);
+  expect(finalJob.result.sidecarPath).toBe(relativeSourcePath + '.txt');
   expect(finalJob.result.sizeBytes).toBeGreaterThan(0);
   expect(finalJob.result.durationMs).toBeGreaterThanOrEqual(0);
 });

--- a/backend/test/mcp/file.tools.test.js
+++ b/backend/test/mcp/file.tools.test.js
@@ -26,6 +26,10 @@ const { MongoMemoryServer } = require('mongodb-memory-server');
 
 const BACKEND_ROOT = path.join(__dirname, '..', '..');
 const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'file-tools-test-'));
+// #266: file.get_transcript flows through getTranscript which resolves
+// sidecarPath via UPLOADS_DIR. Point UPLOADS_DIR at TMP_DIR before requiring
+// any controller code.
+process.env.UPLOADS_DIR = TMP_DIR;
 
 const { runWithContext } = require(path.join(BACKEND_ROOT, 'src/mcp/context'));
 
@@ -68,22 +72,25 @@ async function createFileWithJob(admin, opts = {}) {
   const FileModel = mongoose.model('File');
   const JobModel = mongoose.model('Job');
   const originalName = opts.originalName || 'rec.mp3';
-  const sourcePath = path.join(TMP_DIR, `${admin._id}-${Date.now()}-${Math.random()}-${originalName}`);
-  fs.writeFileSync(sourcePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+  // #266: sourcePath stored RELATIVE to TMP_DIR (= UPLOADS_DIR).
+  const relativeSourcePath = `${admin._id}-${Date.now()}-${Math.random()}-${originalName}`;
+  const absoluteSourcePath = path.join(TMP_DIR, relativeSourcePath);
+  fs.writeFileSync(absoluteSourcePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
 
   const file = await FileModel.create({
     createdBy: admin._id,
     originalName,
     mimeType: 'audio/mpeg',
     sizeBytes: 1024,
-    sourcePath,
+    sourcePath: relativeSourcePath,
     contentHash: opts.contentHash || 'abc',
   });
 
   if (opts.skipJob) return { file };
 
   const transcriptText = opts.transcriptText || 'A 00:00  test transcript';
-  fs.writeFileSync(sourcePath + '.txt', transcriptText, 'utf-8');
+  const relativeSidecarPath = relativeSourcePath + '.txt';
+  fs.writeFileSync(absoluteSourcePath + '.txt', transcriptText, 'utf-8');
 
   const job = await JobModel.create({
     createdBy: admin._id,
@@ -91,7 +98,7 @@ async function createFileWithJob(admin, opts = {}) {
     refModel: 'File',
     refId: file._id,
     status: opts.jobStatus || 'done',
-    result: opts.jobResult || { sidecarPath: sourcePath + '.txt', sizeBytes: transcriptText.length, durationMs: 1234 },
+    result: opts.jobResult || { sidecarPath: relativeSidecarPath, sizeBytes: transcriptText.length, durationMs: 1234 },
     error: opts.jobError || '',
   });
   await FileModel.findByIdAndUpdate(file._id, { transcriptionJobId: job._id });

--- a/backend/test/migrate-file-sourcepath-relative.test.js
+++ b/backend/test/migrate-file-sourcepath-relative.test.js
@@ -1,0 +1,60 @@
+/**
+ * Pure-function tests for #266 migration helper (toRelative). The full DB
+ * sweep is exercised manually via `node src/setup/migrate-...js --dry-run`
+ * against Atlas. Here we verify the classification + prefix stripping logic
+ * is idempotent and covers all known absolute-path shapes.
+ */
+
+const { toRelative } = require('../src/setup/migrate-file-sourcepath-relative');
+
+describe('migrate.toRelative — #266 idempotent prefix stripping', () => {
+  test('already-relative path is returned untouched', () => {
+    const r = toRelative('6a03e003dcaca7e136b3fc03/2026/05/e488f9b8.wav');
+    expect(r.kind).toBe('already-relative');
+    expect(r.value).toBe('6a03e003dcaca7e136b3fc03/2026/05/e488f9b8.wav');
+  });
+
+  test('mac dev absolute /Users/.../backend/uploads/ is stripped', () => {
+    const r = toRelative(
+      '/Users/duke/Documents/GitHub/crm/backend/uploads/abc123/2026/05/9168fffc.m4a'
+    );
+    expect(r.kind).toBe('converted');
+    expect(r.value).toBe('abc123/2026/05/9168fffc.m4a');
+  });
+
+  test('mac dev absolute /Users/.../uploads/ (no backend/) is stripped', () => {
+    const r = toRelative('/Users/ziyue/work/proj/uploads/aaa/2026/05/bbb.mp3');
+    expect(r.kind).toBe('converted');
+    expect(r.value).toBe('aaa/2026/05/bbb.mp3');
+  });
+
+  test('Linux container absolute /usr/src/app/uploads/ is stripped', () => {
+    const r = toRelative(
+      '/usr/src/app/uploads/6a03e003dcaca7e136b3fc03/2026/05/e488f9b8-7798.wav.txt'
+    );
+    expect(r.kind).toBe('converted');
+    expect(r.value).toBe('6a03e003dcaca7e136b3fc03/2026/05/e488f9b8-7798.wav.txt');
+  });
+
+  test('unknown absolute prefix is left untouched + flagged', () => {
+    const r = toRelative('/mnt/some/other/path/file.mp3');
+    expect(r.kind).toBe('unknown-prefix');
+    expect(r.value).toBe('/mnt/some/other/path/file.mp3');
+  });
+
+  test('idempotent — running on the output of a conversion is a no-op', () => {
+    const first = toRelative(
+      '/Users/duke/Documents/GitHub/crm/backend/uploads/abc/2026/05/x.wav'
+    );
+    expect(first.kind).toBe('converted');
+    const second = toRelative(first.value);
+    expect(second.kind).toBe('already-relative');
+    expect(second.value).toBe(first.value);
+  });
+
+  test('invalid (null / undefined / non-string) → invalid kind', () => {
+    expect(toRelative(null).kind).toBe('invalid');
+    expect(toRelative(undefined).kind).toBe('invalid');
+    expect(toRelative(123).kind).toBe('invalid');
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,13 @@ services:
     volumes:
       # 上传文件持久化，避免 docker compose up -d --build 每次擦掉 logo 等资产
       - crm-uploads:/usr/src/app/src/public/uploads
+      # 音频文件 + transcript sidecar 持久化，并和 mcp 容器共享（#266 Bug 1+2）。
+      # 路径必须和 backend/src/controllers/appControllers/fileController/upload.js
+      # 里 UPLOADS_DIR 默认值（`path.resolve(__dirname, '../../../../uploads')` →
+      # `/usr/src/app/uploads`）一致。MCP 的 file.get_transcript 通过 in-process
+      # controllerAdapter 调 fileController.getTranscript，跑在 mcp 容器里 fs，
+      # 因此 mcp 必须挂同一个 named volume 才能读到 backend 写入的 sidecar .txt。
+      - crm-audio-uploads:/usr/src/app/uploads
     restart: unless-stopped
 
   # MCP server 独立容器（与 backend 同镜像，command 覆盖入口），
@@ -51,6 +58,9 @@ services:
       NODE_ENV: production
       # 容器内部绑 0.0.0.0，由上面的 ports 映射决定对外暴露哪个宿主接口
       MCP_HOST: "0.0.0.0"
+    volumes:
+      # 与 backend 共享 audio uploads volume — 见上方 backend.volumes 注释
+      - crm-audio-uploads:/usr/src/app/uploads
     restart: unless-stopped
 
   frontend:
@@ -70,6 +80,7 @@ services:
 
 volumes:
   crm-uploads:
+  crm-audio-uploads:
 
 # 注意：
 # - gotenberg 不再在本 compose 中，它在 Box3 独立运行

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -63,7 +63,7 @@ server {
         proxy_send_timeout 180s;
         proxy_buffering off;
         proxy_cache off;
-        client_max_body_size 20M;
+        client_max_body_size 100M;
     }
 
     # 后端 API 反代（docker-compose 网络内用 service name "backend"）
@@ -76,7 +76,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_read_timeout 60s;
-        client_max_body_size 20M;
+        client_max_body_size 100M;
     }
 
     location /download/ {

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -55,6 +55,18 @@ if [ -f "$CRM_DIR/.secrets/SERVERS.env" ]; then
 fi
 set +a
 
+# #266 Item 3 — fail-fast if backend/.env declares OLA_ENV=prod. Local dev
+# must never point at the production Atlas cluster: cross-env writes pollute
+# the shared DB with host-specific paths and other dev artifacts (see #266
+# Bug 3+4 for the original incident). Prod boxes set OLA_ENV=prod in their
+# .env; local dev leaves it unset OR sets =dev.
+if [ "${OLA_ENV:-dev}" = "prod" ]; then
+  echo -e "${RED}REFUSING TO START: backend/.env has OLA_ENV=prod.${NC}"
+  echo -e "${YELLOW}start-dev.sh is for local development only. Set OLA_ENV=dev (or unset it)${NC}"
+  echo -e "${YELLOW}in backend/.env before running this script. See #266 for context.${NC}"
+  exit 1
+fi
+
 # Always-overwrite render of ~/.nanobot/config.json. Single source of truth
 # is the vendored template + secrets; manual edits to ~/.nanobot/config.json
 # WILL be clobbered on next start (matches the SOUL/AGENTS/TOOLS pattern


### PR DESCRIPTION
Closes #266. Covers the full set of bugs that surfaced when the single-process-local PR #258 design hit prod's split backend/mcp containers + shared Atlas DB.

| # | Bug | Commit |
|---|---|---|
| 1 | MCP container has zero volume mounts → can't read transcripts | `6314b36` |
| 2 | Audio written outside any docker volume → wiped on rebuild | `6314b36` |
| 3 | File.sourcePath absolute → mac path on prod ENOENTs | `1fe4178` |
| 4 | File.sourcePath absolute → prod path on mac ENOENTs (Sydy Liu) | `1fe4178` |
| 5 | Backend Dockerfile missing ffmpeg → every audio Job fails | `47d6b50` |
| 6 | Nginx client_max_body_size 20M → 413 on >20MB audio | `47d6b50` |

Plus Item 3 (option B from #266): `start-dev.sh` fail-fast when `OLA_ENV=prod`, preventing the original cross-env Atlas pollution incident from recurring (`a55446f`).

## Commits (no squash — each Item independently reviewable / revertible)

| sha | item | scope |
|---|---|---|
| `47d6b50` | Bug 5+6 | backend Dockerfile ffmpeg + nginx 100M (hotfix, pre-existing) |
| `6314b36` | Bug 1+2 | docker-compose.yml shared `crm-audio-uploads` volume mounted in backend + mcp |
| `1fe4178` | Bug 3+4 | utils/uploadsPath.js resolver; File.sourcePath + Job.result.sidecarPath stored relative; migration script (idempotent, dry-run default); 5 fixture updates + new fail-fast jest case + 7-case migration helper test |
| `a55446f` | option B | start-dev.sh OLA_ENV=prod fail-fast guard |

## Verification done before push

| Check | Result |
|---|---|
| `MCP_BIND_ADDR=127.0.0.1 docker compose config` syntax | ✓ |
| `docker compose up backend mcp` cross-container write/read both directions | ✓ `ls` IDENTICAL |
| `npx jest --runInBand` | ✓ **308/308** (up from 276) |
| migration `--dry-run` against live Atlas | ✓ **28 File + 22 Job converted**, 0 unknown, 0 invalid |
| `OLA_ENV=prod start-dev.sh` 3-case guard | ✓ unset→0 / dev→0 / prod→1 |

Migration dry-run reaches both mac dev paths (`/Users/duke/...`) and prod container paths (`/usr/src/app/uploads/...`), including Sydy Liu's admin id `6a03e003...` — exactly the cross-host pollution #266 Bug 4 documents.

## Deploy sequence (Box1, after PR merge)

1. `cd /app/crm && git fetch && git checkout main && git pull` (or whatever branch PR lands on)
2. `docker compose down`
3. `docker compose up -d --build` (creates `crm-audio-uploads` volume; pre-existing audio in `crm-backend-1:/usr/src/app/uploads` writable layer is DISCARDED — zyd confirmed no real users yet, data loss accepted)
4. `docker exec -it crm-backend-1 sh -c "cd /usr/src/app && node src/setup/migrate-file-sourcepath-relative.js --commit"` (Atlas: convert 28 File + 22 Job docs to relative paths)
5. Set `OLA_ENV=prod` in Box1's `backend/.env` (so start-dev.sh refuses to run there)
6. Smoke (3 assertions, all must pass):
   - `curl -sS https://app.olatech.ai/health` → 200 + `{ status: 'ok' }`
   - `curl -sS https://app.olatech.ai/api/setting/listAll` → 401 (no cookie)
   - Login + askola "分析 sophie-01.wav" → returns transcript without ENOENT

## Test plan

- [x] jest 308/308 local
- [x] migration dry-run on Atlas safe + correct
- [x] docker compose cross-container shared volume verified
- [x] OLA_ENV guard 3-case
- [ ] Box1 deploy + prod smoke (zyd manual after review)

## Risk / rollback

- Each commit is independent; revert is granular.
- Item 2 is the only behavior change. Between `git pull` and `migrate --commit`, getTranscript on legacy docs returns **500 "路径无效"** (deliberate fail-fast) instead of silent ENOENT. Running migration `--commit` then both old and new docs read correctly.
- If migration mis-fires, dry-run printed exact docs/paths beforehand; rollback is `mongo updateMany` re-prefixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)