### PR TITLE
#257 CRM 转写引擎接入 Paraformer-v2 (per-admin coexist with OpenAI)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,11 +24,35 @@ GEMINI_API_KEY="AIza..."
 
 # ------------------ Audio transcription (sales-coach) ------------------
 
-# OpenAI API key for audio transcription via gpt-4o-transcribe-diarize.
-# Required when the sales-coach pipeline is exercised (AskOla audio upload →
-# transcribe → coach report). Optional for UI-only work (wzh/yili can skip).
+# Provider dispatch (#257) — runtime engine selection:
+#   admin.transcribeProvider > TRANSCRIPTION_PROVIDER env > hardcoded 'openai'
+# Per-admin override beats this env var, so leave unset unless you want a
+# process-wide default. Valid values: openai | paraformer.
+# TRANSCRIPTION_PROVIDER="openai"
+
+# --- OpenAI gpt-4o-transcribe-diarize (push, multipart) ---
+# Required when any admin/job will be routed to OpenAI.
 # Get from https://platform.openai.com/api-keys
 # OPENAI_API_KEY="sk-..."
+
+# --- DashScope Paraformer-v2 (pull, async REST) ---
+# Required when any admin is routed to paraformer. HK Cantonese first-class,
+# 9× cheaper than OpenAI on long-form. Sign up at https://bailian.console.aliyun.com
+# DASHSCOPE_API_KEY="sk-..."
+
+# Public URL that DashScope can fetch the audio file from. Local dev: set by
+# start-dev-paraformer.sh automatically (cloudflared trycloudflare). Prod
+# Box1: direct public IP to bypass Cloudflare WAF (which blocks Aliyun IPs).
+# Required when paraformer is the active provider for any upload.
+#   Local : (auto-injected by start-dev-paraformer.sh — DO NOT set manually)
+#   Prod  : BACKEND_PUBLIC_BASE_URL=http://47.77.239.237
+# BACKEND_PUBLIC_BASE_URL=""
+
+# Optional paraformer tunables (defaults are good for HK 2-speaker sales calls).
+# PARAFORMER_LANG_HINTS="yue,zh,en"        # Cantonese first, Mandarin + English fallback
+# PARAFORMER_SPEAKER_COUNT="2"             # sales + customer
+# PARAFORMER_POLL_INTERVAL_MS="5000"       # poll cadence + heartbeat refresh
+# PARAFORMER_MAX_WAIT_MS="1800000"         # 30 min hard timeout per job
 
 # ------------------ Common ------------------
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -33,6 +33,7 @@
         "mongoose-autopopulate": "^1.1.0",
         "multer": "^1.4.4",
         "node-cache": "^5.1.2",
+        "opencc-js": "^1.3.1",
         "pug": "^3.0.2",
         "resend": "^2.0.0",
         "shortid": "^2.2.16",
@@ -10017,6 +10018,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/opencc-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/opencc-js/-/opencc-js-1.3.1.tgz",
+      "integrity": "sha512-EyKDnjHNYlxo3Blll0OGH5qcyZBI3YmXpqeDEity/db50A5TFfCdvylrBlTyx1XvlSRUmh2a5AHvSf89h4u87Q==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "mongoose-autopopulate": "^1.1.0",
     "multer": "^1.4.4",
     "node-cache": "^5.1.2",
+    "opencc-js": "^1.3.1",
     "pug": "^3.0.2",
     "resend": "^2.0.0",
     "shortid": "^2.2.16",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -9,6 +9,7 @@ const coreAuthRouter = require('./routes/coreRoutes/coreAuth');
 const coreApiRouter = require('./routes/coreRoutes/coreApi');
 const coreDownloadRouter = require('./routes/coreRoutes/coreDownloadRouter');
 const corePublicRouter = require('./routes/coreRoutes/corePublicRouter');
+const corePublicAudioRouter = require('./routes/coreRoutes/corePublicAudioRouter');
 const adminAuth = require('./controllers/coreControllers/adminAuth');
 const trackActivity = require('./middlewares/trackActivity');
 const exportRoutes = require('./routes/exportRoutes');
@@ -105,6 +106,10 @@ app.use('/api', coreAuthRouter);
 app.use('/api', adminAuth.isValidAuthToken, trackActivity, coreApiRouter);
 app.use('/api', adminAuth.isValidAuthToken, trackActivity, erpApiRouter);
 app.use('/download', coreDownloadRouter);
+// #257 — must mount BEFORE corePublicRouter; both share /public prefix but
+// corePublicAudioRouter serves UPLOADS_DIR audio for STT pull (no auth, UUID
+// in path is the secret), corePublicRouter serves backend/src/public/ static.
+app.use('/public/audio', corePublicAudioRouter);
 app.use('/public', corePublicRouter);
 // Excel 导出路由 - 不需要身份验证
 app.use('/export/excel', exportRoutes);

--- a/backend/src/controllers/appControllers/fileController/upload.js
+++ b/backend/src/controllers/appControllers/fileController/upload.js
@@ -6,7 +6,7 @@ const multer = require('multer');
 const mongoose = require('mongoose');
 
 const { uploadSchema, MAX_FILE_SIZE } = require('./schemaValidate');
-const transcribeWithOpenAI = require('@/jobs/transcriptionWorker');
+const runTranscription = require('@/jobs/transcriptionWorker');
 const { UPLOADS_DIR, resolveUploadPath } = require('@/utils/uploadsPath');
 
 const FileModel = mongoose.model('File');
@@ -149,7 +149,7 @@ const upload = async (req, res) => {
         message: `转写任务创建失败: ${err.message}`,
       });
     }
-    transcribeWithOpenAI(fileDoc, job).catch((err) => {
+    runTranscription(fileDoc, job).catch((err) => {
       console.error(`[transcribe] worker failed for File ${fileDoc._id}:`, err.message);
     });
   }

--- a/backend/src/jobs/providers/openaiProvider.js
+++ b/backend/src/jobs/providers/openaiProvider.js
@@ -1,0 +1,80 @@
+// OpenAI gpt-4o-transcribe-diarize STT provider (#257 — extracted from
+// transcriptionWorker.js to live alongside paraformerProvider under
+// providers/, dispatched by runTranscription based on admin.transcribeProvider).
+//
+// Push model: stream the local audio file as multipart to OpenAI. No public
+// URL involvement (contrast with paraformer's pull model).
+
+const fsSync = require('fs');
+const FormData = require('form-data');
+const axios = require('axios');
+
+const OPENAI_URL = 'https://api.openai.com/v1/audio/transcriptions';
+const MODEL = 'gpt-4o-transcribe-diarize';
+const RESPONSE_FORMAT = 'diarized_json';
+
+// Mirrors paraformerProvider's formatParaformerSidecar output shape so both
+// providers produce sidecars LLM-readable with the same `A 00:00  text` form.
+// OpenAI's diarize response already uses A/B/C speaker letters, so this is a
+// straight render (no enum mapping like paraformer's speaker_id 0→A).
+function formatDiarizedJson(payload) {
+  const segments = payload && Array.isArray(payload.segments) ? payload.segments : null;
+  if (!segments || segments.length === 0) {
+    return (payload && payload.text) || '';
+  }
+  return segments
+    .map((seg) => {
+      const speaker = seg.speaker || '?';
+      const start = Number(seg.start) || 0;
+      const text = (seg.text || '').trim();
+      const mm = String(Math.floor(start / 60)).padStart(2, '0');
+      const ss = String(Math.floor(start % 60)).padStart(2, '0');
+      return `${speaker} ${mm}:${ss}  ${text}`;
+    })
+    .join('\n');
+}
+
+async function callOpenAI(audioPath) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY not set');
+  const formData = new FormData();
+  formData.append('file', fsSync.createReadStream(audioPath));
+  formData.append('model', MODEL);
+  formData.append('response_format', RESPONSE_FORMAT);
+  formData.append('chunking_strategy', 'auto');
+  try {
+    const response = await axios.post(OPENAI_URL, formData, {
+      headers: { ...formData.getHeaders(), Authorization: `Bearer ${apiKey}` },
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity,
+      timeout: parseInt(process.env.OPENAI_TRANSCRIPTION_TIMEOUT_MS, 10) || 600000,
+    });
+    return response.data;
+  } catch (err) {
+    // axios swallows the OpenAI error body — surface it so Job.error and the
+    // structured log capture the real "why" instead of just the HTTP code.
+    if (err && err.response) {
+      const status = err.response.status;
+      const body = err.response.data;
+      const bodyJson =
+        typeof body === 'object' ? JSON.stringify(body) : String(body).slice(0, 500);
+      const detail =
+        body && body.error && body.error.message
+          ? body.error.message
+          : bodyJson;
+      const wrapped = new Error(`OpenAI HTTP ${status}: ${detail}`);
+      wrapped.status = status;
+      wrapped.openaiBody = body;
+      throw wrapped;
+    }
+    throw err;
+  }
+}
+
+async function transcribeViaOpenAI(audioPath) {
+  const payload = await callOpenAI(audioPath);
+  return formatDiarizedJson(payload);
+}
+
+module.exports = transcribeViaOpenAI;
+module.exports.__test__ = { callOpenAI, formatDiarizedJson };

--- a/backend/src/jobs/providers/paraformerProvider.js
+++ b/backend/src/jobs/providers/paraformerProvider.js
@@ -1,0 +1,249 @@
+// DashScope Paraformer-v2 STT provider (#257).
+//
+// Architecture: async REST — submit task → poll task_status every N seconds
+// until SUCCEEDED/FAILED → fetch transcripts JSON from a separate signed URL.
+// Paraformer is pull-only (no multipart push), so the audio file must already
+// be reachable at a public HTTP/HTTPS URL constructed from BACKEND_PUBLIC_BASE_URL
+// + the File's relative sourcePath (served by corePublicAudioRouter).
+//
+// Output: sidecar string mirrors the OpenAI formatDiarizedJson shape exactly
+//   `A 00:00  <text>` per line, with speaker_id 0→A, 1→B, etc.
+// Then OpenCC s2hk converts the simplified output to HK traditional + a
+// targeted '繫'→'係' post-fix corrects an OpenCC quirk on Cantonese 系/係.
+
+const axios = require('axios');
+const OpenCC = require('opencc-js');
+
+const SUBMIT_URL = 'https://dashscope.aliyuncs.com/api/v1/services/audio/asr/transcription';
+const TASK_URL_BASE = 'https://dashscope.aliyuncs.com/api/v1/tasks/';
+
+// All tunables come from env with sensible defaults; PARAFORMER_POLL_INTERVAL_MS
+// is the loop tick (heartbeat cadence too); PARAFORMER_MAX_WAIT_MS is the hard
+// timeout for a single transcription (default 30 min — long-form 1h+ should
+// finish in <10 min based on spike).
+const POLL_INTERVAL_MS = parseInt(process.env.PARAFORMER_POLL_INTERVAL_MS, 10) || 5000;
+const POLL_MAX_WAIT_MS = parseInt(process.env.PARAFORMER_MAX_WAIT_MS, 10) || 30 * 60 * 1000;
+const DEFAULT_LANG_HINTS = (process.env.PARAFORMER_LANG_HINTS || 'yue,zh,en')
+  .split(',').map((s) => s.trim()).filter(Boolean);
+const DEFAULT_SPEAKER_COUNT = parseInt(process.env.PARAFORMER_SPEAKER_COUNT, 10) || 2;
+
+// OpenCC converter built once at module load — Trie precomputed, conversion
+// itself is O(n) on the input and called once per job. cn→hk = simplified to
+// HK traditional (preserves Cantonese particles, uses HK-specific glyphs).
+const opencc_s2hk = OpenCC.Converter({ from: 'cn', to: 'hk' });
+
+// --- helpers ---
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function speakerIdToLetter(spkId) {
+  // 0→A 1→B 2→C ... matches the existing OpenAI sidecar convention so the
+  // downstream LLM prompt + ChatInput.jsx Transcript preview UI don't have
+  // to special-case providers.
+  if (typeof spkId !== 'number' || spkId < 0) return '?';
+  if (spkId >= 26) return `S${spkId}`; // safety net for unlikely >26 speakers
+  return String.fromCharCode('A'.charCodeAt(0) + spkId);
+}
+
+function formatMmSs(ms) {
+  const seconds = Math.floor((ms || 0) / 1000);
+  const mm = String(Math.floor(seconds / 60)).padStart(2, '0');
+  const ss = String(seconds % 60).padStart(2, '0');
+  return `${mm}:${ss}`;
+}
+
+// --- public API ---
+
+async function submitTask(fileUrl, opts = {}) {
+  const apiKey = process.env.DASHSCOPE_API_KEY;
+  if (!apiKey) throw new Error('DASHSCOPE_API_KEY not set');
+
+  const langHints = opts.langHints || DEFAULT_LANG_HINTS;
+  const speakerCount = opts.speakerCount || DEFAULT_SPEAKER_COUNT;
+
+  const body = {
+    model: 'paraformer-v2',
+    input: { file_urls: [fileUrl] },
+    parameters: {
+      channel_id: [0],
+      language_hints: langHints,
+      diarization_enabled: true,
+      speaker_count: speakerCount,
+    },
+  };
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+    'X-DashScope-Async': 'enable',
+  };
+
+  let resp;
+  try {
+    resp = await axios.post(SUBMIT_URL, body, { headers, timeout: 60000 });
+  } catch (err) {
+    const status = err.response && err.response.status;
+    const detail = err.response && err.response.data
+      ? JSON.stringify(err.response.data).slice(0, 500)
+      : err.message;
+    throw new Error(`Paraformer submit failed: HTTP ${status || '?'} ${detail}`);
+  }
+
+  const taskId = resp.data && resp.data.output && resp.data.output.task_id;
+  if (!taskId) {
+    throw new Error(`Paraformer submit returned no task_id: ${JSON.stringify(resp.data).slice(0, 500)}`);
+  }
+  console.log(`[paraformer] submit ok task_id=${taskId} file_url=${fileUrl}`);
+  return taskId;
+}
+
+async function pollTask(taskId, opts = {}) {
+  const apiKey = process.env.DASHSCOPE_API_KEY;
+  if (!apiKey) throw new Error('DASHSCOPE_API_KEY not set');
+
+  const onPollHeartbeat = opts.onPollHeartbeat;
+  const url = TASK_URL_BASE + taskId;
+  const headers = { Authorization: `Bearer ${apiKey}` };
+  const t0 = Date.now();
+  const deadline = t0 + POLL_MAX_WAIT_MS;
+  let lastStatus = null;
+
+  while (Date.now() < deadline) {
+    let resp;
+    try {
+      // DashScope's REST query endpoint accepts both GET and POST; we use POST
+      // to mirror the spike script which proved this path works.
+      resp = await axios.post(url, null, { headers, timeout: 30000 });
+    } catch (err) {
+      const status = err.response && err.response.status;
+      const detail = err.response && err.response.data
+        ? JSON.stringify(err.response.data).slice(0, 300)
+        : err.message;
+      throw new Error(`Paraformer poll failed: HTTP ${status || '?'} ${detail}`);
+    }
+
+    const status = resp.data && resp.data.output && resp.data.output.task_status;
+    const elapsedSec = Math.floor((Date.now() - t0) / 1000);
+
+    if (status !== lastStatus) {
+      console.log(`[paraformer] poll [${String(elapsedSec).padStart(4)}s] ${status}`);
+      lastStatus = status;
+    }
+
+    // Heartbeat: tell the orphan-job reaper "I'm still alive." Skip silently
+    // if caller didn't provide one (e.g. one-off scripts).
+    if (typeof onPollHeartbeat === 'function') {
+      try { await onPollHeartbeat(); } catch (e) { /* heartbeat errors non-fatal */ }
+    }
+
+    if (status === 'SUCCEEDED' || status === 'FAILED') {
+      return resp.data;
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`Paraformer poll timeout after ${Math.floor(POLL_MAX_WAIT_MS / 1000)}s (task_id=${taskId})`);
+}
+
+async function fetchTranscripts(transcriptionUrl) {
+  let resp;
+  try {
+    resp = await axios.get(transcriptionUrl, { timeout: 120000 });
+  } catch (err) {
+    const status = err.response && err.response.status;
+    throw new Error(`Paraformer fetch transcripts failed: HTTP ${status || '?'} ${err.message}`);
+  }
+  return (resp.data && resp.data.transcripts) || [];
+}
+
+function formatParaformerSidecar(transcripts) {
+  // Produces lines exactly mirroring OpenAI formatDiarizedJson:
+  //   "A 00:14  text..."
+  const lines = [];
+  for (const tr of transcripts || []) {
+    for (const sent of (tr && tr.sentences) || []) {
+      const speaker = speakerIdToLetter(sent.speaker_id);
+      const mmss = formatMmSs(sent.begin_time);
+      const text = (sent.text || '').trim();
+      lines.push(`${speaker} ${mmss}  ${text}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function applyOpenCC(text) {
+  // OpenCC s2hk converts simplified → HK traditional. Then we fix one quirk:
+  // OpenCC sometimes maps Cantonese 系 (= 係, "is/yes") to 繫 (= "to tie")
+  // because cn→hk lacks the context to distinguish these in casual speech.
+  // Cantonese conversational 系 should always be 係.
+  const converted = opencc_s2hk(text);
+  return converted.replace(/繫/g, '係');
+}
+
+async function transcribeViaParaformer(fileDoc, opts = {}) {
+  const baseUrl = process.env.BACKEND_PUBLIC_BASE_URL;
+  if (!baseUrl) {
+    throw new Error('BACKEND_PUBLIC_BASE_URL not set — paraformer cannot construct public audio URL');
+  }
+  if (!fileDoc || !fileDoc.sourcePath) {
+    throw new Error('transcribeViaParaformer: fileDoc with sourcePath required');
+  }
+
+  // URL constructed from the relative sourcePath. corePublicAudioRouter
+  // serves UPLOADS_DIR via /public/audio. Note: encodeURI on each segment is
+  // unnecessary because upload.js only writes lowercase hex / digits / uuid
+  // pattern — no characters that need URL-encoding.
+  const fileUrl = `${baseUrl.replace(/\/+$/, '')}/public/audio/${fileDoc.sourcePath}`;
+
+  const taskId = await submitTask(fileUrl, opts);
+  const taskData = await pollTask(taskId, opts);
+
+  const taskStatus = taskData.output && taskData.output.task_status;
+  if (taskStatus !== 'SUCCEEDED') {
+    const results = (taskData.output && taskData.output.results) || [];
+    const message = results[0] && (results[0].message || results[0].code) || 'unknown';
+    throw new Error(`Paraformer task FAILED: ${message}`);
+  }
+
+  const results = (taskData.output && taskData.output.results) || [];
+  if (!results.length) throw new Error('Paraformer task SUCCEEDED but no results');
+  const subtaskStatus = results[0].subtask_status;
+  if (subtaskStatus !== 'SUCCEEDED') {
+    const message = results[0].message || results[0].code || subtaskStatus;
+    throw new Error(`Paraformer subtask FAILED: ${message}`);
+  }
+
+  const transcriptionUrl = results[0].transcription_url;
+  if (!transcriptionUrl) throw new Error('Paraformer SUCCEEDED but no transcription_url');
+
+  const transcripts = await fetchTranscripts(transcriptionUrl);
+  const sentenceCount = transcripts.reduce((n, t) => n + ((t.sentences || []).length), 0);
+  const speakerSet = new Set();
+  for (const t of transcripts) {
+    for (const s of (t.sentences || [])) {
+      if (typeof s.speaker_id === 'number') speakerSet.add(s.speaker_id);
+    }
+  }
+  console.log(`[paraformer] fetched ${sentenceCount} sentences ${speakerSet.size} speakers`);
+
+  const rawSidecar = formatParaformerSidecar(transcripts);
+  if (!rawSidecar || rawSidecar.trim() === '') {
+    throw new Error('Paraformer returned empty transcript');
+  }
+  const converted = applyOpenCC(rawSidecar);
+  console.log(`[paraformer] OpenCC s2hk + 繫→係 applied (${rawSidecar.length} → ${converted.length} chars)`);
+  return converted;
+}
+
+module.exports = transcribeViaParaformer;
+module.exports.__test__ = {
+  submitTask,
+  pollTask,
+  fetchTranscripts,
+  formatParaformerSidecar,
+  applyOpenCC,
+  speakerIdToLetter,
+  formatMmSs,
+};

--- a/backend/src/jobs/providers/paraformerProvider.js
+++ b/backend/src/jobs/providers/paraformerProvider.js
@@ -98,6 +98,22 @@ async function submitTask(fileUrl, opts = {}) {
   return taskId;
 }
 
+// Network errors that are usually transient — we retry the poll iteration
+// instead of aborting the whole transcription. HTTP 4xx still aborts (those
+// indicate API contract violations: bad task_id, bad auth, etc.). HTTP 5xx
+// is treated as transient since DashScope occasionally has brief blips.
+const TRANSIENT_ERR_CODES = new Set([
+  'ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'EAI_AGAIN', 'ENOTFOUND', 'ECONNABORTED',
+]);
+const MAX_CONSECUTIVE_TRANSIENT = 5; // safety: don't spin forever if DashScope is fully down
+
+function isTransientError(err) {
+  if (!err) return false;
+  if (err.code && TRANSIENT_ERR_CODES.has(err.code)) return true;
+  if (err.response && err.response.status >= 500 && err.response.status < 600) return true;
+  return false;
+}
+
 async function pollTask(taskId, opts = {}) {
   const apiKey = process.env.DASHSCOPE_API_KEY;
   if (!apiKey) throw new Error('DASHSCOPE_API_KEY not set');
@@ -108,14 +124,26 @@ async function pollTask(taskId, opts = {}) {
   const t0 = Date.now();
   const deadline = t0 + POLL_MAX_WAIT_MS;
   let lastStatus = null;
+  let consecutiveTransient = 0;
 
   while (Date.now() < deadline) {
     let resp;
     try {
-      // DashScope's REST query endpoint accepts both GET and POST; we use POST
-      // to mirror the spike script which proved this path works.
-      resp = await axios.post(url, null, { headers, timeout: 30000 });
+      // GET per DashScope task-query API doc:
+      // https://www.alibabacloud.com/help/en/model-studio/paraformer-recorded-speech-recognition-restful-api
+      resp = await axios.get(url, { headers, timeout: 30000 });
+      consecutiveTransient = 0;
     } catch (err) {
+      if (isTransientError(err) && consecutiveTransient < MAX_CONSECUTIVE_TRANSIENT) {
+        consecutiveTransient += 1;
+        const elapsedSec = Math.floor((Date.now() - t0) / 1000);
+        console.warn(
+          `[paraformer] poll [${String(elapsedSec).padStart(4)}s] transient error ` +
+          `${err.code || err.response?.status} (retry ${consecutiveTransient}/${MAX_CONSECUTIVE_TRANSIENT})`
+        );
+        await sleep(POLL_INTERVAL_MS);
+        continue;
+      }
       const status = err.response && err.response.status;
       const detail = err.response && err.response.data
         ? JSON.stringify(err.response.data).slice(0, 300)

--- a/backend/src/jobs/resumeOrphanJobs.js
+++ b/backend/src/jobs/resumeOrphanJobs.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-const transcribeWithOpenAI = require('./transcriptionWorker');
+const runTranscription = require('./transcriptionWorker');
 
 const ORPHAN_THRESHOLD_MS = 30 * 1000;
 const MAX_ATTEMPTS = 3;
@@ -62,7 +62,7 @@ const resumeOrphanJobs = async () => {
       `[resume-orphan-jobs] job=${job._id} file=${file._id} ${prevStatus}→pending attempts=${job.attempts + 1}`
     );
 
-    transcribeWithOpenAI(file, job).catch((err) => {
+    runTranscription(file, job).catch((err) => {
       console.error(`[resume-orphan-jobs] worker failed for Job ${job._id}: ${err.message}`);
     });
     resumed += 1;

--- a/backend/src/jobs/transcriptionWorker.js
+++ b/backend/src/jobs/transcriptionWorker.js
@@ -1,21 +1,29 @@
+// Transcription dispatcher (#257). Resolves STT provider per upload then
+// hands off to the matching provider module. Per-admin selection beats
+// process-wide env which beats hardcoded 'openai' fallback.
+//
+//   admin.transcribeProvider > process.env.TRANSCRIPTION_PROVIDER > 'openai'
+//
+// Shared helpers (needsCompression / compressToMp3) live here because they
+// apply to OpenAI's push-multipart path (size budget); paraformer's pull
+// path skips compression — DashScope's 2 GB / 2 h limits leave plenty of
+// headroom for the original file.
+
 const path = require('path');
 const fs = require('fs').promises;
-const fsSync = require('fs');
 const { execFile } = require('child_process');
 const { promisify } = require('util');
-const FormData = require('form-data');
-const axios = require('axios');
 const mongoose = require('mongoose');
 
 const { resolveUploadPath } = require('@/utils/uploadsPath');
+const transcribeViaOpenAI = require('./providers/openaiProvider');
+const transcribeViaParaformer = require('./providers/paraformerProvider');
 
 const execFileAsync = promisify(execFile);
 
 const COMPRESSIBLE_EXTS = new Set(['.wav', '.flac', '.aiff', '.aac', '.m4a']);
 const SIZE_THRESHOLD_BYTES = 20 * 1024 * 1024;
-const OPENAI_URL = 'https://api.openai.com/v1/audio/transcriptions';
-const MODEL = 'gpt-4o-transcribe-diarize';
-const RESPONSE_FORMAT = 'diarized_json';
+const VALID_PROVIDERS = new Set(['openai', 'paraformer']);
 
 function needsCompression(file) {
   const ext = path.extname(file.sourcePath).toLowerCase();
@@ -30,87 +38,60 @@ async function compressToMp3(srcPath) {
   return dstPath;
 }
 
-// Mirrors nanobot providers/transcription.py _format_diarized so the sidecar
-// .txt shape stays consistent across CRM-direct and channel-driven paths.
-function formatDiarizedJson(payload) {
-  const segments = payload && Array.isArray(payload.segments) ? payload.segments : null;
-  if (!segments || segments.length === 0) {
-    return (payload && payload.text) || '';
-  }
-  return segments
-    .map((seg) => {
-      const speaker = seg.speaker || '?';
-      const start = Number(seg.start) || 0;
-      const text = (seg.text || '').trim();
-      const mm = String(Math.floor(start / 60)).padStart(2, '0');
-      const ss = String(Math.floor(start % 60)).padStart(2, '0');
-      return `${speaker} ${mm}:${ss}  ${text}`;
-    })
-    .join('\n');
-}
-
-async function callOpenAI(audioPath) {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error('OPENAI_API_KEY not set');
-  const formData = new FormData();
-  formData.append('file', fsSync.createReadStream(audioPath));
-  formData.append('model', MODEL);
-  formData.append('response_format', RESPONSE_FORMAT);
-  formData.append('chunking_strategy', 'auto');
+async function resolveProvider(fileDoc) {
+  let adminProvider = null;
   try {
-    const response = await axios.post(OPENAI_URL, formData, {
-      headers: { ...formData.getHeaders(), Authorization: `Bearer ${apiKey}` },
-      maxBodyLength: Infinity,
-      maxContentLength: Infinity,
-      timeout: parseInt(process.env.OPENAI_TRANSCRIPTION_TIMEOUT_MS, 10) || 600000,
-    });
-    return response.data;
-  } catch (err) {
-    // axios swallows the OpenAI error body — surface it so Job.error and the
-    // structured log capture the real "why" instead of just the HTTP code.
-    if (err && err.response) {
-      const status = err.response.status;
-      const body = err.response.data;
-      const bodyJson =
-        typeof body === 'object' ? JSON.stringify(body) : String(body).slice(0, 500);
-      const detail =
-        body && body.error && body.error.message
-          ? body.error.message
-          : bodyJson;
-      const wrapped = new Error(`OpenAI HTTP ${status}: ${detail}`);
-      wrapped.status = status;
-      wrapped.openaiBody = body;
-      throw wrapped;
-    }
-    throw err;
+    const Admin = mongoose.model('Admin');
+    const admin = await Admin.findById(fileDoc.createdBy).select('transcribeProvider').lean();
+    if (admin && admin.transcribeProvider) adminProvider = admin.transcribeProvider;
+  } catch (e) {
+    // Admin lookup failure shouldn't block transcription — fall through to env/default.
+    console.warn(`[transcribe.dispatch] admin lookup failed: ${e.message}`);
   }
+  const provider = adminProvider || process.env.TRANSCRIPTION_PROVIDER || 'openai';
+  if (!VALID_PROVIDERS.has(provider)) {
+    throw new Error(`Unknown transcription provider: ${provider}`);
+  }
+  return provider;
 }
 
-async function transcribeWithOpenAI(fileDoc, jobDoc) {
+async function runTranscription(fileDoc, jobDoc) {
   const Job = mongoose.model('Job');
   const startTs = Date.now();
   let compressedPath = null;
+
+  const provider = await resolveProvider(fileDoc);
   console.log(
-    `[transcribe.worker] job=${jobDoc._id} file=${fileDoc._id} name=${fileDoc.originalName} size=${fileDoc.sizeBytes} mime=${fileDoc.mimeType} status=pending→running`
+    `[transcribe.worker] job=${jobDoc._id} file=${fileDoc._id} name=${fileDoc.originalName} ` +
+    `size=${fileDoc.sizeBytes} mime=${fileDoc.mimeType} provider=${provider} status=pending→running`
   );
+
   try {
     await Job.findByIdAndUpdate(jobDoc._id, { status: 'running', updated: Date.now() });
 
-    // #266: File.sourcePath is a relative path; resolve to absolute for ffmpeg
-    // / OpenAI calls but never store the absolute form back.
-    const absoluteSourcePath = resolveUploadPath(fileDoc.sourcePath);
-    const audioPath = needsCompression(fileDoc)
-      ? (compressedPath = await compressToMp3(absoluteSourcePath))
-      : absoluteSourcePath;
-
-    const payload = await callOpenAI(audioPath);
-    const transcript = formatDiarizedJson(payload);
-    if (!transcript || transcript.trim() === '') {
-      throw new Error('OpenAI returned empty transcript');
+    let transcript;
+    if (provider === 'openai') {
+      // Push model — compress if needed, then stream multipart.
+      const absoluteSourcePath = resolveUploadPath(fileDoc.sourcePath);
+      const audioPath = needsCompression(fileDoc)
+        ? (compressedPath = await compressToMp3(absoluteSourcePath))
+        : absoluteSourcePath;
+      transcript = await transcribeViaOpenAI(audioPath);
+    } else if (provider === 'paraformer') {
+      // Pull model — DashScope fetches from BACKEND_PUBLIC_BASE_URL via
+      // corePublicAudioRouter; no compression, no local read by us.
+      transcript = await transcribeViaParaformer(fileDoc, {
+        onPollHeartbeat: () =>
+          Job.findByIdAndUpdate(jobDoc._id, { updated: Date.now() }),
+      });
     }
 
-    // Sidecar lives next to the source on disk but is recorded as a relative
-    // path in Job.result.sidecarPath (same portability invariant as #266).
+    if (!transcript || transcript.trim() === '') {
+      throw new Error(`${provider} returned empty transcript`);
+    }
+
+    // Sidecar lives next to source on disk; path stored RELATIVE in Job.result
+    // (same #266 invariant as File.sourcePath).
     const relativeSidecarPath = fileDoc.sourcePath + '.txt';
     const absoluteSidecarPath = resolveUploadPath(relativeSidecarPath);
     await fs.writeFile(absoluteSidecarPath, transcript, 'utf-8');
@@ -123,11 +104,13 @@ async function transcribeWithOpenAI(fileDoc, jobDoc) {
         sidecarPath: relativeSidecarPath,
         sizeBytes: transcriptBytes,
         durationMs,
+        provider,
       },
       updated: Date.now(),
     });
     console.log(
-      `[transcribe.worker] job=${jobDoc._id} status=running→done duration_ms=${durationMs} sidecar_bytes=${transcriptBytes}`
+      `[transcribe.worker] job=${jobDoc._id} provider=${provider} status=running→done ` +
+      `duration_ms=${durationMs} sidecar_bytes=${transcriptBytes}`
     );
   } catch (err) {
     await Job.findByIdAndUpdate(jobDoc._id, {
@@ -136,7 +119,8 @@ async function transcribeWithOpenAI(fileDoc, jobDoc) {
       updated: Date.now(),
     });
     console.error(
-      `[transcribe.worker] job=${jobDoc._id} status=running→failed error=${err.message || String(err)}`
+      `[transcribe.worker] job=${jobDoc._id} provider=${provider} status=running→failed ` +
+      `error=${err.message || String(err)}`
     );
     throw err;
   } finally {
@@ -150,5 +134,5 @@ async function transcribeWithOpenAI(fileDoc, jobDoc) {
   }
 }
 
-module.exports = transcribeWithOpenAI;
-module.exports.__test__ = { needsCompression, compressToMp3, formatDiarizedJson, callOpenAI };
+module.exports = runTranscription;
+module.exports.__test__ = { needsCompression, compressToMp3, resolveProvider };

--- a/backend/src/models/coreModels/Admin.js
+++ b/backend/src/models/coreModels/Admin.js
@@ -41,6 +41,16 @@ const adminSchema = new Schema({
   // 'zh' via `|| 'zh'`. No migration needed.
   language: { type: String, enum: ['zh', 'en'], default: 'zh' },
 
+  // Per-admin STT engine selection (#257). null = fall back to env
+  // TRANSCRIPTION_PROVIDER or hardcoded 'openai'. paraformer = DashScope
+  // Paraformer-v2 (HK Cantonese first-class + 9× cheaper). Existing docs
+  // without this field read null and route to openai unchanged.
+  transcribeProvider: {
+    type: String,
+    enum: ['openai', 'paraformer'],
+    default: null,
+  },
+
   // Updated by trackActivity middleware (≥60s throttle); read by Ola_devboard.
   lastActivity: { type: Date, default: null, index: true },
 

--- a/backend/src/models/coreModels/Admin.js
+++ b/backend/src/models/coreModels/Admin.js
@@ -48,6 +48,9 @@ const adminSchema = new Schema({
   transcribeProvider: {
     type: String,
     enum: ['openai', 'paraformer'],
+    // null = fall back to TRANSCRIPTION_PROVIDER env, then to 'openai'.
+    // Mongoose bypasses enum validation for null/undefined, which is the
+    // sentinel we rely on — do NOT add null to the enum list.
     default: null,
   },
 

--- a/backend/src/routes/coreRoutes/corePublicAudioRouter.js
+++ b/backend/src/routes/coreRoutes/corePublicAudioRouter.js
@@ -1,0 +1,64 @@
+// Public-no-auth audio fetch endpoint for STT providers that pull (Paraformer).
+// Mounted at /public/audio in app.js, so the externally visible URL is
+//   GET /public/audio/<adminId>/<yyyy>/<mm>/<uuid>.<ext>
+// which mirrors File.sourcePath exactly (per #266 relative path scheme).
+//
+// Security model: <uuid> in the path is a UUID v4 generated at upload time
+// (see fileController/upload.js — 122 bits of entropy). That UUID is the
+// unguessable secret. No token, no expiry, no DB lookup. Same posture as the
+// spike Box1 nginx random-slug serve (#257 spike notes).
+//
+// Strict regex on each segment + path traversal defense via startsWith
+// guarantees no escape out of UPLOADS_DIR even with a crafted URL.
+
+const express = require('express');
+const path = require('path');
+
+const { UPLOADS_DIR, resolveUploadPath } = require('@/utils/uploadsPath');
+
+const router = express.Router();
+
+// Format constraints come from upload.js:106-109 — anything that deviates
+// is rejected at 400 before touching the filesystem.
+const ADMIN_ID_RE = /^[a-f0-9]{24}$/;            // Mongo ObjectId hex
+const YEAR_RE = /^\d{4}$/;
+const MONTH_RE = /^\d{2}$/;
+const FILENAME_RE = /^[a-f0-9-]{36}\.[a-z0-9]{1,8}$/i; // uuid v4 + ext
+
+router.route('/:adminId/:year/:month/:filename').get(function (req, res) {
+  try {
+    const { adminId, year, month, filename } = req.params;
+
+    if (!ADMIN_ID_RE.test(adminId)) {
+      return res.status(400).json({ success: false, message: 'invalid adminId' });
+    }
+    if (!YEAR_RE.test(year)) {
+      return res.status(400).json({ success: false, message: 'invalid year' });
+    }
+    if (!MONTH_RE.test(month)) {
+      return res.status(400).json({ success: false, message: 'invalid month' });
+    }
+    if (!FILENAME_RE.test(filename)) {
+      return res.status(400).json({ success: false, message: 'invalid filename' });
+    }
+
+    const relativePath = path.join(adminId, year, month, filename);
+    const absolutePath = resolveUploadPath(relativePath);
+
+    // Belt-and-suspenders: even if regex misses something, the resolved
+    // absolute path MUST stay inside UPLOADS_DIR.
+    if (!absolutePath.startsWith(UPLOADS_DIR + path.sep)) {
+      return res.status(403).json({ success: false, message: 'forbidden' });
+    }
+
+    return res.sendFile(absolutePath, function (err) {
+      if (err) {
+        return res.status(404).json({ success: false, message: 'file not found' });
+      }
+    });
+  } catch (error) {
+    return res.status(503).json({ success: false, message: error.message });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/coreRoutes/corePublicAudioRouter.js
+++ b/backend/src/routes/coreRoutes/corePublicAudioRouter.js
@@ -23,7 +23,7 @@ const router = express.Router();
 const ADMIN_ID_RE = /^[a-f0-9]{24}$/;            // Mongo ObjectId hex
 const YEAR_RE = /^\d{4}$/;
 const MONTH_RE = /^\d{2}$/;
-const FILENAME_RE = /^[a-f0-9-]{36}\.[a-z0-9]{1,8}$/i; // uuid v4 + ext
+const FILENAME_RE = /^[a-f0-9-]{36}\.[a-z0-9]{1,8}$/; // uuid v4 + ext (upload.js always writes lowercase)
 
 router.route('/:adminId/:year/:month/:filename').get(function (req, res) {
   try {
@@ -52,7 +52,11 @@ router.route('/:adminId/:year/:month/:filename').get(function (req, res) {
     }
 
     return res.sendFile(absolutePath, function (err) {
-      if (err) {
+      // sendFile fires the callback twice-shaped: pre-send miss (headers not
+      // yet sent → 404 ok) OR mid-stream client drop (headers + partial body
+      // already on the wire → res.status would throw ERR_HTTP_HEADERS_SENT).
+      // headersSent guard distinguishes the two.
+      if (err && !res.headersSent) {
         return res.status(404).json({ success: false, message: 'file not found' });
       }
     });

--- a/backend/src/setup/set-admin-provider.js
+++ b/backend/src/setup/set-admin-provider.js
@@ -1,0 +1,71 @@
+// Toggle a single admin's transcribeProvider (#257).
+//
+// Usage from backend/ directory:
+//   node src/setup/set-admin-provider.js <email> <openai|paraformer|null>
+//
+// Examples:
+//   node src/setup/set-admin-provider.js admin@admin.com paraformer
+//   node src/setup/set-admin-provider.js sales@gingersoft.com openai
+//   node src/setup/set-admin-provider.js admin@admin.com null   # reset to env default
+//
+// Exit codes: 0 ok, 1 bad args / unknown admin / DB error.
+
+require('dotenv').config({ path: '.env' });
+require('dotenv').config({ path: '.env.local' });
+const mongoose = require('mongoose');
+
+const VALID_PROVIDERS = ['openai', 'paraformer', 'null'];
+
+async function main() {
+  const [, , email, providerArg] = process.argv;
+
+  if (!email || !providerArg) {
+    console.error('Usage: node src/setup/set-admin-provider.js <email> <openai|paraformer|null>');
+    process.exit(1);
+  }
+
+  if (!VALID_PROVIDERS.includes(providerArg)) {
+    console.error(`Invalid provider "${providerArg}". Must be one of: ${VALID_PROVIDERS.join(', ')}`);
+    process.exit(1);
+  }
+
+  if (!process.env.DATABASE) {
+    console.error('DATABASE env var not set — make sure backend/.env exists and is sourced.');
+    process.exit(1);
+  }
+
+  // Load Admin model.
+  require('../models/coreModels/Admin');
+  const Admin = mongoose.model('Admin');
+
+  try {
+    await mongoose.connect(process.env.DATABASE);
+  } catch (err) {
+    console.error('Mongo connect failed:', err.message);
+    process.exit(1);
+  }
+
+  const provider = providerArg === 'null' ? null : providerArg;
+  const result = await Admin.findOneAndUpdate(
+    { email: email.toLowerCase(), removed: { $ne: true } },
+    { transcribeProvider: provider },
+    { new: true }
+  );
+
+  if (!result) {
+    console.error(`No active admin found with email "${email}"`);
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+
+  const display = provider === null ? 'null (will fall back to env / openai)' : provider;
+  console.log(`OK  ${result.email} → transcribeProvider=${display}`);
+
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/backend/test/admin.transcribeProvider.test.js
+++ b/backend/test/admin.transcribeProvider.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for Admin.transcribeProvider field (#257 Item 1).
+ *
+ * Covers:
+ *  - Default value is null when not specified (existing-doc fallback path)
+ *  - Accepted enum values: 'openai' and 'paraformer'
+ *  - Invalid value → save throws ValidationError
+ *  - findOneAndUpdate transitions through both values + back to null
+ */
+
+const path = require('path');
+const mongoose = require('mongoose');
+const { globSync } = require('glob');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+
+let mongo;
+let Admin;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  Admin = mongoose.model('Admin');
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => setTimeout(r, 200));
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  if (Admin) await Admin.deleteMany({});
+});
+
+function adminFixture(extra = {}) {
+  return {
+    email: 'test@example.com',
+    name: 'Test',
+    surname: 'Admin',
+    ...extra,
+  };
+}
+
+test('1. Default transcribeProvider is null (existing-doc fallback)', async () => {
+  const admin = await Admin.create(adminFixture());
+  expect(admin.transcribeProvider).toBeNull();
+});
+
+test('2. transcribeProvider accepts "openai"', async () => {
+  const admin = await Admin.create(adminFixture({ transcribeProvider: 'openai' }));
+  expect(admin.transcribeProvider).toBe('openai');
+});
+
+test('3. transcribeProvider accepts "paraformer"', async () => {
+  const admin = await Admin.create(adminFixture({ transcribeProvider: 'paraformer' }));
+  expect(admin.transcribeProvider).toBe('paraformer');
+});
+
+test('4. Invalid transcribeProvider value rejected by enum', async () => {
+  await expect(
+    Admin.create(adminFixture({ transcribeProvider: 'whisper' }))
+  ).rejects.toThrow(/transcribeProvider/);
+});
+
+test('5. findOneAndUpdate transitions: null → paraformer → openai → null', async () => {
+  const admin = await Admin.create(adminFixture());
+  expect(admin.transcribeProvider).toBeNull();
+
+  await Admin.findByIdAndUpdate(admin._id, { transcribeProvider: 'paraformer' });
+  let reloaded = await Admin.findById(admin._id);
+  expect(reloaded.transcribeProvider).toBe('paraformer');
+
+  await Admin.findByIdAndUpdate(admin._id, { transcribeProvider: 'openai' });
+  reloaded = await Admin.findById(admin._id);
+  expect(reloaded.transcribeProvider).toBe('openai');
+
+  await Admin.findByIdAndUpdate(admin._id, { transcribeProvider: null });
+  reloaded = await Admin.findById(admin._id);
+  expect(reloaded.transcribeProvider).toBeNull();
+});

--- a/backend/test/corePublicAudioRouter.test.js
+++ b/backend/test/corePublicAudioRouter.test.js
@@ -1,0 +1,114 @@
+/**
+ * Tests for corePublicAudioRouter (#257 Item 2).
+ *
+ * Covers:
+ *  - Happy path: valid 4-segment URL serves file from UPLOADS_DIR (200 + bytes)
+ *  - Strict regex on each segment (400 for adminId/year/month/filename mismatch)
+ *  - Path traversal attempts blocked by regex (400) — `..` etc never match
+ *  - Valid format but file absent on disk → 404
+ *  - Belt-and-suspenders: even contrived crafted path stays inside UPLOADS_DIR
+ */
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+
+// Override UPLOADS_DIR to a tmp sandbox BEFORE requiring the router.
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), 'ola-router-test-'));
+process.env.UPLOADS_DIR = SANDBOX;
+
+// Clear @/utils/uploadsPath from cache to ensure it picks up the env override.
+delete require.cache[require.resolve('@/utils/uploadsPath')];
+
+const corePublicAudioRouter = require('@/routes/coreRoutes/corePublicAudioRouter');
+
+const VALID_ADMIN = 'a'.repeat(24);
+const VALID_YEAR = '2026';
+const VALID_MONTH = '05';
+const VALID_FILE = '9f8a3b2c-7e1d-4a5b-9c6d-1f2e3a4b5c6d.m4a';
+
+let app;
+
+beforeAll(() => {
+  app = express();
+  app.use('/public/audio', corePublicAudioRouter);
+
+  // Create the test file at expected sandbox path
+  const dir = path.join(SANDBOX, VALID_ADMIN, VALID_YEAR, VALID_MONTH);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, VALID_FILE), Buffer.from('FAKE_AUDIO_BYTES'));
+});
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+test('1. Happy: valid URL serves file (200 + body bytes)', async () => {
+  const res = await request(app).get(
+    `/public/audio/${VALID_ADMIN}/${VALID_YEAR}/${VALID_MONTH}/${VALID_FILE}`
+  );
+  expect(res.status).toBe(200);
+  expect(res.body.toString()).toBe('FAKE_AUDIO_BYTES');
+});
+
+test('2. Invalid adminId (not 24 hex) → 400', async () => {
+  const res = await request(app).get(
+    `/public/audio/not-a-mongo-id/${VALID_YEAR}/${VALID_MONTH}/${VALID_FILE}`
+  );
+  expect(res.status).toBe(400);
+  expect(res.body.message).toMatch(/adminId/);
+});
+
+test('3. Invalid year (3 digits) → 400', async () => {
+  const res = await request(app).get(
+    `/public/audio/${VALID_ADMIN}/202/${VALID_MONTH}/${VALID_FILE}`
+  );
+  expect(res.status).toBe(400);
+  expect(res.body.message).toMatch(/year/);
+});
+
+test('4. Invalid month (1 digit) → 400', async () => {
+  const res = await request(app).get(
+    `/public/audio/${VALID_ADMIN}/${VALID_YEAR}/5/${VALID_FILE}`
+  );
+  expect(res.status).toBe(400);
+  expect(res.body.message).toMatch(/month/);
+});
+
+test('5. Invalid filename (no extension) → 400', async () => {
+  const noext = '9f8a3b2c-7e1d-4a5b-9c6d-1f2e3a4b5c6d';
+  const res = await request(app).get(
+    `/public/audio/${VALID_ADMIN}/${VALID_YEAR}/${VALID_MONTH}/${noext}`
+  );
+  expect(res.status).toBe(400);
+  expect(res.body.message).toMatch(/filename/);
+});
+
+test('6. Path traversal attempt with .. in filename → blocked by regex (400)', async () => {
+  // Express decodes %2E → '.' so traversal must appear in a way URL can carry.
+  // We use raw `..%2Fetc%2Fpasswd` as filename — fails uuid regex.
+  const res = await request(app).get(
+    `/public/audio/${VALID_ADMIN}/${VALID_YEAR}/${VALID_MONTH}/..%2Fetc%2Fpasswd`
+  );
+  expect(res.status).toBe(400);
+});
+
+test('7. Valid format but file does not exist on disk → 404', async () => {
+  const missing = 'deadbeef-0000-4000-8000-000000000000.m4a';
+  const res = await request(app).get(
+    `/public/audio/${VALID_ADMIN}/${VALID_YEAR}/${VALID_MONTH}/${missing}`
+  );
+  expect(res.status).toBe(404);
+  expect(res.body.message).toMatch(/not found/);
+});
+
+test('8. Wrong adminId (valid hex but different) returns 404, not someone elseʼs file', async () => {
+  const otherAdmin = 'b'.repeat(24);
+  const res = await request(app).get(
+    `/public/audio/${otherAdmin}/${VALID_YEAR}/${VALID_MONTH}/${VALID_FILE}`
+  );
+  // Should pass regex, fail at sendFile (different admin dir doesn't exist)
+  expect(res.status).toBe(404);
+});

--- a/backend/test/file.upload.transcription.test.js
+++ b/backend/test/file.upload.transcription.test.js
@@ -41,7 +41,7 @@ const adminAId = new mongoose.Types.ObjectId();
 let mongo;
 let File;
 let Job;
-let transcribeWithOpenAI;
+let runTranscription;
 
 beforeAll(async () => {
   process.env.OPENAI_API_KEY = 'sk-test-key';
@@ -52,7 +52,7 @@ beforeAll(async () => {
   await mongoose.connect(mongo.getUri());
   File = mongoose.model('File');
   Job = mongoose.model('Job');
-  transcribeWithOpenAI = require(path.join(
+  runTranscription = require(path.join(
     BACKEND_ROOT, 'src/jobs/transcriptionWorker'
   ));
 }, 120000);
@@ -111,7 +111,7 @@ test('1. Happy: small mp3 (no compress) → axios called, sidecar written, Job.d
   const { fileDoc, jobDoc, relativeSourcePath, absoluteSourcePath } =
     await setupAudioFile({ sizeBytes: 5_000_000 });
 
-  await transcribeWithOpenAI(fileDoc, jobDoc);
+  await runTranscription(fileDoc, jobDoc);
 
   expect(child_process.execFile).not.toHaveBeenCalled();
   expect(axios.post).toHaveBeenCalledTimes(1);
@@ -143,7 +143,7 @@ test('2. Large WAV → ffmpeg compress invoked with mono 16k 64k flags → Job.d
     mimeType: 'audio/wav',
   });
 
-  await transcribeWithOpenAI(fileDoc, jobDoc);
+  await runTranscription(fileDoc, jobDoc);
 
   expect(child_process.execFile).toHaveBeenCalledTimes(1);
   const [cmd, args] = child_process.execFile.mock.calls[0];
@@ -161,7 +161,7 @@ test('3. OpenAI 401 → Job.failed + error captured + worker throws', async () =
 
   const { fileDoc, jobDoc } = await setupAudioFile();
 
-  await expect(transcribeWithOpenAI(fileDoc, jobDoc)).rejects.toThrow(/401/);
+  await expect(runTranscription(fileDoc, jobDoc)).rejects.toThrow(/401/);
 
   const finalJob = await Job.findById(jobDoc._id);
   expect(finalJob.status).toBe('failed');
@@ -179,7 +179,7 @@ test('4. ffmpeg ENOENT → Job.failed + axios never called', async () => {
     mimeType: 'audio/wav',
   });
 
-  await expect(transcribeWithOpenAI(fileDoc, jobDoc)).rejects.toThrow(/ffmpeg|ENOENT/i);
+  await expect(runTranscription(fileDoc, jobDoc)).rejects.toThrow(/ffmpeg|ENOENT/i);
 
   const finalJob = await Job.findById(jobDoc._id);
   expect(finalJob.status).toBe('failed');
@@ -192,7 +192,7 @@ test('5. Empty transcript (no segments + no text) → Job.failed', async () => {
 
   const { fileDoc, jobDoc } = await setupAudioFile();
 
-  await expect(transcribeWithOpenAI(fileDoc, jobDoc)).rejects.toThrow(/empty transcript/i);
+  await expect(runTranscription(fileDoc, jobDoc)).rejects.toThrow(/empty transcript/i);
 
   const finalJob = await Job.findById(jobDoc._id);
   expect(finalJob.status).toBe('failed');

--- a/backend/test/paraformerProvider.test.js
+++ b/backend/test/paraformerProvider.test.js
@@ -156,16 +156,20 @@ test('submitTask: response missing task_id → throws', async () => {
 
 // =========== pollTask ===========
 
-test('pollTask: SUCCEEDED on first poll returns data', async () => {
-  axios.post.mockResolvedValueOnce({
+test('pollTask: SUCCEEDED on first poll returns data (uses GET per DashScope doc)', async () => {
+  axios.get.mockResolvedValueOnce({
     data: { output: { task_id: 't1', task_status: 'SUCCEEDED', results: [{ subtask_status: 'SUCCEEDED' }] } },
   });
   const out = await pollTask('t1');
   expect(out.output.task_status).toBe('SUCCEEDED');
+  expect(axios.get).toHaveBeenCalledWith(
+    'https://dashscope.aliyuncs.com/api/v1/tasks/t1',
+    expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer sk-fake-for-tests' }) })
+  );
 });
 
 test('pollTask: heartbeat callback invoked each poll iteration', async () => {
-  axios.post
+  axios.get
     .mockResolvedValueOnce({ data: { output: { task_status: 'RUNNING' } } })
     .mockResolvedValueOnce({ data: { output: { task_status: 'RUNNING' } } })
     .mockResolvedValueOnce({ data: { output: { task_status: 'SUCCEEDED' } } });
@@ -175,7 +179,7 @@ test('pollTask: heartbeat callback invoked each poll iteration', async () => {
 });
 
 test('pollTask: FAILED status returned (caller decides what to do)', async () => {
-  axios.post.mockResolvedValueOnce({
+  axios.get.mockResolvedValueOnce({
     data: { output: { task_status: 'FAILED' }, code: 'InternalError' },
   });
   const out = await pollTask('t1');
@@ -183,9 +187,44 @@ test('pollTask: FAILED status returned (caller decides what to do)', async () =>
 });
 
 test('pollTask: never-finishing task → timeout throw', async () => {
-  axios.post.mockResolvedValue({ data: { output: { task_status: 'RUNNING' } } });
+  axios.get.mockResolvedValue({ data: { output: { task_status: 'RUNNING' } } });
   // POLL_MAX_WAIT_MS=500ms, POLL_INTERVAL_MS=5ms → ~100 polls then throw
   await expect(pollTask('stuck')).rejects.toThrow(/poll timeout/);
+});
+
+test('pollTask: transient ECONNRESET retried, then SUCCEEDED returned', async () => {
+  const err1 = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+  const err2 = Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' });
+  axios.get
+    .mockRejectedValueOnce(err1)
+    .mockRejectedValueOnce(err2)
+    .mockResolvedValueOnce({ data: { output: { task_status: 'SUCCEEDED' } } });
+  const out = await pollTask('flaky');
+  expect(out.output.task_status).toBe('SUCCEEDED');
+  expect(axios.get).toHaveBeenCalledTimes(3);
+});
+
+test('pollTask: HTTP 5xx treated as transient (retried)', async () => {
+  const err5xx = { response: { status: 503, data: { error: 'gateway' } }, message: '503' };
+  axios.get
+    .mockRejectedValueOnce(err5xx)
+    .mockResolvedValueOnce({ data: { output: { task_status: 'SUCCEEDED' } } });
+  const out = await pollTask('flaky5xx');
+  expect(out.output.task_status).toBe('SUCCEEDED');
+});
+
+test('pollTask: HTTP 4xx aborts immediately (NOT retried)', async () => {
+  const err4xx = { response: { status: 401, data: { error: 'unauthorized' } }, message: '401' };
+  axios.get.mockRejectedValueOnce(err4xx);
+  await expect(pollTask('badauth')).rejects.toThrow(/Paraformer poll failed: HTTP 401/);
+  expect(axios.get).toHaveBeenCalledTimes(1);
+});
+
+test('pollTask: persistent transient errors > MAX_CONSECUTIVE_TRANSIENT abort', async () => {
+  const err = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+  // MAX_CONSECUTIVE_TRANSIENT=5, so 6th throws
+  axios.get.mockRejectedValue(err);
+  await expect(pollTask('downhost')).rejects.toThrow(/Paraformer poll failed/);
 });
 
 // =========== fetchTranscripts ===========
@@ -209,11 +248,12 @@ test('fetchTranscripts: HTTP error surfaced', async () => {
 
 // =========== transcribeViaParaformer (full orchestration) ===========
 
-test('transcribeViaParaformer: happy path constructs URL, submits, polls, fetches, formats, OpenCC', async () => {
-  axios.post
-    // submit
-    .mockResolvedValueOnce({ data: { output: { task_id: 'task-xyz' } } })
-    // poll SUCCEEDED
+test('transcribeViaParaformer: happy path constructs URL, submits (POST), polls (GET), fetches (GET), formats, OpenCC', async () => {
+  // submit uses POST
+  axios.post.mockResolvedValueOnce({ data: { output: { task_id: 'task-xyz' } } });
+  // poll uses GET (per DashScope task-query doc)
+  // fetch transcripts also uses GET
+  axios.get
     .mockResolvedValueOnce({
       data: {
         output: {
@@ -221,17 +261,17 @@ test('transcribeViaParaformer: happy path constructs URL, submits, polls, fetche
           results: [{ subtask_status: 'SUCCEEDED', transcription_url: 'https://result.example.com/out.json' }],
         },
       },
+    })
+    .mockResolvedValueOnce({
+      data: {
+        transcripts: [{
+          sentences: [
+            { speaker_id: 0, begin_time: 0, text: '系咯系咯' },
+            { speaker_id: 1, begin_time: 5000, text: '即系咁样' },
+          ],
+        }],
+      },
     });
-  axios.get.mockResolvedValueOnce({
-    data: {
-      transcripts: [{
-        sentences: [
-          { speaker_id: 0, begin_time: 0, text: '系咯系咯' },
-          { speaker_id: 1, begin_time: 5000, text: '即系咁样' },
-        ],
-      }],
-    },
-  });
 
   const fileDoc = { sourcePath: 'aaaaaaaaaaaaaaaaaaaaaaaa/2026/05/9f8a3b2c-7e1d-4a5b-9c6d-1f2e3a4b5c6d.m4a' };
   const out = await transcribeViaParaformer(fileDoc);
@@ -245,8 +285,6 @@ test('transcribeViaParaformer: happy path constructs URL, submits, polls, fetche
   // Verify output is HK traditional with A/B speakers + mmss
   expect(out).toContain('A 00:00');
   expect(out).toContain('B 00:05');
-  // 系 → 係 conversion happens at line start "系咯" too (post-fix catches 繫)
-  // Both lines should NOT contain simplified-only chars
 });
 
 test('transcribeViaParaformer: no BACKEND_PUBLIC_BASE_URL → throws', async () => {
@@ -264,16 +302,15 @@ test('transcribeViaParaformer: fileDoc without sourcePath → throws', async () 
 });
 
 test('transcribeViaParaformer: task FAILED bubbles up specific error', async () => {
-  axios.post
-    .mockResolvedValueOnce({ data: { output: { task_id: 'task-fail' } } })
-    .mockResolvedValueOnce({
-      data: {
-        output: {
-          task_status: 'FAILED',
-          results: [{ message: 'InvalidFile.DownloadFailed' }],
-        },
+  axios.post.mockResolvedValueOnce({ data: { output: { task_id: 'task-fail' } } });
+  axios.get.mockResolvedValueOnce({
+    data: {
+      output: {
+        task_status: 'FAILED',
+        results: [{ message: 'InvalidFile.DownloadFailed' }],
       },
-    });
+    },
+  });
   const fileDoc = { sourcePath: 'aaa/2026/05/file.mp3' };
   await expect(transcribeViaParaformer(fileDoc)).rejects.toThrow(/Paraformer task FAILED.*DownloadFailed/);
 });

--- a/backend/test/paraformerProvider.test.js
+++ b/backend/test/paraformerProvider.test.js
@@ -1,0 +1,279 @@
+/**
+ * Tests for paraformerProvider (#257 Item 3).
+ *
+ * Covers:
+ *  - submitTask: success / no API key / HTTP error / no task_id
+ *  - pollTask: SUCCEEDED / FAILED / heartbeat invoked each tick / timeout
+ *  - fetchTranscripts: returns transcripts array / HTTP failure
+ *  - formatParaformerSidecar: speaker_id 0→A 1→B / mmss format / multi-speaker / empty
+ *  - applyOpenCC: simplified→hk traditional + 繫→係 quirk fix
+ *  - speakerIdToLetter edge cases
+ *  - transcribeViaParaformer happy path orchestration
+ *  - transcribeViaParaformer no BACKEND_PUBLIC_BASE_URL → throws
+ */
+
+// Speed up poll loops for tests — must be set BEFORE require.
+process.env.PARAFORMER_POLL_INTERVAL_MS = '5';
+process.env.PARAFORMER_MAX_WAIT_MS = '500';
+process.env.DASHSCOPE_API_KEY = 'sk-fake-for-tests';
+process.env.BACKEND_PUBLIC_BASE_URL = 'https://test.example.com';
+
+jest.mock('axios');
+const axios = require('axios');
+
+const transcribeViaParaformer = require('@/jobs/providers/paraformerProvider');
+const {
+  submitTask,
+  pollTask,
+  fetchTranscripts,
+  formatParaformerSidecar,
+  applyOpenCC,
+  speakerIdToLetter,
+  formatMmSs,
+} = transcribeViaParaformer.__test__;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+// =========== speakerIdToLetter ===========
+
+test('speakerIdToLetter: 0→A, 1→B, 25→Z, 26→S26, negative→?, non-number→?', () => {
+  expect(speakerIdToLetter(0)).toBe('A');
+  expect(speakerIdToLetter(1)).toBe('B');
+  expect(speakerIdToLetter(25)).toBe('Z');
+  expect(speakerIdToLetter(26)).toBe('S26');
+  expect(speakerIdToLetter(-1)).toBe('?');
+  expect(speakerIdToLetter(null)).toBe('?');
+  expect(speakerIdToLetter(undefined)).toBe('?');
+});
+
+// =========== formatMmSs ===========
+
+test('formatMmSs: 0→00:00, 14000→00:14, 624300→10:24, missing→00:00', () => {
+  expect(formatMmSs(0)).toBe('00:00');
+  expect(formatMmSs(14000)).toBe('00:14');
+  expect(formatMmSs(624300)).toBe('10:24');
+  expect(formatMmSs(null)).toBe('00:00');
+  expect(formatMmSs(undefined)).toBe('00:00');
+});
+
+// =========== formatParaformerSidecar ===========
+
+test('formatParaformerSidecar: maps speaker_id+begin_time+text to lines', () => {
+  const transcripts = [{
+    sentences: [
+      { speaker_id: 0, begin_time: 0, text: 'hello world' },
+      { speaker_id: 1, begin_time: 14000, text: '你好' },
+      { speaker_id: 0, begin_time: 27500, text: 'second turn' },
+    ],
+  }];
+  const out = formatParaformerSidecar(transcripts);
+  expect(out).toBe(
+    'A 00:00  hello world\n' +
+    'B 00:14  你好\n' +
+    'A 00:27  second turn'
+  );
+});
+
+test('formatParaformerSidecar: empty input → empty string', () => {
+  expect(formatParaformerSidecar([])).toBe('');
+  expect(formatParaformerSidecar(null)).toBe('');
+  expect(formatParaformerSidecar([{ sentences: [] }])).toBe('');
+});
+
+// =========== applyOpenCC ===========
+
+test('applyOpenCC: simplified → HK traditional', () => {
+  const input = '讲细啲 嗰啲 听 数 实 时 边 见 国 经 网 余';
+  const out = applyOpenCC(input);
+  // each simplified char → HK traditional equivalent
+  expect(out).toContain('講');
+  expect(out).toContain('聽');
+  expect(out).toContain('數');
+  expect(out).toContain('實');
+  expect(out).toContain('時');
+  expect(out).toContain('邊');
+  expect(out).toContain('國');
+  expect(out).toContain('經');
+  // and no simplified leakage
+  expect(out).not.toMatch(/[讲听数实时边见国经网余]/);
+});
+
+test('applyOpenCC: 繫→係 post-fix (Cantonese 系 quirk)', () => {
+  // OpenCC turns standalone 系个 → 繫個 (= "to tie a piece"), but
+  // Cantonese 系 is always 係 (= "is/yes"). The post-fix corrects this.
+  const input = '系个原因系咩咧';
+  const out = applyOpenCC(input);
+  expect(out).toContain('係'); // appears at least once
+  expect(out).not.toContain('繫'); // never escapes
+});
+
+// =========== submitTask ===========
+
+test('submitTask: happy path returns task_id', async () => {
+  axios.post.mockResolvedValueOnce({
+    data: { output: { task_id: 'task-abc-123', task_status: 'PENDING' } },
+  });
+  const id = await submitTask('https://example.com/audio.mp3');
+  expect(id).toBe('task-abc-123');
+  expect(axios.post).toHaveBeenCalledWith(
+    'https://dashscope.aliyuncs.com/api/v1/services/audio/asr/transcription',
+    expect.objectContaining({
+      model: 'paraformer-v2',
+      input: { file_urls: ['https://example.com/audio.mp3'] },
+      parameters: expect.objectContaining({
+        diarization_enabled: true,
+        language_hints: ['yue', 'zh', 'en'],
+      }),
+    }),
+    expect.objectContaining({ headers: expect.objectContaining({ 'X-DashScope-Async': 'enable' }) })
+  );
+});
+
+test('submitTask: no DASHSCOPE_API_KEY → throws "not set"', async () => {
+  const saved = process.env.DASHSCOPE_API_KEY;
+  delete process.env.DASHSCOPE_API_KEY;
+  try {
+    await expect(submitTask('https://example.com/x.mp3')).rejects.toThrow(/DASHSCOPE_API_KEY not set/);
+  } finally {
+    process.env.DASHSCOPE_API_KEY = saved;
+  }
+});
+
+test('submitTask: HTTP 4xx error surfaced with status + body', async () => {
+  axios.post.mockRejectedValueOnce({
+    response: { status: 400, data: { code: 'InvalidParameter', message: 'bad lang' } },
+    message: 'Request failed with status code 400',
+  });
+  await expect(submitTask('https://example.com/x.mp3')).rejects.toThrow(/Paraformer submit failed: HTTP 400/);
+});
+
+test('submitTask: response missing task_id → throws', async () => {
+  axios.post.mockResolvedValueOnce({ data: { output: { task_status: 'PENDING' } } });
+  await expect(submitTask('https://example.com/x.mp3')).rejects.toThrow(/no task_id/);
+});
+
+// =========== pollTask ===========
+
+test('pollTask: SUCCEEDED on first poll returns data', async () => {
+  axios.post.mockResolvedValueOnce({
+    data: { output: { task_id: 't1', task_status: 'SUCCEEDED', results: [{ subtask_status: 'SUCCEEDED' }] } },
+  });
+  const out = await pollTask('t1');
+  expect(out.output.task_status).toBe('SUCCEEDED');
+});
+
+test('pollTask: heartbeat callback invoked each poll iteration', async () => {
+  axios.post
+    .mockResolvedValueOnce({ data: { output: { task_status: 'RUNNING' } } })
+    .mockResolvedValueOnce({ data: { output: { task_status: 'RUNNING' } } })
+    .mockResolvedValueOnce({ data: { output: { task_status: 'SUCCEEDED' } } });
+  const heartbeat = jest.fn().mockResolvedValue();
+  await pollTask('t1', { onPollHeartbeat: heartbeat });
+  expect(heartbeat).toHaveBeenCalledTimes(3);
+});
+
+test('pollTask: FAILED status returned (caller decides what to do)', async () => {
+  axios.post.mockResolvedValueOnce({
+    data: { output: { task_status: 'FAILED' }, code: 'InternalError' },
+  });
+  const out = await pollTask('t1');
+  expect(out.output.task_status).toBe('FAILED');
+});
+
+test('pollTask: never-finishing task → timeout throw', async () => {
+  axios.post.mockResolvedValue({ data: { output: { task_status: 'RUNNING' } } });
+  // POLL_MAX_WAIT_MS=500ms, POLL_INTERVAL_MS=5ms → ~100 polls then throw
+  await expect(pollTask('stuck')).rejects.toThrow(/poll timeout/);
+});
+
+// =========== fetchTranscripts ===========
+
+test('fetchTranscripts: returns transcripts array from response', async () => {
+  axios.get.mockResolvedValueOnce({
+    data: { transcripts: [{ channel_id: 0, sentences: [{ speaker_id: 0, begin_time: 0, text: 'a' }] }] },
+  });
+  const out = await fetchTranscripts('https://example.com/result.json');
+  expect(out).toHaveLength(1);
+  expect(out[0].sentences[0].text).toBe('a');
+});
+
+test('fetchTranscripts: HTTP error surfaced', async () => {
+  axios.get.mockRejectedValueOnce({
+    response: { status: 404 },
+    message: 'Not Found',
+  });
+  await expect(fetchTranscripts('https://example.com/missing')).rejects.toThrow(/fetch transcripts failed: HTTP 404/);
+});
+
+// =========== transcribeViaParaformer (full orchestration) ===========
+
+test('transcribeViaParaformer: happy path constructs URL, submits, polls, fetches, formats, OpenCC', async () => {
+  axios.post
+    // submit
+    .mockResolvedValueOnce({ data: { output: { task_id: 'task-xyz' } } })
+    // poll SUCCEEDED
+    .mockResolvedValueOnce({
+      data: {
+        output: {
+          task_status: 'SUCCEEDED',
+          results: [{ subtask_status: 'SUCCEEDED', transcription_url: 'https://result.example.com/out.json' }],
+        },
+      },
+    });
+  axios.get.mockResolvedValueOnce({
+    data: {
+      transcripts: [{
+        sentences: [
+          { speaker_id: 0, begin_time: 0, text: '系咯系咯' },
+          { speaker_id: 1, begin_time: 5000, text: '即系咁样' },
+        ],
+      }],
+    },
+  });
+
+  const fileDoc = { sourcePath: 'aaaaaaaaaaaaaaaaaaaaaaaa/2026/05/9f8a3b2c-7e1d-4a5b-9c6d-1f2e3a4b5c6d.m4a' };
+  const out = await transcribeViaParaformer(fileDoc);
+
+  // Verify URL passed to submit
+  const submitArgs = axios.post.mock.calls[0];
+  expect(submitArgs[1].input.file_urls[0]).toBe(
+    `https://test.example.com/public/audio/${fileDoc.sourcePath}`
+  );
+
+  // Verify output is HK traditional with A/B speakers + mmss
+  expect(out).toContain('A 00:00');
+  expect(out).toContain('B 00:05');
+  // 系 → 係 conversion happens at line start "系咯" too (post-fix catches 繫)
+  // Both lines should NOT contain simplified-only chars
+});
+
+test('transcribeViaParaformer: no BACKEND_PUBLIC_BASE_URL → throws', async () => {
+  const saved = process.env.BACKEND_PUBLIC_BASE_URL;
+  delete process.env.BACKEND_PUBLIC_BASE_URL;
+  try {
+    await expect(transcribeViaParaformer({ sourcePath: 'a/b/c.mp3' })).rejects.toThrow(/BACKEND_PUBLIC_BASE_URL not set/);
+  } finally {
+    process.env.BACKEND_PUBLIC_BASE_URL = saved;
+  }
+});
+
+test('transcribeViaParaformer: fileDoc without sourcePath → throws', async () => {
+  await expect(transcribeViaParaformer({})).rejects.toThrow(/sourcePath required/);
+});
+
+test('transcribeViaParaformer: task FAILED bubbles up specific error', async () => {
+  axios.post
+    .mockResolvedValueOnce({ data: { output: { task_id: 'task-fail' } } })
+    .mockResolvedValueOnce({
+      data: {
+        output: {
+          task_status: 'FAILED',
+          results: [{ message: 'InvalidFile.DownloadFailed' }],
+        },
+      },
+    });
+  const fileDoc = { sourcePath: 'aaa/2026/05/file.mp3' };
+  await expect(transcribeViaParaformer(fileDoc)).rejects.toThrow(/Paraformer task FAILED.*DownloadFailed/);
+});

--- a/backend/test/transcriptionWorker.dispatch.test.js
+++ b/backend/test/transcriptionWorker.dispatch.test.js
@@ -1,0 +1,191 @@
+/**
+ * Tests for transcriptionWorker dispatcher logic (#257 Item 4).
+ *
+ * Focus on resolveProvider + dispatch routing (not the provider internals,
+ * which are covered separately in paraformerProvider.test.js and the existing
+ * file.upload.transcription.test.js for openai path).
+ *
+ * Covers:
+ *  - resolveProvider: admin field wins
+ *  - resolveProvider: env wins when admin field is null/missing
+ *  - resolveProvider: hardcoded 'openai' fallback when neither set
+ *  - resolveProvider: admin doc missing → fall through (no crash)
+ *  - runTranscription: paraformer admin routes to paraformerProvider (mocked)
+ *  - runTranscription: openai admin routes to openaiProvider (mocked)
+ *  - runTranscription: unknown provider value → throws explicit error
+ *  - runTranscription: Job.result.provider field written on success
+ */
+
+jest.mock('@/jobs/providers/openaiProvider');
+jest.mock('@/jobs/providers/paraformerProvider');
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const mongoose = require('mongoose');
+const { globSync } = require('glob');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'dispatcher-test-'));
+process.env.UPLOADS_DIR = TMP_DIR;
+
+const transcribeViaOpenAI = require('@/jobs/providers/openaiProvider');
+const transcribeViaParaformer = require('@/jobs/providers/paraformerProvider');
+const runTranscription = require('@/jobs/transcriptionWorker');
+const { resolveProvider } = runTranscription.__test__;
+
+let mongo;
+let Admin;
+let File;
+let Job;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  Admin = mongoose.model('Admin');
+  File = mongoose.model('File');
+  Job = mongoose.model('Job');
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => setTimeout(r, 200));
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+  fs.rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await Admin.deleteMany({});
+  await File.deleteMany({});
+  await Job.deleteMany({});
+  jest.clearAllMocks();
+  delete process.env.TRANSCRIPTION_PROVIDER;
+});
+
+async function makeAdmin({ provider = null, email = 'x@y.com' } = {}) {
+  return Admin.create({
+    email,
+    name: 'Tester',
+    transcribeProvider: provider,
+  });
+}
+
+async function makeFileAndJob(adminId, name = 'a.mp3') {
+  const relativeSourcePath = `${Date.now()}-${Math.random()}-${name}`;
+  const absoluteSourcePath = path.join(TMP_DIR, relativeSourcePath);
+  fs.writeFileSync(absoluteSourcePath, Buffer.alloc(1024, 0));
+  const file = await File.create({
+    createdBy: adminId,
+    originalName: name,
+    mimeType: 'audio/mpeg',
+    sizeBytes: 1024,
+    sourcePath: relativeSourcePath,
+  });
+  const job = await Job.create({
+    createdBy: adminId,
+    type: 'transcription',
+    refModel: 'File',
+    refId: file._id,
+  });
+  return { file, job, absoluteSourcePath, relativeSourcePath };
+}
+
+// =========== resolveProvider ===========
+
+test('resolveProvider: admin field "paraformer" wins over env', async () => {
+  process.env.TRANSCRIPTION_PROVIDER = 'openai';
+  const admin = await makeAdmin({ provider: 'paraformer' });
+  const fileDoc = { createdBy: admin._id };
+  const out = await resolveProvider(fileDoc);
+  expect(out).toBe('paraformer');
+});
+
+test('resolveProvider: env wins when admin field is null', async () => {
+  process.env.TRANSCRIPTION_PROVIDER = 'paraformer';
+  const admin = await makeAdmin({ provider: null });
+  const fileDoc = { createdBy: admin._id };
+  const out = await resolveProvider(fileDoc);
+  expect(out).toBe('paraformer');
+});
+
+test('resolveProvider: hardcoded "openai" fallback when neither set', async () => {
+  delete process.env.TRANSCRIPTION_PROVIDER;
+  const admin = await makeAdmin({ provider: null });
+  const fileDoc = { createdBy: admin._id };
+  const out = await resolveProvider(fileDoc);
+  expect(out).toBe('openai');
+});
+
+test('resolveProvider: admin doc missing → falls through cleanly to env/default', async () => {
+  delete process.env.TRANSCRIPTION_PROVIDER;
+  const fakeId = new mongoose.Types.ObjectId();
+  const fileDoc = { createdBy: fakeId };
+  const out = await resolveProvider(fileDoc);
+  expect(out).toBe('openai');
+});
+
+// =========== runTranscription dispatch ===========
+
+test('runTranscription: paraformer admin → calls paraformerProvider with heartbeat', async () => {
+  transcribeViaParaformer.mockResolvedValue('A 00:00  HK 繁体粤语\nB 00:05  係咩咧');
+  const admin = await makeAdmin({ provider: 'paraformer' });
+  const { file, job, absoluteSourcePath } = await makeFileAndJob(admin._id);
+
+  await runTranscription(file, job);
+
+  expect(transcribeViaParaformer).toHaveBeenCalledTimes(1);
+  expect(transcribeViaParaformer).toHaveBeenCalledWith(
+    expect.objectContaining({ _id: file._id }),
+    expect.objectContaining({ onPollHeartbeat: expect.any(Function) })
+  );
+  expect(transcribeViaOpenAI).not.toHaveBeenCalled();
+
+  const updated = await Job.findById(job._id);
+  expect(updated.status).toBe('done');
+  expect(updated.result.provider).toBe('paraformer');
+  expect(updated.result.sidecarPath).toBe(file.sourcePath + '.txt');
+  // sidecar actually written
+  expect(fs.readFileSync(absoluteSourcePath + '.txt', 'utf-8')).toContain('係咩咧');
+});
+
+test('runTranscription: openai admin → calls openaiProvider with audioPath', async () => {
+  transcribeViaOpenAI.mockResolvedValue('A 00:00  hello');
+  const admin = await makeAdmin({ provider: 'openai' });
+  const { file, job } = await makeFileAndJob(admin._id);
+
+  await runTranscription(file, job);
+
+  expect(transcribeViaOpenAI).toHaveBeenCalledTimes(1);
+  expect(transcribeViaOpenAI.mock.calls[0][0]).toMatch(/\.mp3$/); // audio path arg
+  expect(transcribeViaParaformer).not.toHaveBeenCalled();
+
+  const updated = await Job.findById(job._id);
+  expect(updated.status).toBe('done');
+  expect(updated.result.provider).toBe('openai');
+});
+
+test('runTranscription: env=paraformer + admin null → paraformer', async () => {
+  process.env.TRANSCRIPTION_PROVIDER = 'paraformer';
+  transcribeViaParaformer.mockResolvedValue('A 00:00  test');
+  const admin = await makeAdmin({ provider: null });
+  const { file, job } = await makeFileAndJob(admin._id);
+
+  await runTranscription(file, job);
+  expect(transcribeViaParaformer).toHaveBeenCalledTimes(1);
+  expect(transcribeViaOpenAI).not.toHaveBeenCalled();
+});
+
+test('runTranscription: unknown provider value → throws + Job.failed', async () => {
+  process.env.TRANSCRIPTION_PROVIDER = 'whisper'; // not in VALID_PROVIDERS
+  const admin = await makeAdmin({ provider: null });
+  const { file, job } = await makeFileAndJob(admin._id);
+
+  await expect(runTranscription(file, job)).rejects.toThrow(/Unknown transcription provider: whisper/);
+  // Provider rejection happens before status flips to running — Job stays
+  // in pending. That's correct: the dispatcher fails fast and the upload
+  // returns the fileId so caller can retry after fix.
+});

--- a/ola/PARAFORMER_LOCAL_DEV.md
+++ b/ola/PARAFORMER_LOCAL_DEV.md
@@ -1,0 +1,159 @@
+# Paraformer 本地开发 SOP
+
+> 配套 #257 — DashScope Paraformer-v2 转写引擎接入。OpenAI 推 multipart 不需要任何
+> tunnel，paraformer 只接受 public URL 拉取，所以本地开发必须挂 cloudflared
+> quick tunnel 把 Mac 后端临时暴露给 DashScope。
+
+## 一、首次 setup（每台机器只做一次）
+
+### 1. 装 cloudflared
+```bash
+brew install cloudflared
+```
+
+### 2. backend/.env 加 DASHSCOPE_API_KEY
+```bash
+echo 'DASHSCOPE_API_KEY=sk-xxxxxxxxxxxxxxxx' >> backend/.env
+```
+
+key 找 zyd 拿。`BACKEND_PUBLIC_BASE_URL` 不要手填，`start-dev-paraformer.sh` 会
+动态写入。
+
+### 3. 把要测的 admin 切到 paraformer
+```bash
+cd backend
+node src/setup/set-admin-provider.js admin@admin.com paraformer
+```
+
+切回时：
+```bash
+node src/setup/set-admin-provider.js admin@admin.com openai
+node src/setup/set-admin-provider.js admin@admin.com null   # 跟随 env 默认
+```
+
+## 二、每次 E2E 测试
+
+### Terminal 1 — 一键起 backend + tunnel
+```bash
+bash start-dev-paraformer.sh
+```
+
+输出：
+```
+[1/3] Starting cloudflared quick tunnel → http://localhost:8888 ...
+     Waiting for tunnel URL... ok (5s)
+     → https://xxx-yyy-zzz.trycloudflare.com
+[2/3] Wrote BACKEND_PUBLIC_BASE_URL → backend/.env
+[3/3] Handing off to start-dev.sh ...
+=== Status ===
+  Backend         : running (port 8888)
+  ...
+```
+
+### Terminal 2 — 实时看 worker log
+```bash
+tail -f /tmp/ola-backend.log | grep -E 'transcribe|paraformer'
+```
+
+### Terminal 3 — 真正 E2E
+```bash
+# (a) 登录拿 cookie
+curl -sX POST http://localhost:8888/api/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@admin.com","password":"admin123"}' \
+  -c /tmp/cookies.txt > /dev/null
+
+# (b) 上传音频（示例用 /Users/duke/Desktop/未命名.m4a）
+RESP=$(curl -sX POST http://localhost:8888/api/file/upload \
+  -b /tmp/cookies.txt \
+  -F "file=@/Users/duke/Desktop/未命名.m4a")
+FILE_ID=$(echo $RESP | jq -r .result._id)
+JOB_ID=$(echo $RESP | jq -r .result.transcriptionJobId)
+echo "file=$FILE_ID job=$JOB_ID"
+
+# (c) Smoke: 验证 corePublicAudioRouter 可达（关键卫兵）
+SOURCE=$(curl -sb /tmp/cookies.txt http://localhost:8888/api/file/read/$FILE_ID | jq -r .result.sourcePath)
+URL=$(grep BACKEND_PUBLIC_BASE_URL backend/.env | cut -d= -f2)
+curl -sIo /dev/null -w "public/audio: HTTP %{http_code}\n" "$URL/public/audio/$SOURCE"
+# 期望 HTTP 200 — 这一步炸了 → tunnel 或 router 问题，跟 paraformer 无关
+
+# (d) 轮询 Job
+while :; do
+  STATUS=$(curl -sb /tmp/cookies.txt http://localhost:8888/api/job/read/$JOB_ID | jq -r .result.status)
+  echo "$(date +%H:%M:%S) status=$STATUS"
+  [ "$STATUS" = "done" ] && break
+  [ "$STATUS" = "failed" ] && { echo "FAIL"; curl -sb /tmp/cookies.txt http://localhost:8888/api/job/read/$JOB_ID | jq .result.error; exit 1; }
+  sleep 3
+done
+
+# (e) 读 sidecar
+curl -sb /tmp/cookies.txt http://localhost:8888/api/file/transcript/$FILE_ID \
+  | jq -r .result.transcript | head -20
+```
+
+## 三、PASS 标准（5 条断言）
+
+terminal 2 应该看到：
+```
+[transcribe.worker] job=... file=... provider=paraformer  pending→running
+[paraformer] submit ok task_id=xxxx-xxxx
+[paraformer] poll [   0s] RUNNING
+[paraformer] poll [   5s] RUNNING (heartbeat job.updated=now)
+[paraformer] poll [  15s] SUCCEEDED
+[paraformer] fetched <N> sentences <M> speakers
+[paraformer] OpenCC s2hk + 繫→係 applied
+[transcribe.worker] job=... status=done duration_ms=<N>
+```
+
+terminal 3 (e) sidecar 应该满足：
+1. ✓ 首行格式 `A 00:00  跟住大家有個關係...` — 注意 `A` 不是 `SPEAKER_0`，`關係/時候` 是繁体
+2. ✓ 含 `A` 和 `B` 两个 speaker（如果有第二人）
+3. ✓ mm:ss 时间戳单调递增
+
+terminal 3 (c) 必须 `HTTP 200` — 本地 dev 链路完整性的卫兵。
+
+整体 Job 流转 `pending → running → done`，无 `failed`。
+
+## 四、停止 + 清理
+
+```bash
+bash stop-dev.sh
+```
+
+会自动：
+- kill backend / MCP / nanobot / frontend
+- kill cloudflared
+- 从 backend/.env 删 BACKEND_PUBLIC_BASE_URL 那行
+- 清 /tmp/ola-cloudflared.pid + .url
+
+跑完一定要 `bash stop-dev.sh`，不然 cloudflared 进程会留到下次 start-dev-paraformer.sh 启动时被 stale-pid 检测清掉。
+
+## 五、Debug 矩阵
+
+| 失败 step | 第一时间看 |
+|---|---|
+| (c) 不是 HTTP 200 | `cat /tmp/ola-cloudflared.log` 看 tunnel 健康；`tail /tmp/ola-backend.log` 看 corePublicAudioRouter 报错；regex 是不是挡掉合法 path |
+| (d) 长时间 running | terminal 2 有 `submit ok` 吗？没有 → `DASHSCOPE_API_KEY` 没读到，确认 backend 启动时已 source .env；有 submit + poll RUNNING 永不变 → DashScope 拉不到 cloudflared URL，看 cloudflared log |
+| (d) failed | `curl -sb cookies http://.../api/job/read/<id>` 拿 `result.error`，按 error 内容定位 |
+| sidecar 是简体 | OpenCC `s2hk` 没生效，看 paraformerProvider.js 里 `applyOpenCC` throw 没；package.json 有 `opencc-js` 依赖吗 |
+| sidecar 是 `SPEAKER_0` 不是 `A` | speaker_id→letter map 没接上，看 `formatParaformerSidecar` |
+| terminal 1 报 `cloudflared not found` | `brew install cloudflared` |
+| terminal 1 报 `WARN: no DASHSCOPE_API_KEY` | 按上面"首次 setup"第 2 步加 |
+| Ctrl-C 后 backend 仍跑 | 用 `bash stop-dev.sh` 不要 Ctrl-C |
+
+## 六、Workflow 选择
+
+- **改 paraformer 本身 / OpenCC / dispatcher**：用 `bash start-dev-paraformer.sh`
+- **改任意 provider 无关代码**（FE / 其他 controller / MCP）：用 `bash start-dev.sh` 跳过 tunnel，admin 切回 openai，不用 cloudflared 也能跑
+
+## 七、生产 Box1
+
+prod 不需要 cloudflared。Box1 `.env.production` 里：
+
+```bash
+DASHSCOPE_API_KEY=sk-...
+BACKEND_PUBLIC_BASE_URL=http://47.77.239.237   # Box1 公网 IP，绕过 CF
+```
+
+`http://` 不是 `https://` —— DashScope 直 IP 拉，没有域名走 CF 拦截。这是 spike
+#257 已经验证 work 的链路。

--- a/start-dev-paraformer.sh
+++ b/start-dev-paraformer.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Ola CRM — paraformer dev startup (wraps start-dev.sh)
+# Starts cloudflared quick tunnel → writes BACKEND_PUBLIC_BASE_URL into
+# backend/.env → calls start-dev.sh. Required when admin.transcribeProvider
+# is paraformer locally, because DashScope must fetch the audio file over a
+# publicly-reachable URL and a Mac behind NAT cannot serve directly.
+#
+# State files (read by stop-dev.sh for symmetric cleanup):
+#   /tmp/ola-cloudflared.pid       — tunnel process PID
+#   /tmp/ola-cloudflared.url       — the trycloudflare URL written to .env
+#
+# Usage: bash start-dev-paraformer.sh
+# Stop : bash stop-dev.sh           # handles both this + plain start-dev.sh
+
+set -e
+
+CRM_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$CRM_DIR/backend/.env"
+CF_LOG=/tmp/ola-cloudflared.log
+CF_PID_FILE=/tmp/ola-cloudflared.pid
+CF_URL_FILE=/tmp/ola-cloudflared.url
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo ""
+echo "=== Ola CRM Dev (Paraformer mode) ==="
+echo ""
+
+# Pre-flight
+if ! command -v cloudflared >/dev/null 2>&1; then
+  echo -e "${RED}cloudflared not found.${NC} Install once: brew install cloudflared"
+  exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo -e "${RED}Missing $ENV_FILE${NC} — see backend/.env.example"
+  exit 1
+fi
+
+if ! grep -q '^DASHSCOPE_API_KEY=' "$ENV_FILE"; then
+  echo -e "${YELLOW}WARN: $ENV_FILE has no DASHSCOPE_API_KEY — paraformer path will fail at runtime.${NC}"
+  echo -e "${YELLOW}      Add DASHSCOPE_API_KEY=sk-... to backend/.env (see ola/PARAFORMER_LOCAL_DEV.md).${NC}"
+fi
+
+# Kill any stale tunnel from a previous run (don't accumulate processes)
+if [ -f "$CF_PID_FILE" ]; then
+  OLD_PID=$(cat "$CF_PID_FILE")
+  if kill -0 "$OLD_PID" 2>/dev/null; then
+    echo -e "${YELLOW}Killing stale cloudflared (PID $OLD_PID) from previous run${NC}"
+    kill "$OLD_PID" 2>/dev/null || true
+    sleep 1
+  fi
+  rm -f "$CF_PID_FILE"
+fi
+
+# 1. Start cloudflared quick tunnel pointing at backend (8888)
+echo -e "${GREEN}[1/3] Starting cloudflared quick tunnel → http://localhost:8888 ...${NC}"
+: > "$CF_LOG"
+cloudflared tunnel --url http://localhost:8888 --no-autoupdate >"$CF_LOG" 2>&1 &
+CF_PID=$!
+echo "$CF_PID" > "$CF_PID_FILE"
+
+# 2. Wait for trycloudflare URL (timeout 30s)
+echo -n "     Waiting for tunnel URL..."
+TUNNEL_URL=""
+for i in $(seq 1 30); do
+  TUNNEL_URL=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$CF_LOG" 2>/dev/null | head -1)
+  if [ -n "$TUNNEL_URL" ]; then
+    echo -e " ${GREEN}ok${NC} (${i}s)"
+    echo "$TUNNEL_URL" > "$CF_URL_FILE"
+    break
+  fi
+  sleep 1
+done
+
+if [ -z "$TUNNEL_URL" ]; then
+  echo -e " ${RED}timeout${NC}"
+  echo "     cloudflared log tail:"
+  tail -10 "$CF_LOG" | sed 's/^/       /'
+  kill "$CF_PID" 2>/dev/null || true
+  rm -f "$CF_PID_FILE"
+  exit 1
+fi
+echo "     → $TUNNEL_URL"
+
+# 3. Inject BACKEND_PUBLIC_BASE_URL into backend/.env
+#    Always purge any pre-existing line first (idempotent). Ensure file ends
+#    with a newline before append, otherwise our new line gets concatenated
+#    to whatever last line lacks the trailing '\n' (real bug from first run).
+#    BSD sed (macOS) needs the empty '' after -i.
+sed -i '' '/^BACKEND_PUBLIC_BASE_URL=/d' "$ENV_FILE"
+[ -n "$(tail -c1 "$ENV_FILE")" ] && echo "" >> "$ENV_FILE"
+echo "BACKEND_PUBLIC_BASE_URL=$TUNNEL_URL" >> "$ENV_FILE"
+echo -e "${GREEN}[2/3] Wrote BACKEND_PUBLIC_BASE_URL → $ENV_FILE${NC}"
+
+# 4. Hand off to start-dev.sh — it sources backend/.env so the tunnel URL
+#    is picked up by backend env when nodemon spawns.
+echo -e "${GREEN}[3/3] Handing off to start-dev.sh ...${NC}"
+echo ""
+exec bash "$CRM_DIR/start-dev.sh"

--- a/stop-dev.sh
+++ b/stop-dev.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-# Ola CRM — stop all dev services
+# Ola CRM — stop all dev services (handles both start-dev.sh and
+# start-dev-paraformer.sh; paraformer extras are no-ops when not active).
+
+CRM_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$CRM_DIR/backend/.env"
+CF_PID_FILE=/tmp/ola-cloudflared.pid
+CF_URL_FILE=/tmp/ola-cloudflared.url
 
 echo "Stopping Ola dev services..."
 
@@ -15,6 +21,20 @@ for PORT in 8888 8889 8900 8901 3000; do
     echo "  Killed process on port $PORT"
   fi
 done
+
+# Paraformer dev cleanup — only fires if start-dev-paraformer.sh was used.
+if [ -f "$CF_PID_FILE" ]; then
+  CF_PID=$(cat "$CF_PID_FILE")
+  if kill -0 "$CF_PID" 2>/dev/null; then
+    kill "$CF_PID" 2>/dev/null || true
+    echo "  Killed cloudflared (PID $CF_PID)"
+  fi
+  rm -f "$CF_PID_FILE" "$CF_URL_FILE"
+fi
+if [ -f "$ENV_FILE" ] && grep -q '^BACKEND_PUBLIC_BASE_URL=' "$ENV_FILE"; then
+  sed -i '' '/^BACKEND_PUBLIC_BASE_URL=/d' "$ENV_FILE"
+  echo "  Removed BACKEND_PUBLIC_BASE_URL from backend/.env"
+fi
 
 rm -f /tmp/ola-dev-pids
 echo "Done."


### PR DESCRIPTION
## Summary

CRM 端转写引擎加入 Alibaba DashScope **Paraformer-v2**，跟现有 OpenAI `gpt-4o-transcribe-diarize` **per-admin 共存**。Sophie HK 粤语客户切到 paraformer 上，质量/速度/成本 9× 碾压 OpenAI（详见 issue #257 spike data）。

OpenAI 路径完全保留，零 FE 改动，4-state UI 不变。

## Spike → 决策 → 实现

| 维度 | OpenAI gpt-4o-transcribe-diarize | Paraformer-v2 |
|---|---|---|
| 粤语准确率 | 🔴 全是英文胡话 ("set our sofa") | 🟢 native 粤语 (我哋/嘅/嗰/啲/喺/㖞) |
| Speaker | 🔴 60s 4 个 hallucinate | 🟢 21min 稳定 2 人 global speaker_id |
| 最大时长 | 23min | 2h |
| 价格 | \$0.36/h | ¥0.288/h ≈ \$0.04/h (~9× 便宜) |
| API | sync multipart | async REST polling |

## 架构（6 atomic commits）

1. **feat(dev)** — `start-dev-paraformer.sh` + `set-admin-provider.js` + `PARAFORMER_LOCAL_DEV.md`：local cloudflared quick tunnel 把 backend 公网暴露给 DashScope，per-admin switcher 一行切。
2. **feat(admin)** — `Admin.transcribeProvider` 字段，nullable enum，null = 兜底 openai。
3. **feat(public)** — `corePublicAudioRouter` 在 `/public/audio/<adminId>/<yyyy>/<mm>/<uuid>.<ext>` serve UPLOADS_DIR，UUID v4 (122 bits) 当 unguessable secret，4 段 regex + traversal 防护。
4. **feat(transcribe)** — `paraformerProvider.js` submit/poll(heartbeat)/fetch/format + `opencc-js` s2hk + `繫→係` Cantonese 系 quirk fix。
5. **refactor(transcribe)** — `transcriptionWorker.js` dispatcher：`admin.transcribeProvider > env > 'openai'`；OpenAI 逻辑抽到 `providers/openaiProvider.js`。
6. **docs(env)** — `.env.example` documents 4 new vars + Box1 vs local 差异。

## Test plan

- [x] **Unit (46 new jest cases)**：Admin schema 5 / corePublicAudioRouter 8 / paraformerProvider 20 / dispatcher 8 + 5 pre-existing openai cases pass refactored
- [x] **Local E2E**：`/Users/duke/Desktop/未命名.m4a` (8:36 HK 粤语) → admin=paraformer → tunnel → 47 sentences / 2 speakers / 56 繁体字 / 0 简体 / 21.4s 端到端，5 条断言全过
- [x] **Regression**：admin 切回 openai 路径还 work（dispatcher 不破老路径，refactor 没改 callOpenAI/formatDiarizedJson 行为）
- [ ] **Box1 pre-deploy smoke**（部署前 zyd + Claude 一起执行）：
  - 直 IP `http://47.77.239.237/public/audio/<path>` 200/400/403/404 4-condition curl
  - opencc-js npm install
  - .env.production 加 `DASHSCOPE_API_KEY` + `BACKEND_PUBLIC_BASE_URL=http://47.77.239.237`

## Closes / supersedes

- Sister: closes #267 (粤语 language hint) — paraformer `language_hints=['yue','zh','en']` 完全覆盖
- Sister: supersedes #256 (Tingwu dual-engine) — paraformer 取代 Tingwu 方向，wontfix

## Out of scope (v2 follow-up)

- `vocabulary_id` 热词表（Sophie 那次 `三龙/添加7/GingerSoft` proper-noun 错误的修法）
- 区域自动路由 (`Admin.region` based)
- 简↔繁 配置项（v1 hardcoded `s2hk`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)