### PR TITLE
style(auth): use OLA_LOGO.png uniformly on login page

### DIFF
--- a/frontend/src/modules/AuthModule/index.jsx
+++ b/frontend/src/modules/AuthModule/index.jsx
@@ -5,7 +5,7 @@ import { Layout, Col, Divider, Typography } from 'antd';
 import AuthLayout from '@/layout/AuthLayout';
 import SideContent from './SideContent';
 
-import logo from '@/style/images/logo.png';
+import logo from '@/style/images/OLA_LOGO.png';
 
 const { Content } = Layout;
 const { Title } = Typography;


### PR DESCRIPTION
## 改动内容

- 统一登录页面的 Logo 图案，将手机端的 logo.png 替换为电脑端统一的 OLA_LOGO.png。

## 验证

- [x] 本地测试通过
- [x] 不破坏现有功能