### PR TITLE
style(ui): global datatable hover styling and click-to-read interactive enhancements

### DIFF
--- a/frontend/src/components/DataTable/DataTable.jsx
+++ b/frontend/src/components/DataTable/DataTable.jsx
@@ -138,7 +138,10 @@ export default function DataTable({ config, extra = [] }) {
         >
           <EllipsisOutlined
             style={{ cursor: 'pointer', fontSize: '24px' }}
-            onClick={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
           />
         </Dropdown>
       ),
@@ -205,6 +208,9 @@ export default function DataTable({ config, extra = [] }) {
         loading={listIsLoading}
         onChange={handelDataTableLoad}
         scroll={{ x: true }}
+        onRow={(record) => ({
+          onClick: () => handleRead(record),
+        })}
       />
     </>
   );

--- a/frontend/src/modules/AdvancedCrudModule/DataTable.jsx
+++ b/frontend/src/modules/AdvancedCrudModule/DataTable.jsx
@@ -138,7 +138,10 @@ export default function DataTable({ config, extra = [] }) {
         >
           <EllipsisOutlined
             style={{ cursor: 'pointer', fontSize: '24px' }}
-            onClick={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
           />
         </Dropdown>
       ),
@@ -188,6 +191,9 @@ export default function DataTable({ config, extra = [] }) {
         loading={listIsLoading}
         onChange={handelDataTableLoad}
         scroll={{ x: true }}
+        onRow={(record) => ({
+          onClick: () => handleRead(record),
+        })}
       />
     </>
   );

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -141,7 +141,10 @@ export default function DataTable({ config, extra = [] }) {
         >
           <EllipsisOutlined
             style={{ cursor: 'pointer', fontSize: '24px' }}
-            onClick={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
           />
         </Dropdown>
       ),
@@ -207,6 +210,9 @@ export default function DataTable({ config, extra = [] }) {
         loading={listIsLoading}
         onChange={handelDataTableLoad}
         scroll={{ x: true }}
+        onRow={(record) => ({
+          onClick: () => handleRead(record),
+        })}
       />
     </>
   );

--- a/frontend/src/style/partials/customAntd.css
+++ b/frontend/src/style/partials/customAntd.css
@@ -78,10 +78,13 @@
   font-size: 13px;
   color: #333;
   border-bottom: 1px solid #f5f5f5;
+  transition: color 0.15s ease, background-color 0.15s ease;
 }
 
 .ant-table-tbody > tr:hover > td {
   background: #fafafa !important;
+  color: #0084ff !important;
+  cursor: pointer;
 }
 
 .ant-typography strong {


### PR DESCRIPTION
## 改动内容

- 全局表格悬浮视觉增强（customAntd.css）：鼠标悬浮行时文字颜色平滑过渡为亮蓝色（#0084ff，匹配 Antigravity 发送按钮），背景变灰色，光标变为手型。
- 引入了整行点击跳转/详情展示交互（DataTable.jsx）：升级了 DataTable 组件（包括通用组件、ErpPanel 以及 AdvancedCrud），支持点击数据行任何位置直接展示详情/跳转详情页面。
- 拦截了操作列“...”点击的事件冒泡，保证二级菜单弹出时不产生误触冲突。
- 彻底清理了临时测试的 MongoDB 商品数据及前端拦截器假数据。

## 验证

- [x] 本地测试通过
- [x] 不破坏现有功能