### PR TITLE
style(ui): Files page layout refactoring and DataTable styling fixes

### DIFF
--- a/frontend/src/apps/Header/HeaderContainer.jsx
+++ b/frontend/src/apps/Header/HeaderContainer.jsx
@@ -46,6 +46,7 @@ import {
 const PAGE_MAP = {
   '/': { icon: <DashboardOutlined />, label: 'Dashboard' },
   '/askola': { icon: <SmileOutlined />, label: 'Ask Ola' },
+  '/file': { icon: <FileOutlined />, label: 'file' },
   // === MVP-HIDDEN: 以下页面已从导航中隐藏 ===
   // '/notifications': { icon: <BellOutlined />, label: 'Notifications' },
   // '/messages': { icon: <MessageOutlined />, label: 'Messages' },

--- a/frontend/src/components/DataTable/DataTable.jsx
+++ b/frontend/src/components/DataTable/DataTable.jsx
@@ -209,6 +209,7 @@ export default function DataTable({ config, extra = [] }) {
         scroll={{ x: true }}
         onRow={(record) => ({
           onClick: () => handleRead(record),
+          style: { cursor: 'pointer' },
         })}
       />
     </>

--- a/frontend/src/components/DataTable/DataTable.jsx
+++ b/frontend/src/components/DataTable/DataTable.jsx
@@ -46,6 +46,8 @@ export default function DataTable({ config, extra = [] }) {
   const { moneyFormatter } = useMoney();
   const { dateFormat } = useDate();
 
+  const dispatch = useDispatch();
+
   const items = [
     {
       label: translate('Show'),
@@ -140,7 +142,6 @@ export default function DataTable({ config, extra = [] }) {
             style={{ cursor: 'pointer', fontSize: '24px' }}
             onClick={(e) => {
               e.stopPropagation();
-              e.preventDefault();
             }}
           />
         </Dropdown>
@@ -151,8 +152,6 @@ export default function DataTable({ config, extra = [] }) {
   const { result: listResult, isLoading: listIsLoading } = useSelector(selectListItems);
 
   const { pagination, items: dataSource } = listResult;
-
-  const dispatch = useDispatch();
 
   const handelDataTableLoad = useCallback((pagination) => {
     const options = { page: pagination.current || 1, items: pagination.pageSize || 10 };

--- a/frontend/src/modules/AdvancedCrudModule/DataTable.jsx
+++ b/frontend/src/modules/AdvancedCrudModule/DataTable.jsx
@@ -191,6 +191,7 @@ export default function DataTable({ config, extra = [] }) {
         scroll={{ x: true }}
         onRow={(record) => ({
           onClick: () => handleRead(record),
+          style: { cursor: 'pointer' },
         })}
       />
     </>

--- a/frontend/src/modules/AdvancedCrudModule/DataTable.jsx
+++ b/frontend/src/modules/AdvancedCrudModule/DataTable.jsx
@@ -77,6 +77,7 @@ export default function DataTable({ config, extra = [] }) {
     },
   ];
 
+  const dispatch = useDispatch();
   const navigate = useNavigate();
 
   const handleRead = (record) => {
@@ -140,15 +141,12 @@ export default function DataTable({ config, extra = [] }) {
             style={{ cursor: 'pointer', fontSize: '24px' }}
             onClick={(e) => {
               e.stopPropagation();
-              e.preventDefault();
             }}
           />
         </Dropdown>
       ),
     },
   ];
-
-  const dispatch = useDispatch();
 
   const handelDataTableLoad = (pagination) => {
     const options = { page: pagination.current || 1, items: pagination.pageSize || 10 };

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -210,6 +210,7 @@ export default function DataTable({ config, extra = [] }) {
         scroll={{ x: true }}
         onRow={(record) => ({
           onClick: () => handleRead(record),
+          style: { cursor: 'pointer' },
         })}
       />
     </>

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -79,6 +79,7 @@ export default function DataTable({ config, extra = [] }) {
     },
   ];
 
+  const dispatch = useDispatch();
   const navigate = useNavigate();
 
   const handleRead = (record) => {
@@ -143,15 +144,12 @@ export default function DataTable({ config, extra = [] }) {
             style={{ cursor: 'pointer', fontSize: '24px' }}
             onClick={(e) => {
               e.stopPropagation();
-              e.preventDefault();
             }}
           />
         </Dropdown>
       ),
     },
   ];
-
-  const dispatch = useDispatch();
 
   const handelDataTableLoad = (pagination) => {
     const options = { page: pagination.current || 1, items: pagination.pageSize || 10 };

--- a/frontend/src/pages/File/index.jsx
+++ b/frontend/src/pages/File/index.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Button, Input, Space, Typography, message } from 'antd';
+import { Button, Input, message } from 'antd';
 import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
+import { PageHeader } from '@ant-design/pro-layout';
 
 import { crud } from '@/redux/crud/actions';
 import { selectListItems } from '@/redux/crud/selectors';
 import useLanguage from '@/locale/useLanguage';
+import { ErpLayout } from '@/layout';
 
 import FileDataTable from './FileDataTable';
 import FileUploadModal from './FileUploadModal';
@@ -49,33 +51,39 @@ export default function FilePage() {
   };
 
   return (
-    <div style={{ padding: '24px' }}>
-      <Typography.Title level={3} style={{ marginBottom: 16 }}>
-        {translate('file')}
-      </Typography.Title>
-
-      <Space style={{ marginBottom: 16 }} wrap>
-        <Button
-          type="primary"
-          icon={<PlusOutlined />}
-          onClick={() => setUploadOpen(true)}
-        >
-          {translate('upload_file')}
-        </Button>
-        <Button
-          icon={<ReloadOutlined />}
-          onClick={refresh}
-          loading={isLoading}
-        >
-          {translate('refresh')}
-        </Button>
-        <Input.Search
-          placeholder={translate('search_by_filename')}
-          allowClear
-          style={{ width: 300 }}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
-      </Space>
+    <ErpLayout>
+      <PageHeader
+        title={translate('file')}
+        ghost={true}
+        extra={[
+          <Input.Search
+            key="search"
+            placeholder={translate('search_by_filename')}
+            allowClear
+            style={{ width: 250 }}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />,
+          <Button
+            key="refresh"
+            icon={<ReloadOutlined />}
+            onClick={refresh}
+            loading={isLoading}
+          >
+            {translate('refresh')}
+          </Button>,
+          <Button
+            key="upload"
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => setUploadOpen(true)}
+          >
+            {translate('upload_file')}
+          </Button>,
+        ]}
+        style={{
+          padding: '20px 0px',
+        }}
+      />
 
       <FileDataTable
         items={filtered}
@@ -95,6 +103,6 @@ export default function FilePage() {
         open={!!drawerFileId}
         onClose={() => setDrawerFileId(null)}
       />
-    </div>
+    </ErpLayout>
   );
 }

--- a/frontend/src/style/partials/customAntd.css
+++ b/frontend/src/style/partials/customAntd.css
@@ -83,7 +83,6 @@
 
 .ant-table-tbody > tr:hover > td {
   background: #fafafa !important;
-  color: #0084ff !important;
   cursor: pointer;
 }
 

--- a/frontend/src/style/partials/customAntd.css
+++ b/frontend/src/style/partials/customAntd.css
@@ -83,7 +83,6 @@
 
 .ant-table-tbody > tr:hover > td {
   background: #fafafa !important;
-  cursor: pointer;
 }
 
 .ant-typography strong {


### PR DESCRIPTION
## 改动内容

- **重构 Files 页面布局**：将 `File/index.jsx` 重构为使用全局统一的 `<ErpLayout>` 容器，获得标准的白色圆角卡片背景（`whiteBox`）、标准边距与底边投影。
- **修复顶部标题与图标**：在 `HeaderContainer.jsx` 中新增 `/file` 路由到 `PAGE_MAP` 的映射，绑定与左侧栏一致的 `<FileOutlined />` 图标和多语言 `'file'` 键。
- **优化控制栏**：将搜索框、刷新按钮和上传按钮重新布局，完美置于标准的 `<PageHeader>` 右侧 `extra` 操作区，使其与 Quote 页面及其他核心 ERP 页面排版保持完全一致。
- **修复 DataTable 悬浮与点击逻辑**（之前 commit）：
  - 移除了 DataTable 下拉菜单点击处理器中的 `e.preventDefault()`。
  - 清理了 `customAntd.css` 中对 `ant-table-tbody > tr:hover > td` 的 `color: #0084ff !important` 覆盖，优化悬浮体验。

## 验证

- [x] 本地预览通过，在 localhost:3000/file 验证通过
- [x] 多语言中/英翻译解析正常
- [x] 不破坏现有功能