### PR TITLE
fix(integrations): resolve dropdown selection and row expansion conflicts

### DIFF
--- a/frontend/src/apps/Header/HeaderContainer.jsx
+++ b/frontend/src/apps/Header/HeaderContainer.jsx
@@ -47,6 +47,7 @@ import {
 const PAGE_MAP = {
   '/': { icon: <DashboardOutlined />, label: 'Dashboard' },
   '/askola': { icon: <SmileOutlined />, label: 'Ask Ola' },
+  '/control': { icon: <CheckSquareOutlined />, label: 'Tasks' },
   '/file': { icon: <FileOutlined />, label: 'file' },
   '/integrations': { icon: <ApiOutlined />, label: 'integrations' },
   // === MVP-HIDDEN: 以下页面已从导航中隐藏 ===

--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -46,6 +46,7 @@ import {
   QuestionCircleOutlined,
   LogoutOutlined,
   RightOutlined,
+  DeploymentUnitOutlined,
 } from '@ant-design/icons';
 
 const { Sider } = Layout;
@@ -93,6 +94,11 @@ function Sidebar({ collapsible, isMobile = false }) {
           key: 'askola',
           icon: <SmileOutlined />,
           label: <Link to={'/askola'}>{translate('Ask Ola')}</Link>,
+        },
+        {
+          key: 'control',
+          icon: <DeploymentUnitOutlined />,
+          label: <Link to={'/control'}>{translate('Mission Control')}</Link>,
         },
         {
           key: 'file',

--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -46,7 +46,7 @@ import {
   QuestionCircleOutlined,
   LogoutOutlined,
   RightOutlined,
-  DeploymentUnitOutlined,
+  CheckSquareOutlined,
 } from '@ant-design/icons';
 
 const { Sider } = Layout;
@@ -97,8 +97,8 @@ function Sidebar({ collapsible, isMobile = false }) {
         },
         {
           key: 'control',
-          icon: <DeploymentUnitOutlined />,
-          label: <Link to={'/control'}>{translate('Mission Control')}</Link>,
+          icon: <CheckSquareOutlined />,
+          label: <Link to={'/control'}>{translate('Tasks')}</Link>,
         },
         {
           key: 'file',

--- a/frontend/src/mock/missionMockData.js
+++ b/frontend/src/mock/missionMockData.js
@@ -1,0 +1,209 @@
+/**
+ * Mission Control Mock Data — Palantir-style lead-to-quote command center.
+ *
+ * Shape = front/back contract. Backend Mission model must return objects of
+ * this shape from GET /mission/list.
+ *
+ * `report[]` reuses the AskOla block/widget schema so the drawer renders
+ * it with existing block components. It is the condensed agent work log —
+ * NOT raw emails.
+ */
+
+const MOCK_MISSIONS = [
+  // ── 1. Inquiry · processing ────────────────────────────────────────────
+  {
+    id: 'm_001',
+    client: { name: 'Shanghai Steel Trading Co.', contact: 'Mr. Wang', country: '🇨🇳' },
+    channel: 'whatsapp',
+    stage: 'inquiry',
+    agentState: 'processing',
+    summary: 'Parsing inquiry PDF — 5 wire-rope SKUs requested, matching against catalog.',
+    lastActivityAt: '2026-06-04T13:48:00Z',
+    assignedTo: { name: 'Yuandong', initial: 'Y' },
+    linkedQuote: null,
+    pendingActionCount: 0,
+    goal: 'Extract product needs → match catalog → assist drafting a quote',
+    linkedEntities: [
+      { type: 'client', label: 'Shanghai Steel Trading Co.' },
+      { type: 'merch', label: 'WR-6001' },
+    ],
+    tools: ['merch-matcher', 'quote-drafter'],
+    report: [
+      { type: 'thinking', content: 'Parsing PDF attachment...\nExtracted 5 product requirements\nMatching against merchandise catalog...' },
+      { type: 'text', content: 'Parsing the customer\'s inquiry file. Extracted **5 product requirements** — matching results coming shortly.' },
+    ],
+  },
+
+  // ── 2. Inquiry · awaiting approval ─────────────────────────────────────
+  {
+    id: 'm_002',
+    client: { name: 'Jakarta Hardware Imports', contact: 'Budi', country: '🇮🇩' },
+    channel: 'whatsapp',
+    stage: 'inquiry',
+    agentState: 'awaiting_approval',
+    summary: '3 of 5 SKUs matched (98% / 95% / 91%). 2 unmatched — needs your call before quoting.',
+    lastActivityAt: '2026-06-04T13:20:00Z',
+    assignedTo: { name: 'Ziyue', initial: 'Z' },
+    linkedQuote: null,
+    pendingActionCount: 2,
+    goal: 'Confirm matches → resolve 2 unmatched SKUs → draft quote',
+    linkedEntities: [
+      { type: 'client', label: 'Jakarta Hardware Imports' },
+      { type: 'merch', label: 'WR-6001' },
+      { type: 'merch', label: 'WR-8002' },
+    ],
+    tools: ['merch-matcher', 'quote-drafter'],
+    report: [
+      {
+        type: 'text',
+        content: 'Parsed inquiry. **3 matched**, **2 unmatched**. Please confirm whether to draft a quote from the matched items only.',
+      },
+      {
+        type: 'widget',
+        widgetType: 'merch_match',
+        data: {
+          matched: [
+            { serialNumber: 'WR-6001', name: '6mm Galvanized Wire Rope (6×19)', confidence: 98 },
+            { serialNumber: 'WR-8002', name: '8mm Stainless Wire Rope (7×7)', confidence: 95 },
+            { serialNumber: 'WR-1003', name: '10mm PVC-Coated Wire Rope (6×37)', confidence: 91 },
+          ],
+          unmatched: ['12mm Special Alloy Wire Rope', '5mm Copper-Core Wire Rope'],
+        },
+      },
+      {
+        type: 'action',
+        actions: [
+          { label: 'Approve & draft quote', actionId: 'create_quote', primary: true },
+          { label: 'Add unmatched to catalog', actionId: 'add_unmatched' },
+          { label: 'Reject', actionId: 'reject' },
+        ],
+      },
+    ],
+  },
+
+  // ── 3. Negotiation · idle ──────────────────────────────────────────────
+  {
+    id: 'm_003',
+    client: { name: 'Hamburg Marine Supply', contact: 'Klaus', country: '🇩🇪' },
+    channel: 'email',
+    stage: 'negotiation',
+    agentState: 'idle',
+    summary: 'Customer requested 8% volume discount on a 2,000m order. Awaiting your pricing decision.',
+    lastActivityAt: '2026-06-04T09:10:00Z',
+    assignedTo: { name: 'Yuandong', initial: 'Y' },
+    linkedQuote: { number: 'QT-20260603-014', total: 16400, currency: 'USD' },
+    pendingActionCount: 0,
+    goal: 'Negotiate price within margin floor → re-issue quote',
+    linkedEntities: [
+      { type: 'client', label: 'Hamburg Marine Supply' },
+      { type: 'quote', label: 'QT-20260603-014' },
+    ],
+    tools: ['price-researcher', 'quote-drafter'],
+    report: [
+      {
+        type: 'text',
+        content: 'Customer is requesting an **8% discount** on a 2,000m commitment. Current unit price is at market average — a 5% counter-offer keeps margin above floor. Recommend countering at **5%**.',
+      },
+    ],
+  },
+
+  // ── 4. Quote drafting · processing ─────────────────────────────────────
+  {
+    id: 'm_004',
+    client: { name: 'São Paulo Construções', contact: 'Carla', country: '🇧🇷' },
+    channel: 'whatsapp',
+    stage: 'quote_drafting',
+    agentState: 'processing',
+    summary: 'Drafting quote QT-20260604-021 from matched catalog — 3 line items, pricing pending.',
+    lastActivityAt: '2026-06-04T13:05:00Z',
+    assignedTo: { name: 'Ziyue', initial: 'Z' },
+    linkedQuote: { number: 'QT-20260604-021', total: 6220, currency: 'CNY' },
+    pendingActionCount: 0,
+    goal: 'Generate draft quote → salesperson fills final pricing',
+    linkedEntities: [
+      { type: 'client', label: 'São Paulo Construções' },
+      { type: 'quote', label: 'QT-20260604-021' },
+    ],
+    tools: ['quote-drafter'],
+    report: [
+      {
+        type: 'text',
+        content: 'Generated quote draft from the 3 confirmed items. **Unit prices left blank for the salesperson** — agent never invents prices.',
+      },
+      {
+        type: 'widget',
+        widgetType: 'quote_draft',
+        data: {
+          quoteNumber: 'QT-20260604-021',
+          clientName: 'São Paulo Construções',
+          items: [
+            { serialNumber: 'WR-6001', name: '6mm Galvanized Wire Rope (6×19)', quantity: 500, unit: 'm', price: 4.5 },
+            { serialNumber: 'WR-8002', name: '8mm Stainless Wire Rope (7×7)',   quantity: 300, unit: 'm', price: 8.2 },
+            { serialNumber: 'WR-1003', name: '10mm PVC-Coated Wire Rope (6×37)', quantity: 200, unit: 'm', price: 6.8 },
+          ],
+        },
+      },
+    ],
+  },
+
+  // ── 5. Quote finalization · awaiting approval ──────────────────────────
+  {
+    id: 'm_005',
+    client: { name: 'Lagos Industrial Ltd', contact: 'Chioma', country: '🇳🇬' },
+    channel: 'email',
+    stage: 'quote_finalization',
+    agentState: 'awaiting_approval',
+    summary: 'Quote ready to send — drafted email + PDF. Approve to send via Email.',
+    lastActivityAt: '2026-06-04T11:40:00Z',
+    assignedTo: { name: 'Yuandong', initial: 'Y' },
+    linkedQuote: { number: 'QT-20260603-009', total: 23800, currency: 'USD' },
+    pendingActionCount: 1,
+    goal: 'Finalize pricing + terms → send quote to customer',
+    linkedEntities: [
+      { type: 'client', label: 'Lagos Industrial Ltd' },
+      { type: 'quote', label: 'QT-20260603-009' },
+    ],
+    tools: ['quote-drafter', 'email-composer'],
+    report: [
+      {
+        type: 'text',
+        content: 'Quote **QT-20260603-009** is finalized (FOB terms included). Draft email is ready — **awaiting your approval to send**.',
+      },
+      {
+        type: 'action',
+        actions: [
+          { label: 'Approve & send via Email', actionId: 'send_quote', primary: true },
+          { label: 'Edit draft', actionId: 'edit_draft' },
+        ],
+      },
+    ],
+  },
+
+  // ── 6. Won · done ──────────────────────────────────────────────────────
+  {
+    id: 'm_006',
+    client: { name: 'Dubai Trading FZE', contact: 'Omar', country: '🇦🇪' },
+    channel: 'whatsapp',
+    stage: 'won',
+    agentState: 'done',
+    summary: 'Quote accepted ✓ — customer confirmed PO. Summary synced to client notes.',
+    lastActivityAt: '2026-06-03T16:30:00Z',
+    assignedTo: { name: 'Ziyue', initial: 'Z' },
+    linkedQuote: { number: 'QT-20260602-003', total: 41250, currency: 'USD' },
+    pendingActionCount: 0,
+    goal: 'Quote accepted → hand off to order fulfillment',
+    linkedEntities: [
+      { type: 'client', label: 'Dubai Trading FZE' },
+      { type: 'quote', label: 'QT-20260602-003' },
+    ],
+    tools: [],
+    report: [
+      {
+        type: 'text',
+        content: 'Customer **accepted quote** QT-20260602-003 for **$41,250**. Closing summary synced to client notes. Recommend handing off to the purchase order flow.',
+      },
+    ],
+  },
+];
+
+export default MOCK_MISSIONS;

--- a/frontend/src/modules/MissionControlModule/MissionBoard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionBoard.jsx
@@ -1,0 +1,82 @@
+import { Empty, Badge } from 'antd';
+import MissionCard from './MissionCard';
+import { STAGES, MATRIX_COLUMNS } from './constants';
+
+const COL_STATUS = { processing: 'processing', awaiting_approval: 'warning', done: 'success' };
+
+function PipelineView({ missions, onSelect }) {
+  return (
+    <div className="mc-board mc-board--pipeline">
+      {STAGES.map((stage) => {
+        const items = missions.filter((m) => m.stage === stage.key);
+        return (
+          <div className="mc-col" key={stage.key} style={{ '--stage-color': stage.color }}>
+            <div className="mc-col-head">
+              <span className="mc-col-dot" style={{ background: stage.color }} />
+              <span className="mc-col-title">{stage.label}</span>
+              <span className="mc-col-count">{items.length}</span>
+            </div>
+            <div className="mc-col-body">
+              {items.length === 0
+                ? <div className="mc-col-empty">—</div>
+                : items.map((m) => <MissionCard key={m.id} mission={m} onClick={onSelect} />)
+              }
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MatrixView({ missions, onSelect }) {
+  return (
+    <div
+      className="mc-board mc-board--matrix"
+      style={{ gridTemplateColumns: `160px repeat(${MATRIX_COLUMNS.length}, 1fr)` }}
+    >
+      {/* Corner */}
+      <div className="mc-matrix-corner" />
+
+      {/* Column headers — one outer table, no Card wrappers */}
+      {MATRIX_COLUMNS.map((col) => (
+        <div className="mc-matrix-colhead" key={col.key}>
+          <Badge status={COL_STATUS[col.key] || 'default'} />
+          <div className="mc-matrix-colhead-text">
+            <span className="mc-matrix-colhead-label">{col.label}</span>
+            <span className="mc-matrix-colhead-desc">{col.desc}</span>
+          </div>
+        </div>
+      ))}
+
+      {/* Stage rows */}
+      {STAGES.map((stage) => (
+        <div className="mc-matrix-row" key={stage.key} style={{ display: 'contents' }}>
+          <div className="mc-matrix-rowhead" style={{ '--stage-color': stage.color }}>
+            <span className="mc-col-dot" style={{ background: stage.color }} />
+            {stage.label}
+          </div>
+          {MATRIX_COLUMNS.map((col) => {
+            const items = missions.filter(
+              (m) => m.stage === stage.key && col.states.includes(m.agentState),
+            );
+            return (
+              <div className="mc-matrix-cell" key={col.key}>
+                {items.map((m) => <MissionCard key={m.id} mission={m} onClick={onSelect} />)}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function MissionBoard({ missions, layout, onSelect }) {
+  if (!missions?.length) {
+    return <div style={{ padding: '60px 0', textAlign: 'center' }}><Empty description="No active missions" /></div>;
+  }
+  return layout === 'matrix'
+    ? <MatrixView missions={missions} onSelect={onSelect} />
+    : <PipelineView missions={missions} onSelect={onSelect} />;
+}

--- a/frontend/src/modules/MissionControlModule/MissionBoard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionBoard.jsx
@@ -12,13 +12,28 @@ function PipelineView({ missions, onSelect }) {
         return (
           <div className="mc-col" key={stage.key} style={{ '--stage-color': stage.color }}>
             <div className="mc-col-head">
-              <span className="mc-col-dot" style={{ background: stage.color }} />
-              <span className="mc-col-title">{stage.label}</span>
-              <span className="mc-col-count">{items.length}</span>
+              <Badge
+                color={stage.color}
+                text={
+                  <span className="mc-col-title" style={{ color: '#262626', fontWeight: 600 }}>
+                    {stage.label}
+                  </span>
+                }
+              />
+              <Badge
+                count={items.length}
+                showZero
+                style={{
+                  backgroundColor: '#f0f2f5',
+                  color: '#8c8c8c',
+                  boxShadow: 'none',
+                  fontWeight: 600,
+                }}
+              />
             </div>
             <div className="mc-col-body">
               {items.length === 0
-                ? <div className="mc-col-empty">—</div>
+                ? <div className="mc-col-empty">No active items</div>
                 : items.map((m) => <MissionCard key={m.id} mission={m} onClick={onSelect} />)
               }
             </div>

--- a/frontend/src/modules/MissionControlModule/MissionCard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionCard.jsx
@@ -1,0 +1,83 @@
+import { Avatar, Tooltip } from 'antd';
+import {
+  WhatsAppOutlined, MailOutlined, WechatOutlined,
+  ClockCircleOutlined, ThunderboltOutlined,
+} from '@ant-design/icons';
+import { STAGE_MAP, AGENT_STATES, CHANNELS, timeAgo } from './constants';
+
+const CHANNEL_ICON = {
+  whatsapp: WhatsAppOutlined,
+  email: MailOutlined,
+  wechat: WechatOutlined,
+};
+
+// Agent state → a single dot color; no text label on the card (keep cards minimal)
+const STATE_DOT = {
+  processing: '#1677ff',
+  awaiting_approval: '#faad14',
+  idle: '#d9d9d9',
+  done: '#52c41a',
+};
+
+export default function MissionCard({ mission, onClick }) {
+  const stage = STAGE_MAP[mission.stage];
+  const agent = AGENT_STATES[mission.agentState];
+  const channel = CHANNELS[mission.channel];
+  const ChannelIcon = CHANNEL_ICON[mission.channel] || MailOutlined;
+  const needsAction = mission.pendingActionCount > 0;
+
+  return (
+    <div
+      className={`mc-card${needsAction ? ' mc-card--urgent' : ''}`}
+      style={{ '--stage-color': stage?.color }}
+      onClick={() => onClick?.(mission)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onClick?.(mission)}
+    >
+      {/* Urgent banner — the only non-neutral color element on a card */}
+      {needsAction && (
+        <div className="mc-card-banner">
+          <ThunderboltOutlined />
+          <span>Action Required · {mission.pendingActionCount}</span>
+        </div>
+      )}
+
+      {/* Row 1: channel + client + state dot */}
+      <div className="mc-card-head">
+        {/* Channel icon — neutral gray, tooltip shows the channel name */}
+        <Tooltip title={channel?.label} placement="top">
+          <span className="mc-card-channel">
+            <ChannelIcon />
+          </span>
+        </Tooltip>
+        <span className="mc-card-client">{mission.client.name}</span>
+        {/* State dot only — label visible on hover / in drawer */}
+        <Tooltip title={agent?.label} placement="top">
+          <span className="mc-card-state-dot" style={{ background: STATE_DOT[mission.agentState] }} />
+        </Tooltip>
+      </div>
+
+      {/* Row 2: condensed summary */}
+      <p className="mc-card-summary">{mission.summary}</p>
+
+      {/* Row 3: amount · time · assignee — right-aligned, all muted */}
+      <div className="mc-card-foot">
+        {mission.linkedQuote
+          ? <span className="mc-card-amount">
+              {mission.linkedQuote.currency}&nbsp;{mission.linkedQuote.total.toLocaleString()}
+            </span>
+          : <span />
+        }
+        <div className="mc-card-foot-right">
+          <span className="mc-card-time">
+            <ClockCircleOutlined />&nbsp;{timeAgo(mission.lastActivityAt)}
+          </span>
+          <Avatar size={20} style={{ background: '#f0f0f0', color: '#888', fontSize: 11, fontWeight: 600 }}>
+            {mission.assignedTo?.initial}
+          </Avatar>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/MissionCard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionCard.jsx
@@ -13,10 +13,10 @@ const CHANNEL_ICON = {
 
 // Agent state → a single dot color; no text label on the card (keep cards minimal)
 const STATE_DOT = {
-  processing: '#1677ff',
-  awaiting_approval: '#faad14',
-  idle: '#d9d9d9',
-  done: '#52c41a',
+  processing: '#1890ff',
+  awaiting_approval: '#ffa940',
+  idle: '#595959',
+  done: '#95de64',
 };
 
 export default function MissionCard({ mission, onClick }) {

--- a/frontend/src/modules/MissionControlModule/MissionComposer.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionComposer.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Segmented, Mentions, Button, Space, message } from 'antd';
+import { WhatsAppOutlined, MailOutlined, WechatOutlined, SendOutlined, RobotOutlined } from '@ant-design/icons';
+import { CHANNELS } from './constants';
+
+const MENTION_OPTIONS = [
+  { value: 'Client:current', label: '@Client (current customer)' },
+  { value: 'Merch:WR-6001', label: '@Merch:WR-6001' },
+  { value: 'Factory:Jiangsu-WR', label: '@Factory:Jiangsu Wire Rope' },
+  { value: 'Quote:current', label: '@Quote (linked)' },
+  { value: 'agent:merch-matcher', label: '@merch-matcher (agent)' },
+  { value: 'agent:quote-drafter', label: '@quote-drafter (agent)' },
+  { value: 'agent:price-researcher', label: '@price-researcher (agent)' },
+];
+
+const CHANNEL_OPTS = [
+  { value: 'whatsapp', label: <><WhatsAppOutlined /> WhatsApp</> },
+  { value: 'email',    label: <><MailOutlined /> Email</> },
+  { value: 'wechat',  label: <><WechatOutlined /> WeChat</> },
+];
+
+export default function MissionComposer({ defaultChannel = 'whatsapp' }) {
+  const [channel, setChannel] = useState(defaultChannel);
+  const [value, setValue] = useState('');
+
+  const send = () => {
+    if (!value.trim()) { message.warning('Message is empty'); return; }
+    message.success(`(Demo) Sent via ${CHANNELS[channel]?.label}`);
+    setValue('');
+  };
+
+  return (
+    <div className="mc-composer">
+      <div className="mc-composer-top">
+        <Segmented size="small" value={channel} onChange={setChannel} options={CHANNEL_OPTS} />
+      </div>
+      <Mentions
+        className="mc-composer-input"
+        autoSize={{ minRows: 2, maxRows: 4 }}
+        value={value}
+        onChange={setValue}
+        options={MENTION_OPTIONS}
+        prefix="@"
+        placeholder={`Reply via ${CHANNELS[channel]?.label} — type @ to reference an entity or agent`}
+      />
+      <div className="mc-composer-actions">
+        <Space>
+          <Button size="small" icon={<RobotOutlined />} onClick={() => message.info('(Demo) Ola is drafting a reply…')}>
+            Draft with Ola
+          </Button>
+          <Button size="small" type="primary" icon={<SendOutlined />} onClick={send}>
+            Send via {CHANNELS[channel]?.label}
+          </Button>
+        </Space>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/MissionDrawer.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionDrawer.jsx
@@ -1,0 +1,96 @@
+import { Drawer, Steps, Tag, Divider } from 'antd';
+import {
+  WhatsAppOutlined, MailOutlined, WechatOutlined,
+  AimOutlined, LinkOutlined, ToolOutlined,
+} from '@ant-design/icons';
+import { STAGES, AGENT_STATES, stageIndex } from './constants';
+import ReportFeed from './ReportFeed';
+import MissionComposer from './MissionComposer';
+
+const CHANNEL_ICON = { whatsapp: WhatsAppOutlined, email: MailOutlined, wechat: WechatOutlined };
+
+const STATE_DOT = {
+  processing: '#1677ff',
+  awaiting_approval: '#faad14',
+  idle: '#d9d9d9',
+  done: '#52c41a',
+};
+
+export default function MissionDrawer({ mission, open, onClose }) {
+  if (!mission) return <Drawer open={false} onClose={onClose} />;
+
+  const agent = AGENT_STATES[mission.agentState];
+  const ChannelIcon = CHANNEL_ICON[mission.channel] || MailOutlined;
+
+  const title = (
+    <div className="mc-drawer-title">
+      <span className="mc-drawer-channel"><ChannelIcon /></span>
+      <span className="mc-drawer-client">{mission.client.name}</span>
+      <span className="mc-card-state-dot" style={{ background: STATE_DOT[mission.agentState] }} />
+      <span style={{ fontSize: 12, color: '#aaa' }}>{agent?.label}</span>
+    </div>
+  );
+
+  return (
+    <Drawer
+      title={title}
+      open={open}
+      onClose={onClose}
+      placement="right"
+      width={680}
+      footer={<MissionComposer defaultChannel={mission.channel} />}
+      styles={{
+        footer: { padding: '12px 16px', borderTop: '1px solid #f0f0f0' },
+        header: { borderBottom: '1px solid #f0f0f0' },
+      }}
+    >
+      <Steps
+        size="small"
+        current={stageIndex(mission.stage)}
+        status={mission.stage === 'won' ? 'finish' : 'process'}
+        items={STAGES.map((s) => ({ title: s.short }))}
+        style={{ marginBottom: 20 }}
+      />
+
+      <div className="mc-context">
+        <div className="mc-context-row">
+          <AimOutlined className="mc-context-icon" />
+          <span className="mc-context-label">Goal</span>
+          <span className="mc-context-val">{mission.goal}</span>
+        </div>
+        <div className="mc-context-row">
+          <LinkOutlined className="mc-context-icon" />
+          <span className="mc-context-label">Linked</span>
+          <span className="mc-context-val">
+            {mission.linkedEntities.map((e) => (
+              <Tag key={`${e.type}-${e.label}`} style={{ marginBottom: 2 }}>
+                {e.type}: {e.label}
+              </Tag>
+            ))}
+          </span>
+        </div>
+        {mission.tools?.length > 0 && (
+          <div className="mc-context-row">
+            <ToolOutlined className="mc-context-icon" />
+            <span className="mc-context-label">Tools</span>
+            <span className="mc-context-val">
+              {mission.tools.map((t) => (
+                <Tag key={t} style={{ fontFamily: 'monospace', marginBottom: 2 }}>
+                  {t}
+                </Tag>
+              ))}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <Divider style={{ margin: '16px 0 12px' }}>
+        <span style={{ fontSize: 11, color: '#bbb', fontWeight: 600, letterSpacing: '0.5px', textTransform: 'uppercase' }}>
+          Agent Report
+        </span>
+      </Divider>
+
+      <ReportFeed blocks={mission.report} />
+    </Drawer>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/ReportFeed.jsx
+++ b/frontend/src/modules/MissionControlModule/ReportFeed.jsx
@@ -1,0 +1,38 @@
+import TextBlock from '@/components/AskOla/blocks/TextBlock';
+import WidgetBlock from '@/components/AskOla/blocks/WidgetBlock';
+import ActionBlock from '@/components/AskOla/blocks/ActionBlock';
+import ThinkingBlock from '@/components/AskOla/blocks/ThinkingBlock';
+import FileBlock from '@/components/AskOla/blocks/FileBlock';
+import SaveToNotes from './SaveToNotes';
+
+function renderBlock(block) {
+  switch (block.type) {
+    case 'text':    return <TextBlock content={block.content} />;
+    case 'widget':  return <WidgetBlock widgetType={block.widgetType} data={block.data} />;
+    case 'action':  return <ActionBlock actions={block.actions} />;
+    case 'thinking':return <ThinkingBlock content={block.content} />;
+    case 'file':    return <FileBlock filename={block.filename} fileType={block.fileType} size={block.size} url={block.url} />;
+    default:        return <div className="askola-block-unknown">[unsupported: {block.type}]</div>;
+  }
+}
+
+function summarize(block) {
+  if (block.type === 'text')   return block.content.replace(/[*#`]/g, '').slice(0, 120);
+  if (block.type === 'widget') return `[${block.widgetType}] agent 输出`;
+  if (block.type === 'thinking') return 'Agent 推理过程';
+  if (block.type === 'file')   return block.filename;
+  return '';
+}
+
+export default function ReportFeed({ blocks = [] }) {
+  return (
+    <div className="mc-feed">
+      {blocks.map((block, i) => (
+        <div className="mc-report-block" key={i}>
+          {block.type !== 'action' && <SaveToNotes payload={summarize(block)} />}
+          {renderBlock(block)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/SaveToNotes.jsx
+++ b/frontend/src/modules/MissionControlModule/SaveToNotes.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Popover, Radio, Button, Space, Typography, message } from 'antd';
+import { PushpinOutlined } from '@ant-design/icons';
+
+const TARGET_LABELS = {
+  client: 'This client',
+  merch: 'Merchandise',
+  factory: 'Factory',
+};
+
+export default function SaveToNotes({ payload, targetTypes = ['client', 'merch', 'factory'] }) {
+  const [open, setOpen] = useState(false);
+  const [target, setTarget] = useState(targetTypes[0]);
+
+  const content = (
+    <div style={{ width: 200 }} onClick={(e) => e.stopPropagation()}>
+      <Typography.Text type="secondary" style={{ fontSize: 12 }}>Save to</Typography.Text>
+      <div style={{ margin: '8px 0' }}>
+        <Radio.Group value={target} onChange={(e) => setTarget(e.target.value)}>
+          <Space direction="vertical" size={4}>
+            {targetTypes.map((t) => (
+              <Radio key={t} value={t}>{TARGET_LABELS[t]}</Radio>
+            ))}
+          </Space>
+        </Radio.Group>
+      </div>
+      {payload && (
+        <Typography.Paragraph
+          ellipsis={{ rows: 2 }}
+          style={{ fontSize: 11, color: '#aaa', background: '#fafafa', padding: '4px 8px', borderRadius: 4, marginBottom: 8 }}
+        >
+          {payload}
+        </Typography.Paragraph>
+      )}
+      <Button
+        type="primary" size="small" block
+        onClick={() => { setOpen(false); message.success(`Saved to ${TARGET_LABELS[target]} notes (demo)`); }}
+      >
+        Save note
+      </Button>
+    </div>
+  );
+
+  return (
+    <Popover content={content} title={null} trigger="click" open={open} onOpenChange={setOpen} placement="leftTop">
+      <button className="mc-pin-btn" title="Save to notes" onClick={(e) => e.stopPropagation()}>
+        <PushpinOutlined />
+      </button>
+    </Popover>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/constants.js
+++ b/frontend/src/modules/MissionControlModule/constants.js
@@ -1,0 +1,60 @@
+// Mission Control — shared metadata for the lead-to-quote command center.
+//
+// UI-only prototype constants. The real values are the *contract* the backend
+// Mission model will mirror once it exists (stage + channel enums, agentState).
+// Keep this list as the single source of truth for the board so columns,
+// chips and the detail stepper never drift apart.
+
+// ── Business pipeline (the lead-to-quote funnel) ─────────────────────────────
+// `won` is shown as the terminal column; `lost` is a terminal state too but is
+// filtered out of the default board (surfaced via a filter later).
+export const STAGES = [
+  { key: 'inquiry', label: 'Lead Inquiry', short: 'Inquiry', color: '#1668dc' },
+  { key: 'negotiation', label: 'Negotiation', short: 'Negotiation', color: '#13a8a8' },
+  { key: 'quote_drafting', label: 'Quote Drafting', short: 'Drafting', color: '#d89614' },
+  { key: 'quote_finalization', label: 'Quote Finalization', short: 'Finalizing', color: '#642ab5' },
+  { key: 'won', label: 'Won', short: 'Won', color: '#52c41a' },
+];
+
+export const STAGE_MAP = Object.fromEntries(STAGES.map((s) => [s.key, s]));
+
+export function stageIndex(key) {
+  return STAGES.findIndex((s) => s.key === key);
+}
+
+// ── Agent execution state (Palantir's Processing / Approval / Completed) ──────
+export const AGENT_STATES = {
+  processing: { key: 'processing', label: 'Processing', color: '#3b82f6' },
+  awaiting_approval: { key: 'awaiting_approval', label: 'Awaiting Approval', color: '#faad14' },
+  idle: { key: 'idle', label: 'Idle', color: '#7b88a0' },
+  done: { key: 'done', label: 'Completed', color: '#52c41a' },
+};
+
+// The 3 status columns of the Palantir-style matrix view. `idle` folds into
+// Processing so every mission lands in exactly one cell.
+export const MATRIX_COLUMNS = [
+  { key: 'processing', label: 'Agent Active', desc: 'Ola is working on this', states: ['processing', 'idle'] },
+  { key: 'awaiting_approval', label: 'Needs Review', desc: 'Waiting for your input', states: ['awaiting_approval'] },
+  { key: 'done', label: 'Done', desc: 'Mission completed', states: ['done'] },
+];
+
+// ── Inbound/outbound channels — generic, never hardcode whatsapp as the only
+// source (CLAUDE.md MVP rule). WeChat / Email are first-class peers.
+export const CHANNELS = {
+  whatsapp: { key: 'whatsapp', label: 'WhatsApp', color: '#25d366' },
+  email: { key: 'email', label: 'Email', color: '#3b82f6' },
+  wechat: { key: 'wechat', label: 'WeChat', color: '#07c160' },
+};
+
+// ── Small relative-time helper for card timestamps ("12m ago"). ──────────────
+export function timeAgo(iso) {
+  if (!iso) return '';
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diff / 60000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  return `${day}d ago`;
+}

--- a/frontend/src/modules/MissionControlModule/constants.js
+++ b/frontend/src/modules/MissionControlModule/constants.js
@@ -9,11 +9,11 @@
 // `won` is shown as the terminal column; `lost` is a terminal state too but is
 // filtered out of the default board (surfaced via a filter later).
 export const STAGES = [
-  { key: 'inquiry', label: 'Lead Inquiry', short: 'Inquiry', color: '#1668dc' },
-  { key: 'negotiation', label: 'Negotiation', short: 'Negotiation', color: '#13a8a8' },
-  { key: 'quote_drafting', label: 'Quote Drafting', short: 'Drafting', color: '#d89614' },
-  { key: 'quote_finalization', label: 'Quote Finalization', short: 'Finalizing', color: '#642ab5' },
-  { key: 'won', label: 'Won', short: 'Won', color: '#52c41a' },
+  { key: 'inquiry', label: 'Lead Inquiry', short: 'Inquiry', color: '#1890ff' },
+  { key: 'negotiation', label: 'Negotiation', short: 'Negotiation', color: '#13c2c2' },
+  { key: 'quote_drafting', label: 'Quote Drafting', short: 'Drafting', color: '#722ed1' },
+  { key: 'quote_finalization', label: 'Quote Finalization', short: 'Finalizing', color: '#ffa940' },
+  { key: 'won', label: 'Won', short: 'Won', color: '#95de64' },
 ];
 
 export const STAGE_MAP = Object.fromEntries(STAGES.map((s) => [s.key, s]));
@@ -24,10 +24,10 @@ export function stageIndex(key) {
 
 // ── Agent execution state (Palantir's Processing / Approval / Completed) ──────
 export const AGENT_STATES = {
-  processing: { key: 'processing', label: 'Processing', color: '#3b82f6' },
-  awaiting_approval: { key: 'awaiting_approval', label: 'Awaiting Approval', color: '#faad14' },
-  idle: { key: 'idle', label: 'Idle', color: '#7b88a0' },
-  done: { key: 'done', label: 'Completed', color: '#52c41a' },
+  processing: { key: 'processing', label: 'Processing', color: '#1890ff' },
+  awaiting_approval: { key: 'awaiting_approval', label: 'Awaiting Approval', color: '#ffa940' },
+  idle: { key: 'idle', label: 'Idle', color: '#595959' },
+  done: { key: 'done', label: 'Completed', color: '#95de64' },
 };
 
 // The 3 status columns of the Palantir-style matrix view. `idle` folds into

--- a/frontend/src/modules/MissionControlModule/index.jsx
+++ b/frontend/src/modules/MissionControlModule/index.jsx
@@ -1,11 +1,10 @@
 import { useState, useMemo } from 'react';
-import { Input, Segmented, Typography, Space } from 'antd';
+import { Input, Segmented } from 'antd';
 import { AppstoreOutlined, TableOutlined, SearchOutlined } from '@ant-design/icons';
+import { PageHeader } from '@ant-design/pro-layout';
 import MOCK_MISSIONS from '@/mock/missionMockData';
 import MissionBoard from './MissionBoard';
 import MissionDrawer from './MissionDrawer';
-
-const { Title, Text } = Typography;
 
 export default function MissionControlModule() {
   const [layout, setLayout] = useState('pipeline');
@@ -24,23 +23,26 @@ export default function MissionControlModule() {
 
   return (
     <div className="mc-root">
-      <div className="mc-header">
-        <div>
-          <Title level={4} style={{ margin: 0 }}>Tasks</Title>
-          <Text type="secondary" style={{ fontSize: 13 }}>
-            Lead-to-Quote tracker · {missions.length} active
-          </Text>
-        </div>
-        <Space size={12}>
+      <PageHeader
+        title="Tasks"
+        subTitle={`Lead-to-Quote tracker · ${missions.length} active`}
+        ghost={false}
+        style={{
+          padding: '0 0 20px 0',
+          background: 'transparent',
+        }}
+        extra={[
           <Input
+            key="search"
             allowClear
             prefix={<SearchOutlined style={{ color: '#bbb' }} />}
             placeholder="Search by client or summary"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            style={{ width: 240 }}
-          />
+            style={{ width: 240, borderRadius: '6px' }}
+          />,
           <Segmented
+            key="layout"
             value={layout}
             onChange={setLayout}
             options={[
@@ -48,8 +50,8 @@ export default function MissionControlModule() {
               { value: 'matrix',   icon: <TableOutlined />,    label: 'Matrix' },
             ]}
           />
-        </Space>
-      </div>
+        ]}
+      />
 
       <MissionBoard missions={missions} layout={layout} onSelect={setActive} />
       <MissionDrawer mission={active} open={!!active} onClose={() => setActive(null)} />

--- a/frontend/src/modules/MissionControlModule/index.jsx
+++ b/frontend/src/modules/MissionControlModule/index.jsx
@@ -1,0 +1,58 @@
+import { useState, useMemo } from 'react';
+import { Input, Segmented, Typography, Space } from 'antd';
+import { AppstoreOutlined, TableOutlined, SearchOutlined } from '@ant-design/icons';
+import MOCK_MISSIONS from '@/mock/missionMockData';
+import MissionBoard from './MissionBoard';
+import MissionDrawer from './MissionDrawer';
+
+const { Title, Text } = Typography;
+
+export default function MissionControlModule() {
+  const [layout, setLayout] = useState('pipeline');
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(null);
+
+  const missions = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return MOCK_MISSIONS;
+    return MOCK_MISSIONS.filter(
+      (m) =>
+        m.client.name.toLowerCase().includes(q) ||
+        m.summary.toLowerCase().includes(q),
+    );
+  }, [query]);
+
+  return (
+    <div className="mc-root">
+      <div className="mc-header">
+        <div>
+          <Title level={4} style={{ margin: 0 }}>Mission Control</Title>
+          <Text type="secondary" style={{ fontSize: 13 }}>
+            Lead-to-Quote tracker · {missions.length} active
+          </Text>
+        </div>
+        <Space size={12}>
+          <Input
+            allowClear
+            prefix={<SearchOutlined style={{ color: '#bbb' }} />}
+            placeholder="Search by client or summary"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            style={{ width: 240 }}
+          />
+          <Segmented
+            value={layout}
+            onChange={setLayout}
+            options={[
+              { value: 'pipeline', icon: <AppstoreOutlined />, label: 'Pipeline' },
+              { value: 'matrix',   icon: <TableOutlined />,    label: 'Matrix' },
+            ]}
+          />
+        </Space>
+      </div>
+
+      <MissionBoard missions={missions} layout={layout} onSelect={setActive} />
+      <MissionDrawer mission={active} open={!!active} onClose={() => setActive(null)} />
+    </div>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/index.jsx
+++ b/frontend/src/modules/MissionControlModule/index.jsx
@@ -26,7 +26,7 @@ export default function MissionControlModule() {
     <div className="mc-root">
       <div className="mc-header">
         <div>
-          <Title level={4} style={{ margin: 0 }}>Mission Control</Title>
+          <Title level={4} style={{ margin: 0 }}>Tasks</Title>
           <Text type="secondary" style={{ fontSize: 13 }}>
             Lead-to-Quote tracker · {missions.length} active
           </Text>

--- a/frontend/src/pages/Integrations/index.jsx
+++ b/frontend/src/pages/Integrations/index.jsx
@@ -1,6 +1,6 @@
-import { useState, useMemo } from 'react';
-import { Button, Input, Switch, Row, Col, Tag, Segmented, message, Modal } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
+import { useState, useMemo, Fragment, useEffect, useRef, useCallback } from 'react';
+import { Button, Input, Switch, Row, Col, Tag, Segmented, message, Modal, Dropdown } from 'antd';
+import { PlusOutlined, UserOutlined, LockOutlined, CheckOutlined, DownOutlined, SearchOutlined, EditOutlined } from '@ant-design/icons';
 import { PageHeader } from '@ant-design/pro-layout';
 import useLanguage from '@/locale/useLanguage';
 import whatsappLogo from '@/style/images/whatsapp.png';
@@ -23,6 +23,25 @@ const INTEGRATIONS_DATA = [
       />
     ),
   },
+  {
+    id: 'notion',
+    name: 'Notion',
+    connected: false,
+    popular: true,
+    descriptionKey: 'integration_desc_notion',
+    logo: (
+      <svg
+        fill="#000000"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        style={{ width: '22px', height: '22px', objectFit: 'contain' }}
+      >
+        <title>Notion</title>
+        <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.981-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.887l-15.177.887c-.56.047-.747.327-.747.933zm14.337.745c.093.42 0 .84-.42.888l-.7.14v10.264c-.608.327-1.168.514-1.635.514-.748 0-.935-.234-1.495-.933l-4.577-7.186v6.952L12.21 19s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.233V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279v-6.44l-1.215-.139c-.093-.514.28-.887.747-.933zM1.936 1.035l13.31-.98c1.634-.14 2.055-.047 3.082.7l4.249 2.986c.7.513.934.653.934 1.213v16.378c0 1.026-.373 1.634-1.68 1.726l-15.458.934c-.98.047-1.448-.093-1.962-.747l-3.129-4.06c-.56-.747-.793-1.306-.793-1.96V2.667c0-.839.374-1.54 1.447-1.632z" />
+      </svg>
+    ),
+  },
 ];
 
 export default function IntegrationsPage() {
@@ -36,11 +55,83 @@ export default function IntegrationsPage() {
   const [activeTab, setActiveTab] = useState('all');
   const [showConnectedOnly, setShowConnectedOnly] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isNotionModalOpen, setIsNotionModalOpen] = useState(false);
+  
+  // Notion Modal States
+  const [nickname, setNickname] = useState("Team's Account");
+  const [accessType, setAccessType] = useState('team');
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  const [notionAccounts, setNotionAccounts] = useState([
+    {
+      id: '1',
+      label: "Team's Account",
+      access: 'team',
+      addedBy: 'will.ziheng',
+      enabled: true,
+      locked: false,
+      tools: {
+        getUsers: 'auto',
+        updateDataSource: 'auto',
+        getComments: 'auto',
+      }
+    },
+    {
+      id: '2',
+      label: "Personal Account",
+      access: 'private',
+      addedBy: 'will.ziheng',
+      enabled: true,
+      locked: false,
+      tools: {
+        getUsers: 'ask',
+        updateDataSource: 'off',
+        getComments: 'auto',
+      }
+    }
+  ]);
+  const [currentView, setCurrentView] = useState('list');
+  const [notionSearchQuery, setNotionSearchQuery] = useState('');
+  
+  // Settings & Tools Expansion States
+  const [selectedAccountId, setSelectedAccountId] = useState(null);
+  const [activeSubTab, setActiveSubTab] = useState('settings');
+  const [openDropdownId, setOpenDropdownId] = useState(null);
 
+  // Global click-away listener to close any open custom dropdown
+  useEffect(() => {
+    if (!openDropdownId) return;
+    const handleClickOutside = (e) => {
+      // If the click is inside a dropdown zone, let the zone's own handler deal with it
+      if (e.target.closest('[data-dropdown-zone]')) return;
+      setOpenDropdownId(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [openDropdownId]);
+
+  const handleToggleRowSelection = (id) => {
+    setSelectedAccountId((prev) => (prev === id ? null : id));
+  };
+
+  const handleRowClick = (e, accountId) => {
+    // If the click originated from inside a dropdown zone, skip row toggle
+    if (e.target.closest('[data-dropdown-zone]')) return;
+    handleToggleRowSelection(accountId);
+  };
+ 
   // TODO: replace with Redux dispatch + real backend endpoint when integration backend is wired
   const handleToggleConnection = (id, name) => {
     if (id === 'whatsapp' && !connectedIds.has('whatsapp')) {
       setIsModalOpen(true);
+      return;
+    }
+    if (id === 'notion') {
+      if (connectedIds.has('notion')) {
+        setCurrentView('notion');
+      } else {
+        setIsNotionModalOpen(true);
+      }
       return;
     }
     const wasConnected = connectedIds.has(id);
@@ -60,6 +151,198 @@ export default function IntegrationsPage() {
     }
   };
 
+  const handleUpdateAccountAccess = (id, newAccess) => {
+    setNotionAccounts((prev) =>
+      prev.map((account) =>
+        account.id === id ? { ...account, access: newAccess } : account
+      )
+    );
+    message.success(`Access level updated successfully`);
+  };
+
+  const handleUpdateAccountLabel = (id, newLabel) => {
+    setNotionAccounts((prev) =>
+      prev.map((account) =>
+        account.id === id ? { ...account, label: newLabel } : account
+      )
+    );
+  };
+
+  const handleUpdateAccountEnabled = (id, enabled) => {
+    setNotionAccounts((prev) =>
+      prev.map((account) =>
+        account.id === id ? { ...account, enabled } : account
+      )
+    );
+    message.success(enabled ? `Integration enabled` : `Integration disabled`);
+  };
+
+  const handleUpdateAccountLocked = (id, locked) => {
+    setNotionAccounts((prev) =>
+      prev.map((account) =>
+        account.id === id ? { ...account, locked } : account
+      )
+    );
+    message.success(locked ? `Integration locked` : `Integration unlocked`);
+  };
+
+  const handleDisconnectAccount = (id) => {
+    setNotionAccounts((prev) => prev.filter((account) => account.id !== id));
+    setSelectedAccountId(null);
+    // If no accounts left, reset Notion connected status
+    setNotionAccounts((curr) => {
+      if (curr.length === 0) {
+        setConnectedIds((prevIds) => {
+          const next = new Set(prevIds);
+          next.delete('notion');
+          return next;
+        });
+        setCurrentView('list');
+      }
+      return curr;
+    });
+    message.success(`Integration disconnected successfully`);
+  };
+
+  const handleUpdateToolSetting = (accountId, toolKey, value) => {
+    setNotionAccounts((prev) =>
+      prev.map((account) => {
+        if (account.id === accountId) {
+          return {
+            ...account,
+            tools: {
+              ...(account.tools || {}),
+              [toolKey]: value,
+            }
+          };
+        }
+        return account;
+      })
+    );
+    message.success(`Tool setting updated successfully`);
+  };
+
+  const getToolLabel = (val) => {
+    if (val === 'off') return 'Off';
+    if (val === 'ask') return 'Ask for confirmation';
+    return 'Run automatically';
+  };
+
+  const toolDropdownButtonStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '8px',
+    height: '36px',
+    width: '180px',
+    padding: '0 12px',
+    borderRadius: '8px',
+    border: '1px solid #d9d9d9',
+    background: '#ffffff',
+    color: '#262626',
+    fontSize: '13px',
+    fontWeight: '500',
+    fontFamily: 'Inter, sans-serif',
+    boxShadow: 'none',
+    cursor: 'pointer',
+  };
+
+  // Custom dropdown menu component (no Ant Design Dropdown, no Portal)
+  const CustomDropdown = ({ id, triggerContent, menuContent, menuWidth = 200 }) => {
+    const isOpen = openDropdownId === id;
+    return (
+      <div data-dropdown-zone="true" style={{ position: 'relative', display: 'inline-block' }}>
+        <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpenDropdownId(isOpen ? null : id);
+          }}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '8px',
+            height: '32px',
+            padding: '0 10px',
+            borderRadius: '6px',
+            border: 'none',
+            background: '#f5f5f5',
+            color: '#595959',
+            fontSize: '13px',
+            fontWeight: '500',
+            fontFamily: 'Inter, sans-serif',
+            boxShadow: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          {triggerContent}
+          <DownOutlined style={{ fontSize: '10px', color: '#8c8c8c' }} />
+        </Button>
+        {isOpen && (
+          <div style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            marginTop: '4px',
+            zIndex: 1050,
+            background: '#ffffff',
+            border: '1px solid #f0f0f0',
+            borderRadius: '12px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+            padding: '8px 0',
+            width: menuWidth,
+          }}>
+            {menuContent}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderToolDropdownMenu = (accountId, toolKey) => {
+    const currentVal = notionAccounts.find(a => a.id === accountId)?.tools?.[toolKey] || 'auto';
+    const dropdownId = `tool-${accountId}-${toolKey}`;
+    return (
+      <CustomDropdown
+        id={dropdownId}
+        menuWidth={200}
+        triggerContent={<span style={{ fontFamily: 'Inter, sans-serif', fontSize: '13px', fontWeight: '500', color: '#262626' }}>{getToolLabel(currentVal)}</span>}
+        menuContent={
+          <>
+            {[
+              { label: 'Off', value: 'off' },
+              { label: 'Run automatically', value: 'auto' },
+              { label: 'Ask for confirmation', value: 'ask' }
+            ].map((opt) => (
+              <div
+                key={opt.value}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '10px 16px',
+                  cursor: 'pointer',
+                  background: currentVal === opt.value ? '#f5f5f5' : 'transparent',
+                  fontFamily: 'Inter, sans-serif',
+                  fontSize: '14px',
+                  color: '#1f1f1f',
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleUpdateToolSetting(accountId, toolKey, opt.value);
+                  setOpenDropdownId(null);
+                }}
+              >
+                {opt.label}
+                {currentVal === opt.value && <CheckOutlined style={{ color: '#1f1f1f' }} />}
+              </div>
+            ))}
+          </>
+        }
+      />
+    );
+  };
+ 
   const filteredIntegrations = useMemo(() => {
     return INTEGRATIONS_DATA.filter((item) => {
       const matchesSearch = item.name.toLowerCase().includes(searchQuery.toLowerCase());
@@ -68,6 +351,12 @@ export default function IntegrationsPage() {
       return matchesSearch && matchesTab && matchesConnected;
     });
   }, [connectedIds, searchQuery, activeTab, showConnectedOnly]);
+
+  const filteredNotionAccounts = useMemo(() => {
+    return notionAccounts.filter((account) =>
+      account.label.toLowerCase().includes(notionSearchQuery.toLowerCase())
+    );
+  }, [notionAccounts, notionSearchQuery]);
 
   return (
     <div
@@ -79,143 +368,579 @@ export default function IntegrationsPage() {
         minHeight: '80vh',
       }}
     >
-      {/* Header Zone */}
-      <PageHeader
-        title={translate('integrations')}
-        ghost={false}
-        extra={[
-          <Input.Search
-            key="search"
-            placeholder={translate('search')}
-            allowClear
-            style={{ width: 250 }}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            value={searchQuery}
-          />,
-          <Button
-            key="add-custom"
-            type="default"
-            icon={<PlusOutlined />}
-            style={{
-              borderRadius: '6px',
-              borderColor: '#d9d9d9',
-              color: '#595959',
-              height: '36px',
-              fontSize: '14px',
-              fontWeight: 500,
-              boxShadow: '0 2px 0 rgba(0, 0, 0, 0.016)',
-              cursor: 'pointer',
-              transition: 'all 0.3s',
-            }}
-            onClick={() => message.info(translate('custom_mcp_coming_soon'))}
-          >
-            {translate('add_custom_mcp')}
-          </Button>,
-        ]}
-        style={{ padding: '20px 0px' }}
-      >
-        <p style={{ color: '#595959', fontSize: '15px', margin: '0 0 16px 0', fontFamily: 'Inter, system-ui, sans-serif' }}>
-          {translate('integrations_subtitle')}
-        </p>
-      </PageHeader>
+      <style>{`
+        /* Override Ant Design default pink/lavender halos for inputs & buttons */
+        .ant-input:focus, 
+        .ant-input-focused,
+        .ant-input:hover,
+        .ant-input-affix-wrapper:focus,
+        .ant-input-affix-wrapper-focused,
+        .ant-input-affix-wrapper:hover {
+          border-color: #bfbfbf !important;
+          box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.05) !important;
+          outline: none !important;
+        }
 
-      {/* Tabs and Show Connected Switch Bar commented out as currently not needed */}
-      {/* 
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
-        <Segmented
-          options={[
-            { label: translate('all_integrations'), value: 'all' },
-            { label: translate('popular_integrations'), value: 'popular' },
-          ]}
-          value={activeTab}
-          onChange={setActiveTab}
-        />
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <span style={{ color: '#8c8c8c', fontSize: '14px', fontFamily: 'Inter, sans-serif' }}>
-            {translate('show_connected_only')}
-          </span>
-          <Switch
-            checked={showConnectedOnly}
-            onChange={(checked) => setShowConnectedOnly(checked)}
-            style={{ background: showConnectedOnly ? '#52c41a' : '#bfbfbf' }}
-          />
-        </div>
-      </div>
-      */}
+        /* Default outline/active buttons */
+        .ant-btn:focus-visible,
+        .ant-btn:active {
+          outline: none !important;
+          box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.04) !important;
+        }
 
-      {/* Grid of integration cards */}
-      <Row gutter={[24, 24]}>
-        {filteredIntegrations.map((item) => {
-          const isConnected = connectedIds.has(item.id);
-          return (
-            <Col xs={24} sm={12} md={8} key={item.id}>
-              <div
-                className={`whiteBox shadow integration-card${isConnected ? ' integration-card--connected' : ''}`}
-                onClick={() => handleToggleConnection(item.id, item.name)}
-                style={{ cursor: 'pointer' }}
+        /* Primary action button click / focus */
+        .ant-btn-primary:focus,
+        .ant-btn-primary:active,
+        .ant-btn-primary:focus-visible {
+          background: #1f1f1f !important;
+          border-color: #1f1f1f !important;
+          box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.08) !important;
+        }
+
+        .ant-btn-primary:hover {
+          background: #333333 !important;
+          border-color: #333333 !important;
+          color: #ffffff !important;
+        }
+
+        /* Switch active focus ring */
+        .ant-switch:focus,
+        .ant-switch:focus-visible {
+          box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.08) !important;
+          outline: none !important;
+        }
+
+        /* Disable all dynamic transitions and animations for Switch, Access Button, and Dropdown overlays */
+        .ant-switch, 
+        .ant-switch *,
+        .ant-switch-handle,
+        .ant-switch-handle::before,
+        .ant-btn,
+        .ant-btn *,
+        .ant-dropdown,
+        .ant-dropdown *,
+        .ant-dropdown-menu,
+        .ant-dropdown-menu * {
+          transition: none !important;
+          animation: none !important;
+        }
+      `}</style>
+      {currentView === 'list' ? (
+        <>
+          {/* Header Zone */}
+          <PageHeader
+            title={translate('integrations')}
+            ghost={false}
+            extra={[
+              <Input.Search
+                key="search"
+                placeholder={translate('search')}
+                allowClear
+                style={{ width: 250 }}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                value={searchQuery}
+              />,
+              <Button
+                key="add-custom"
+                type="default"
+                icon={<PlusOutlined />}
+                style={{
+                  borderRadius: '6px',
+                  borderColor: '#d9d9d9',
+                  color: '#595959',
+                  height: '36px',
+                  fontSize: '14px',
+                  fontWeight: 500,
+                  boxShadow: '0 2px 0 rgba(0, 0, 0, 0.016)',
+                  cursor: 'pointer',
+                  transition: 'all 0.3s',
+                }}
+                onClick={() => message.info(translate('custom_mcp_coming_soon'))}
               >
-                {/* Logo — always visible, no animation */}
-                <div className="integration-card__logo">
-                  {item.logo}
-                </div>
+                {translate('add_custom_mcp')}
+              </Button>,
+            ]}
+            style={{ padding: '20px 0px' }}
+          >
+            <p style={{ color: '#595959', fontSize: '15px', margin: '0 0 16px 0', fontFamily: 'Inter, system-ui, sans-serif' }}>
+              {translate('integrations_subtitle')}
+            </p>
+          </PageHeader>
 
-                {/* Text area — clips the two sliding layers */}
-                <div className="integration-card__text-area">
-                  {/* Name + tag: slides up and out on hover */}
-                  <div className="integration-card__name-row">
-                    <span
-                      style={{
-                        fontWeight: '500',
-                        fontSize: '16px',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        fontFamily: 'Inter, system-ui, sans-serif',
-                      }}
-                    >
-                      {item.name}
-                    </span>
-                    <div>
-                      {isConnected ? (
-                        <Tag
-                          color="success"
-                          style={{ borderRadius: '12px', border: 'none', padding: '2px 10px', fontSize: '12px', fontWeight: '500', margin: 0 }}
+          {/* Grid of integration cards */}
+          <Row gutter={[24, 24]}>
+            {filteredIntegrations.map((item) => {
+              const isConnected = connectedIds.has(item.id);
+              return (
+                <Col xs={24} sm={12} md={8} key={item.id}>
+                  <div
+                    className={`whiteBox shadow integration-card${isConnected ? ' integration-card--connected' : ''}`}
+                    onClick={() => handleToggleConnection(item.id, item.name)}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    {/* Logo — always visible, no animation */}
+                    <div className="integration-card__logo">
+                      {item.logo}
+                    </div>
+
+                    {/* Text area — clips the two sliding layers */}
+                    <div className="integration-card__text-area">
+                      {/* Name + tag: slides up and out on hover */}
+                      <div className="integration-card__name-row">
+                        <span
+                          style={{
+                            fontWeight: '500',
+                            fontSize: '16px',
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            fontFamily: 'Inter, system-ui, sans-serif',
+                          }}
                         >
-                          {translate('connected')}
-                        </Tag>
-                      ) : (
-                        <Tag
-                          color="default"
-                          style={{ borderRadius: '12px', border: '1px solid #d9d9d9', background: '#ffffff', color: '#8c8c8c', padding: '2px 10px', fontSize: '12px', fontWeight: '500', margin: 0 }}
-                        >
-                          {translate('connect')}
-                        </Tag>
-                      )}
+                          {item.name}
+                        </span>
+                        <div>
+                          {isConnected ? (
+                            <Tag
+                              color="success"
+                              style={{ borderRadius: '12px', border: 'none', padding: '2px 10px', fontSize: '12px', fontWeight: '500', margin: 0 }}
+                            >
+                              {translate('connected')}
+                            </Tag>
+                          ) : (
+                            <Tag
+                              color="default"
+                              style={{ borderRadius: '12px', border: '1px solid #d9d9d9', background: '#ffffff', color: '#8c8c8c', padding: '2px 10px', fontSize: '12px', fontWeight: '500', margin: 0 }}
+                            >
+                              {translate('connect')}
+                            </Tag>
+                          )}
+                        </div>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </div>
-            </Col>
-          );
-        })}
-      </Row>
+                </Col>
+              );
+            })}
+          </Row>
 
-      {/* Empty State */}
-      {filteredIntegrations.length === 0 && (
-        <div
-          className="whiteBox shadow"
-          style={{
-            background: '#ffffff',
-            padding: '60px 20px',
-            textAlign: 'center',
-            borderRadius: '12px',
-            border: '1px solid #eeeeee',
-            color: '#8c8c8c',
-            fontSize: '15px',
-          }}
-        >
-          {translate('no_integrations_found')}
-        </div>
+          {/* Empty State */}
+          {filteredIntegrations.length === 0 && (
+            <div
+              className="whiteBox shadow"
+              style={{
+                background: '#ffffff',
+                padding: '60px 20px',
+                textAlign: 'center',
+                borderRadius: '12px',
+                border: '1px solid #eeeeee',
+                color: '#8c8c8c',
+                fontSize: '15px',
+              }}
+            >
+              {translate('no_integrations_found')}
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          {/* Breadcrumbs */}
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '24px', fontSize: '14px', fontFamily: 'Inter, sans-serif' }}>
+            <span
+              onClick={() => setCurrentView('list')}
+              style={{ color: '#8c8c8c', cursor: 'pointer', transition: 'color 0.2s' }}
+              onMouseEnter={(e) => e.target.style.color = '#595959'}
+              onMouseLeave={(e) => e.target.style.color = '#8c8c8c'}
+            >
+              Integrations
+            </span>
+            <span style={{ color: '#bfbfbf' }}>&gt;</span>
+            <span style={{ color: '#1f1f1f', fontWeight: '500' }}>Notion</span>
+          </div>
+
+          {/* Title Row */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '32px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+              <svg fill="#000000" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style={{ width: '32px', height: '32px' }}>
+                <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.981-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.887l-15.177.887c-.56.047-.747.327-.747.933zm14.337.745c.093.42 0 .84-.42.888l-.7.14v10.264c-.608.327-1.168.514-1.635.514-.748 0-.935-.234-1.495-.933l-4.577-7.186v6.952L12.21 19s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.233V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279v-6.44l-1.215-.139c-.093-.514.28-.887.747-.933zM1.936 1.035l13.31-.98c1.634-.14 2.055-.047 3.082.7l4.249 2.986c.7.513.934.653.934 1.213v16.378c0 1.026-.373 1.634-1.68 1.726l-15.458.934c-.98.047-1.448-.093-1.962-.747l-3.129-4.06c-.56-.747-.793-1.306-.793-1.96V2.667c0-.839.374-1.54 1.447-1.632z" />
+              </svg>
+              <h1 style={{ fontSize: '32px', fontWeight: '600', color: '#1f1f1f', margin: 0, fontFamily: 'Inter, system-ui, sans-serif' }}>
+                Notion
+              </h1>
+            </div>
+
+            <Button
+              icon={<PlusOutlined />}
+              onClick={() => {
+                setNickname(`Account ${notionAccounts.length + 1}`);
+                setIsNotionModalOpen(true);
+              }}
+              style={{
+                height: '38px',
+                borderRadius: '8px',
+                border: '1px solid #d9d9d9',
+                color: '#262626',
+                fontWeight: '500',
+                fontFamily: 'Inter, sans-serif',
+                fontSize: '14px',
+                cursor: 'pointer',
+              }}
+            >
+              Add another account
+            </Button>
+          </div>
+
+          {/* Accounts Count */}
+          <div style={{ color: '#8c8c8c', fontSize: '14px', marginBottom: '12px', fontFamily: 'Inter, sans-serif' }}>
+            {filteredNotionAccounts.length} {filteredNotionAccounts.length === 1 ? 'account' : 'accounts'} connected
+          </div>
+
+          {/* Table of Accounts */}
+          {filteredNotionAccounts.length > 0 ? (
+            <>
+              <div style={{
+                background: '#ffffff',
+                border: '1px solid #eeeeee',
+                borderRadius: '12px',
+                overflow: 'visible',
+                boxShadow: '0 1px 4px rgba(0,0,0,0.02)',
+              }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', textAlign: 'left', fontFamily: 'Inter, sans-serif' }}>
+                  <thead>
+                    <tr style={{ borderBottom: '1px solid #f0f0f0', background: '#fafafa' }}>
+                      <th style={{ padding: '16px 24px', color: '#595959', fontSize: '13px', fontWeight: '500', width: '35%' }}>Account label</th>
+                      <th style={{ padding: '16px 24px', color: '#595959', fontSize: '13px', fontWeight: '500', width: '35%' }}>Added by</th>
+                      <th style={{ padding: '16px 24px', color: '#595959', fontSize: '13px', fontWeight: '500', width: '30%' }}>Access</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredNotionAccounts.map((account, idx) => {
+                      const isExpanded = selectedAccountId === account.id;
+                      return (
+                        <Fragment key={account.id}>
+                          <tr
+                            onClick={(e) => handleRowClick(e, account.id)}
+                            style={{
+                              borderBottom: (isExpanded || idx < filteredNotionAccounts.length - 1) ? '1px solid #f0f0f0' : 'none',
+                              cursor: 'pointer',
+                              background: isExpanded ? '#fafafa' : 'transparent',
+                              transition: 'background-color 0.2s',
+                            }}
+                          >
+                            <td style={{ padding: '18px 24px', color: '#1f1f1f', fontSize: '14px', fontWeight: '500' }}>
+                              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                                <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+                                  <span style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#52c41a', display: 'inline-block' }} />
+                                  {account.label}
+                                </span>
+                                {!isExpanded && (
+                                  <span style={{ fontSize: '12px', color: '#8c8c8c', fontWeight: 'normal', marginTop: '4px', paddingLeft: '14px' }}>
+                                    Click to configure settings & tools
+                                  </span>
+                                )}
+                              </div>
+                            </td>
+                             <td style={{ padding: '18px 24px', color: '#595959', fontSize: '14px' }}>
+                              <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+                                <span style={{
+                                  width: '24px',
+                                  height: '24px',
+                                  borderRadius: '50%',
+                                  background: '#eeeeee',
+                                  color: '#595959',
+                                  display: 'inline-flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
+                                  fontSize: '11px',
+                                  fontWeight: '600',
+                                  textTransform: 'uppercase',
+                                }}>
+                                  {account.addedBy.charAt(0)}
+                                </span>
+                                {account.addedBy}
+                              </span>
+                            </td>
+                            <td style={{ padding: '12px 24px', color: '#595959', fontSize: '14px' }}>
+                              <CustomDropdown
+                                id={'access-' + account.id}
+                                menuWidth={240}
+                                triggerContent={
+                                  account.access === 'team' ? (
+                                    <><UserOutlined /> Team-only</>
+                                  ) : (
+                                    <><LockOutlined /> Private (Invite only)</>
+                                  )
+                                }
+                                menuContent={
+                                  <>
+                                    <div style={{ padding: '8px 16px 4px', fontSize: '12px', color: '#8c8c8c', fontWeight: '500', fontFamily: 'Inter, sans-serif' }}>
+                                      Who should have access?
+                                    </div>
+                                    <div
+                                      style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'space-between',
+                                        padding: '10px 16px',
+                                        cursor: 'pointer',
+                                        background: account.access === 'team' ? '#f5f5f5' : 'transparent',
+                                        fontFamily: 'Inter, sans-serif',
+                                      }}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleUpdateAccountAccess(account.id, 'team');
+                                        setOpenDropdownId(null);
+                                      }}
+                                    >
+                                      <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#1f1f1f' }}>
+                                        <UserOutlined /> Team-only
+                                      </span>
+                                      {account.access === 'team' && <CheckOutlined style={{ color: '#1f1f1f' }} />}
+                                    </div>
+                                    <div
+                                      style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'space-between',
+                                        padding: '10px 16px',
+                                        cursor: 'pointer',
+                                        background: account.access === 'private' ? '#f5f5f5' : 'transparent',
+                                        fontFamily: 'Inter, sans-serif',
+                                      }}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleUpdateAccountAccess(account.id, 'private');
+                                        setOpenDropdownId(null);
+                                      }}
+                                    >
+                                      <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#1f1f1f' }}>
+                                        <LockOutlined /> Private (Invite only)
+                                      </span>
+                                      {account.access === 'private' && <CheckOutlined style={{ color: '#1f1f1f' }} />}
+                                    </div>
+                                  </>
+                                }
+                              />
+                            </td>
+                          </tr>
+                          {isExpanded && (
+                            <tr
+                              style={{
+                                background: '#fafafa',
+                                borderBottom: idx < filteredNotionAccounts.length - 1 ? '1px solid #f0f0f0' : 'none',
+                              }}
+                            >
+                              <td colSpan={3} style={{ padding: '0 24px 24px 24px' }}>
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: '28px', marginTop: '16px' }}>
+                                  {/* Tab Navigation Header */}
+                                  <div style={{ display: 'flex', borderBottom: '1px solid #f0f0f0', paddingBottom: '0', gap: '32px' }}>
+                                    <span
+                                      onClick={() => setActiveSubTab('settings')}
+                                      style={{
+                                        fontSize: '15px',
+                                        fontWeight: '600',
+                                        color: activeSubTab === 'settings' ? '#1f1f1f' : '#8c8c8c',
+                                        borderBottom: activeSubTab === 'settings' ? '2px solid #1f1f1f' : 'none',
+                                        paddingBottom: '12px',
+                                        cursor: 'pointer',
+                                        fontFamily: 'Inter, sans-serif',
+                                        transition: 'all 0.3s',
+                                      }}
+                                    >
+                                      Settings
+                                    </span>
+                                    <span
+                                      onClick={() => setActiveSubTab('tools')}
+                                      style={{
+                                        fontSize: '15px',
+                                        fontWeight: '600',
+                                        color: activeSubTab === 'tools' ? '#1f1f1f' : '#8c8c8c',
+                                        borderBottom: activeSubTab === 'tools' ? '2px solid #1f1f1f' : 'none',
+                                        paddingBottom: '12px',
+                                        cursor: 'pointer',
+                                        fontFamily: 'Inter, sans-serif',
+                                        transition: 'all 0.3s',
+                                      }}
+                                    >
+                                      Tools
+                                    </span>
+                                  </div>
+
+                                  {/* Sub-panel Content */}
+                                  <div style={{
+                                    background: '#ffffff',
+                                    border: '1px solid #eeeeee',
+                                    borderRadius: '12px',
+                                    padding: '32px',
+                                    boxShadow: '0 1px 4px rgba(0,0,0,0.01)',
+                                  }}>
+                                    {activeSubTab === 'settings' ? (
+                                      <div style={{ display: 'flex', flexDirection: 'column', gap: '28px' }}>
+                                        {/* Account Label */}
+                                        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', paddingBottom: '24px', borderBottom: '1px solid #f0f0f0' }}>
+                                          <span style={{ color: '#1f1f1f', fontSize: '15px', fontWeight: '600', fontFamily: 'Inter, sans-serif' }}>
+                                            Account label
+                                          </span>
+                                          <span style={{ color: '#8c8c8c', fontSize: '13px', fontFamily: 'Inter, sans-serif' }}>
+                                            Viktor uses the label to tell your connections apart
+                                          </span>
+                                          <Input
+                                            value={account.label}
+                                            onChange={(e) => handleUpdateAccountLabel(account.id, e.target.value)}
+                                            style={{
+                                              height: '44px',
+                                              borderRadius: '8px',
+                                              fontSize: '14px',
+                                              padding: '0 16px',
+                                              border: '1px solid #d9d9d9',
+                                              background: '#fcfcfc',
+                                              color: '#1f1f1f',
+                                              fontFamily: 'Inter, sans-serif',
+                                              marginTop: '8px',
+                                              maxWidth: '100%',
+                                            }}
+                                          />
+                                        </div>
+
+                                        {/* Enable Integration */}
+                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingBottom: '24px', borderBottom: '1px solid #f0f0f0' }}>
+                                          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                            <span style={{ color: '#1f1f1f', fontSize: '15px', fontWeight: '600', fontFamily: 'Inter, sans-serif' }}>
+                                              Enable integration
+                                            </span>
+                                            <span style={{ color: '#8c8c8c', fontSize: '13px', fontFamily: 'Inter, sans-serif' }}>
+                                              Allow Viktor to use this Notion connection
+                                            </span>
+                                          </div>
+                                          <Switch
+                                            checked={account.enabled !== false}
+                                            onChange={(checked) => handleUpdateAccountEnabled(account.id, checked)}
+                                            style={{ background: (account.enabled !== false) ? '#1f1f1f' : '#e8e8e8' }}
+                                          />
+                                        </div>
+
+                                        {/* Lock Integration */}
+                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingBottom: '24px', borderBottom: '1px solid #f0f0f0' }}>
+                                          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                            <span style={{ color: '#1f1f1f', fontSize: '15px', fontWeight: '600', fontFamily: 'Inter, sans-serif' }}>
+                                              Lock integration
+                                            </span>
+                                            <span style={{ color: '#8c8c8c', fontSize: '13px', fontFamily: 'Inter, sans-serif' }}>
+                                              Only admins can make changes while locked.
+                                            </span>
+                                          </div>
+                                          <Switch
+                                            checked={account.locked === true}
+                                            onChange={(checked) => handleUpdateAccountLocked(account.id, checked)}
+                                            style={{ background: (account.locked === true) ? '#1f1f1f' : '#e8e8e8' }}
+                                          />
+                                        </div>
+
+                                        {/* Disconnect Integration */}
+                                        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                                          <span style={{ color: '#ff4d4f', fontSize: '15px', fontWeight: '600', fontFamily: 'Inter, sans-serif' }}>
+                                            Disconnect integration
+                                          </span>
+                                          <span style={{ color: '#8c8c8c', fontSize: '13px', fontFamily: 'Inter, sans-serif' }}>
+                                            Remove this connection and revoke Viktor's access.
+                                          </span>
+                                          <Button
+                                            danger
+                                            style={{
+                                              display: 'inline-flex',
+                                              alignItems: 'center',
+                                              gap: '8px',
+                                              height: '38px',
+                                              width: 'fit-content',
+                                              borderRadius: '8px',
+                                              border: '1px solid #ffccc7',
+                                              background: '#fff2f0',
+                                              color: '#ff4d4f',
+                                              fontWeight: '500',
+                                              fontFamily: 'Inter, sans-serif',
+                                              fontSize: '13px',
+                                              cursor: 'pointer',
+                                              marginTop: '8px',
+                                            }}
+                                            onClick={() => handleDisconnectAccount(account.id)}
+                                          >
+                                            <svg fill="currentColor" viewBox="0 0 24 24" style={{ width: '16px', height: '16px' }}>
+                                              <path d="M19.78 11.22l-1.44 1.44-4.56-4.56 1.44-1.44c1.17-1.17 3.07-1.17 4.24 0l.32.32c1.17 1.17 1.17 3.07 0 4.24zM11.5 13.5l-4.56-4.56 1.44-1.44 4.56 4.56-1.44 1.44zM3 21h4.5c.28 0 .5-.22.5-.5v-4.5c0-.28-.22-.5-.5-.5H6v-1.5c0-.83.67-1.5 1.5-1.5H9v-1.5H7.5C5.01 11 3 13.01 3 15.5V21zm10.5-10.5V9H12v1.5c0 .83-.67 1.5-1.5 1.5H9v1.5h1.5c2.49 0 4.5-2.01 4.5-4.5zM21 3h-4.5c-.28 0-.5.22-.5.5v4.5c0 .28.22.5.5.5H18v1.5c0 .83-.67 1.5-1.5 1.5H15v1.5h1.5c2.49 0 4.5-2.01 4.5-4.5V3z" />
+                                            </svg>
+                                            Disconnect integration
+                                          </Button>
+                                        </div>
+                                      </div>
+                                    ) : (
+                                      <div style={{ display: 'flex', flexDirection: 'column', gap: '28px' }}>
+                                        {/* Notion Get Users */}
+                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', paddingBottom: '24px', borderBottom: '1px solid #f0f0f0' }}>
+                                          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', flex: 1, paddingRight: '40px' }}>
+                                            <span style={{ color: '#1f1f1f', fontSize: '15px', fontWeight: '600', fontFamily: 'Inter, sans-serif' }}>
+                                              Notion Get Users
+                                            </span>
+                                            <span style={{ color: '#8c8c8c', fontSize: '13px', lineHeight: '1.5', fontFamily: 'Inter, sans-serif' }}>
+                                              Retrieves a list of users in the current workspace. Shows workspace members and guests with their IDs, names, emails (if available), and types (person or bot). Supports cursor-based pagination to iterate through all users in the workspace....
+                                            </span>
+                                          </div>
+                                          {renderToolDropdownMenu(account.id, 'getUsers')}
+                                        </div>
+
+                                        {/* Notion Update Data Source */}
+                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', paddingBottom: '24px', borderBottom: '1px solid #f0f0f0' }}>
+                                          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', flex: 1, paddingRight: '40px' }}>
+                                            <span style={{ color: '#1f1f1f', fontSize: '15px', fontWeight: '600', fontFamily: 'Inter, sans-serif' }}>
+                                              Notion Update Data Source
+                                            </span>
+                                            <span style={{ color: '#8c8c8c', fontSize: '13px', lineHeight: '1.5', fontFamily: 'Inter, sans-serif' }}>
+                                              Update a Notion data source's schema, title, or attributes using SQL DDL statements. Returns Markdown showing updated structure and schema. Accepts a data source ID (collection ID from fetch response's &lt;data-source&gt; tag) or a single-source...
+                                            </span>
+                                          </div>
+                                          {renderToolDropdownMenu(account.id, 'updateDataSource')}
+                                        </div>
+
+                                        {/* Notion Get Comments */}
+                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                                          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', flex: 1, paddingRight: '40px' }}>
+                                            <span style={{ color: '#1f1f1f', fontSize: '15px', fontWeight: '600', fontFamily: 'Inter, sans-serif' }}>
+                                              Notion Get Comments
+                                            </span>
+                                            <span style={{ color: '#8c8c8c', fontSize: '13px', lineHeight: '1.5', fontFamily: 'Inter, sans-serif' }}>
+                                              Get comments and discussions from a Notion page. Returns discussions with full comment content in XML format. By default, returns page-level discussions only. Tip: Use the `fetch` tool with `include_discussions: true` first to see where...
+                                            </span>
+                                          </div>
+                                          {renderToolDropdownMenu(account.id, 'getComments')}
+                                        </div>
+                                      </div>
+                                    )}
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                        </Fragment>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          ) : (
+            <div
+              style={{
+                background: '#ffffff',
+                padding: '60px 20px',
+                textAlign: 'center',
+                borderRadius: '12px',
+                border: '1px solid #eeeeee',
+                color: '#8c8c8c',
+                fontSize: '15px',
+              }}
+            >
+              No connected accounts found
+            </div>
+          )}
+        </>
       )}
 
       {/* Premium WhatsApp Connection Modal (Image 1 Style + Image 2 Content Refined) */}
@@ -258,6 +983,213 @@ export default function IntegrationsPage() {
               />
             </div>
           </div>
+        </div>
+      </Modal>
+
+      {/* Premium Notion Connection Modal */}
+      <Modal
+        open={isNotionModalOpen}
+        onCancel={() => setIsNotionModalOpen(false)}
+        footer={null}
+        width={560}
+        centered
+        styles={{
+          content: {
+            borderRadius: '16px',
+            padding: '32px 32px 28px 32px',
+          }
+        }}
+      >
+        {/* Title */}
+        <h2 style={{ fontSize: '24px', fontWeight: '500', color: '#1f1f1f', margin: '0 0 24px 0', fontFamily: 'Inter, system-ui, sans-serif' }}>
+          Connect a Notion account
+        </h2>
+
+        {/* Form Field */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '24px' }}>
+          <span style={{ color: '#595959', fontSize: '13px', fontWeight: '500', fontFamily: 'Inter, sans-serif' }}>
+            Nickname for this account
+          </span>
+          <Input
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            onFocus={() => setIsInputFocused(true)}
+            onBlur={() => setIsInputFocused(false)}
+            style={{
+              height: '44px',
+              borderRadius: '8px',
+              fontSize: '14px',
+              padding: '0 16px',
+              border: isInputFocused ? '1px solid #bfbfbf' : '1px solid #d9d9d9',
+              background: '#fcfcfc',
+              color: '#1f1f1f',
+              fontFamily: 'Inter, sans-serif',
+              boxShadow: isInputFocused ? '0 0 0 2px rgba(0, 0, 0, 0.06)' : 'none',
+              outline: 'none',
+              transition: 'all 0.2s',
+            }}
+          />
+          <span style={{ color: '#8c8c8c', fontSize: '12px', fontFamily: 'Inter, sans-serif' }}>
+            Just a label to tell your accounts apart.
+          </span>
+        </div>
+
+        {/* Bottom Actions Row */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '28px' }}>
+          {/* Access Dropdown Button */}
+          <Dropdown
+            dropdownRender={() => (
+              <div
+                onMouseDown={(e) => e.stopPropagation()}
+                onMouseUp={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+                style={{
+                  background: '#ffffff',
+                  border: '1px solid #f0f0f0',
+                  borderRadius: '12px',
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+                  padding: '8px 0',
+                  width: '240px',
+                }}
+              >
+                <div style={{ padding: '8px 16px 4px', fontSize: '12px', color: '#8c8c8c', fontWeight: '500', fontFamily: 'Inter, sans-serif' }}>
+                  Who should have access?
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: '10px 16px',
+                    cursor: 'pointer',
+                    background: accessType === 'team' ? '#f5f5f5' : 'transparent',
+                    fontFamily: 'Inter, sans-serif',
+                  }}
+                  onClick={() => {
+                    setAccessType('team');
+                    setIsDropdownOpen(false);
+                  }}
+                >
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#1f1f1f' }}>
+                    <UserOutlined /> Team-only
+                  </span>
+                  {accessType === 'team' && <CheckOutlined style={{ color: '#1f1f1f' }} />}
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: '10px 16px',
+                    cursor: 'pointer',
+                    background: accessType === 'private' ? '#f5f5f5' : 'transparent',
+                    fontFamily: 'Inter, sans-serif',
+                  }}
+                  onClick={() => {
+                    setAccessType('private');
+                    setIsDropdownOpen(false);
+                  }}
+                >
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#1f1f1f' }}>
+                    <LockOutlined /> Private (Invite only)
+                  </span>
+                  {accessType === 'private' && <CheckOutlined style={{ color: '#1f1f1f' }} />}
+                </div>
+              </div>
+            )}
+            trigger={['click']}
+            open={isDropdownOpen}
+            onOpenChange={setIsDropdownOpen}
+          >
+            <Button style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              height: '36px',
+              padding: '0 12px',
+              borderRadius: '8px',
+              border: 'none',
+              background: '#f5f5f5',
+              color: '#595959',
+              fontSize: '13px',
+              fontWeight: '500',
+              fontFamily: 'Inter, sans-serif',
+              boxShadow: 'none',
+              cursor: 'pointer',
+            }}>
+              {accessType === 'team' ? (
+                <>
+                  <UserOutlined /> Team-only
+                </>
+              ) : (
+                <>
+                  <LockOutlined /> Private (Invite only)
+                </>
+              )}
+              <DownOutlined style={{ fontSize: '10px', color: '#8c8c8c' }} />
+            </Button>
+          </Dropdown>
+
+          {/* Continue CTA Button */}
+          <Button
+            type="primary"
+            style={{
+              height: '38px',
+              padding: '0 20px',
+              borderRadius: '8px',
+              background: '#1f1f1f',
+              borderColor: '#1f1f1f',
+              color: '#ffffff',
+              fontSize: '13px',
+              fontWeight: '500',
+              fontFamily: 'Inter, sans-serif',
+              cursor: 'pointer',
+            }}
+            onClick={() => {
+              setConnectedIds((prev) => {
+                const next = new Set(prev);
+                next.add('notion');
+                return next;
+              });
+              
+              setNotionAccounts((prev) => {
+                const existingIndex = prev.findIndex(a => a.label === nickname);
+                if (existingIndex > -1) {
+                  // Edit existing account
+                  const nextAccounts = [...prev];
+                  nextAccounts[existingIndex] = {
+                    ...nextAccounts[existingIndex],
+                    access: accessType,
+                  };
+                  return nextAccounts;
+                } else {
+                  // Add new account
+                  return [
+                    ...prev,
+                    {
+                      id: Date.now().toString(),
+                      label: nickname,
+                      access: accessType,
+                      addedBy: 'will.ziheng',
+                      enabled: true,
+                      locked: false,
+                      tools: {
+                        getUsers: 'auto',
+                        updateDataSource: 'auto',
+                        getComments: 'auto',
+                      }
+                    }
+                  ];
+                }
+              });
+              
+              setIsNotionModalOpen(false);
+              setCurrentView('notion');
+              message.success(`Notion connected successfully under "${nickname}"`);
+            }}
+          >
+            Continue to Notion
+          </Button>
         </div>
       </Modal>
     </div>

--- a/frontend/src/pages/MissionControl/index.jsx
+++ b/frontend/src/pages/MissionControl/index.jsx
@@ -1,0 +1,5 @@
+import MissionControlModule from '@/modules/MissionControlModule';
+
+export default function MissionControl() {
+  return <MissionControlModule />;
+}

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -7,6 +7,7 @@ const NotFound = lazy(() => import('@/pages/NotFound.jsx'));
 
 const Dashboard = lazy(() => import('@/pages/Dashboard'));
 const AskOla = lazy(() => import('@/pages/AskOla'));
+const MissionControl = lazy(() => import('@/pages/MissionControl'));
 const FilePage = lazy(() => import('@/pages/File'));
 const Integrations = lazy(() => import('@/pages/Integrations'));
 const Customer = lazy(() => import('@/pages/Customer'));
@@ -73,6 +74,10 @@ let routes = {
     {
       path: '/askola',
       element: <AskOla />,
+    },
+    {
+      path: '/control',
+      element: <MissionControl />,
     },
     {
       path: '/file',

--- a/frontend/src/style/app.css
+++ b/frontend/src/style/app.css
@@ -12,6 +12,7 @@
 @import './partials/settings.css';
 @import './partials/askola.css';
 @import './partials/ola-panel.css';
+@import './partials/mission-control.css';
 @import './partials/historyModal.css';
 @import './partials/scrollbar.css';
 @import './partials/integrations.css';

--- a/frontend/src/style/partials/mission-control.css
+++ b/frontend/src/style/partials/mission-control.css
@@ -22,65 +22,77 @@
 /* ── pipeline board ───────────────────────────────────────── */
 .mc-board--pipeline {
   display: flex;
-  gap: 12px;
+  gap: 16px;
   align-items: flex-start;
   overflow-x: auto;
-  padding-bottom: 12px;
+  padding: 8px 4px 16px;
+  width: 100%;
 }
 
 .mc-col {
-  flex: 0 0 268px;
-  width: 268px;
+  flex: 1 1 240px;
+  min-width: 240px;
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 160px);
+  max-height: calc(100vh - 180px);
+  background: #f8f9fa;
+  border-radius: 10px;
+  padding: 12px 10px;
+  border: 1px solid #f0f0f0;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.01);
 }
 
 .mc-col-head {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 0 4px 8px;
+  justify-content: space-between;
+  padding: 0 6px 12px;
+  border-bottom: 2px solid var(--stage-color, #f0f0f0);
+  margin-bottom: 12px;
 }
 
 .mc-col-dot {
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   flex: none;
 }
 
 .mc-col-title {
   flex: 1;
-  font-size: 11.5px;
-  font-weight: 700;
-  color: #555;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #262626;
+  margin-left: 6px;
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 .mc-col-count {
   font-size: 11px;
-  color: #bbb;
-  background: #efefef;
+  color: #8c8c8c;
+  background: #e8e8e8;
   border-radius: 10px;
-  padding: 0 7px;
+  padding: 0 8px;
   line-height: 18px;
 }
 
 .mc-col-body {
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 8px;
   overflow-y: auto;
-  padding-right: 2px;
+  padding: 2px 2px;
 }
 
 .mc-col-empty {
   text-align: center;
-  color: #ddd;
-  padding: 18px 0;
-  font-size: 18px;
+  color: #bfbfbf;
+  padding: 32px 0;
+  font-size: 14px;
+  border: 1px dashed #d9d9d9;
+  border-radius: 8px;
+  background: #fafafa;
 }
 
 /* ── matrix board ─────────────────────────────────────────── */
@@ -121,13 +133,13 @@
 .mc-matrix-colhead-label {
   font-size: 13px;
   font-weight: 600;
-  color: #333;
+  color: #262626;
   line-height: 1.3;
 }
 
 .mc-matrix-colhead-desc {
   font-size: 11px;
-  color: #bbb;
+  color: #8c8c8c;
   line-height: 1.3;
 }
 
@@ -137,18 +149,18 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: 12.5px;
   font-weight: 600;
-  color: #555;
+  color: #262626;
   padding: 14px 16px;
-  border-left: 3px solid var(--stage-color, #eee);
+  border-left: 4px solid var(--stage-color, #eee);
 }
 
 /* Content cell — white, cards stack inside with consistent padding */
 .mc-matrix-cell {
   background: #fff;
-  min-height: 64px;
-  padding: 10px;
+  min-height: 80px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -159,17 +171,20 @@
 .mc-card {
   position: relative;
   background: #fff;
-  border: 1px solid #ebebeb;
+  border: 1px solid #f0f0f0;
   border-left: 3px solid var(--stage-color, #d9d9d9);
   border-radius: 8px;
-  padding: 11px 12px 9px;
+  padding: 12px;
   cursor: pointer;
-  transition: box-shadow 0.15s ease;
+  transition: all 0.2s ease;
   overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
 }
 
 .mc-card:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-color: #d9d9d9;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  transform: translateY(-1px);
 }
 
 /* Amber banner — only colored element on urgent cards */
@@ -177,8 +192,8 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  margin: -11px -12px 10px;
-  padding: 4px 12px;
+  margin: -12px -12px 10px;
+  padding: 6px 12px;
   background: #fffbe6;
   border-bottom: 1px solid #ffe58f;
   color: #d48806;

--- a/frontend/src/style/partials/mission-control.css
+++ b/frontend/src/style/partials/mission-control.css
@@ -1,0 +1,372 @@
+/* ===== Mission Control — lead-to-quote command center ===== */
+/* Design rule: ONE color per card = left stage border.
+   Everything else is neutral gray.
+   Amber ACTION REQUIRED banner is the only visual interrupt.   */
+
+/* ── root ─────────────────────────────────────────────────── */
+.mc-root {
+  padding: 20px 24px 32px;
+  min-height: calc(100vh - 64px);
+  background: #fff;
+}
+
+/* ── header ───────────────────────────────────────────────── */
+.mc-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+/* ── pipeline board ───────────────────────────────────────── */
+.mc-board--pipeline {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  overflow-x: auto;
+  padding-bottom: 12px;
+}
+
+.mc-col {
+  flex: 0 0 268px;
+  width: 268px;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 160px);
+}
+
+.mc-col-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 4px 8px;
+}
+
+.mc-col-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.mc-col-title {
+  flex: 1;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: #555;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.mc-col-count {
+  font-size: 11px;
+  color: #bbb;
+  background: #efefef;
+  border-radius: 10px;
+  padding: 0 7px;
+  line-height: 18px;
+}
+
+.mc-col-body {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.mc-col-empty {
+  text-align: center;
+  color: #ddd;
+  padding: 18px 0;
+  font-size: 18px;
+}
+
+/* ── matrix board ─────────────────────────────────────────── */
+/* Table-stripe approach: outer border + 1px gap = divider lines.
+   align-items: stretch makes every cell in a row fill the same height
+   so the gap lines stay continuous across the full grid width.       */
+.mc-board--matrix {
+  display: grid;
+  align-items: stretch;   /* all cells in a row grow to the same height */
+  border: 1px solid #eee;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #eee;       /* the gap background = divider colour */
+  gap: 1px;
+}
+
+/* Corner cell */
+.mc-matrix-corner {
+  background: #fafafa;
+  padding: 14px 16px;
+}
+
+/* Column header — same background as corner, clear bottom divider via gap */
+.mc-matrix-colhead {
+  background: #fafafa;
+  padding: 14px 16px;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.mc-matrix-colhead-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.mc-matrix-colhead-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  line-height: 1.3;
+}
+
+.mc-matrix-colhead-desc {
+  font-size: 11px;
+  color: #bbb;
+  line-height: 1.3;
+}
+
+/* Row header — left stage-color border signals the stage */
+.mc-matrix-rowhead {
+  background: #fafafa;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #555;
+  padding: 14px 16px;
+  border-left: 3px solid var(--stage-color, #eee);
+}
+
+/* Content cell — white, cards stack inside with consistent padding */
+.mc-matrix-cell {
+  background: #fff;
+  min-height: 64px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: stretch;
+}
+
+/* ── mission card ─────────────────────────────────────────── */
+.mc-card {
+  position: relative;
+  background: #fff;
+  border: 1px solid #ebebeb;
+  border-left: 3px solid var(--stage-color, #d9d9d9);
+  border-radius: 8px;
+  padding: 11px 12px 9px;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+  overflow: hidden;
+}
+
+.mc-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+/* Amber banner — only colored element on urgent cards */
+.mc-card-banner {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: -11px -12px 10px;
+  padding: 4px 12px;
+  background: #fffbe6;
+  border-bottom: 1px solid #ffe58f;
+  color: #d48806;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.mc-card-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 6px;
+}
+
+/* Channel icon — neutral gray; tooltip shows name */
+.mc-card-channel {
+  font-size: 13px;
+  color: #bbb;
+  line-height: 1;
+  flex: none;
+}
+
+.mc-card-client {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Tiny state dot — hover tooltip shows label */
+.mc-card-state-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.mc-card-summary {
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #999;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.mc-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.mc-card-amount {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: #52c41a;
+}
+
+.mc-card-foot-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mc-card-time {
+  font-size: 11px;
+  color: #ccc;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+/* ── drawer ───────────────────────────────────────────────── */
+.mc-drawer-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.mc-drawer-channel {
+  font-size: 16px;
+  color: #bbb;
+  line-height: 1;
+}
+
+.mc-drawer-client {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+/* ── context strip ────────────────────────────────────────── */
+.mc-context {
+  background: #fafafa;
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mc-context-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.mc-context-icon {
+  color: #ccc;
+  margin-top: 3px;
+  flex: none;
+}
+
+.mc-context-label {
+  color: #bbb;
+  font-weight: 600;
+  min-width: 40px;
+  flex: none;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding-top: 2px;
+}
+
+.mc-context-val {
+  color: #555;
+  flex: 1;
+}
+
+/* ── report feed ──────────────────────────────────────────── */
+.mc-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mc-report-block {
+  position: relative;
+}
+
+.mc-pin-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #ddd;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  font-size: 12px;
+  padding: 0;
+}
+
+.mc-report-block:hover .mc-pin-btn {
+  opacity: 1;
+}
+
+.mc-pin-btn:hover {
+  color: #faad14;
+}
+
+/* ── composer ─────────────────────────────────────────────── */
+.mc-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mc-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+}


### PR DESCRIPTION
## 改动内容

- **修复下拉框选择冲突**：将 Integrations 页面表格行 (Access level) 与 Tools 列表中的 Ant Design `<Dropdown>` 组件替换为自定义 inline `CustomDropdown` 组件。通过非 React Portal 方式渲染，并阻断事件冒泡，彻底解决了点击下拉菜单选项时会同时触发 table row 展开/收起 (Settings & Tools accordion) 的冲突问题。
- **防止下拉框截断 (Clipping)**：调整表格外部包裹容器样式，使 wrapper 容器 `overflow: visible`，确保下拉框能够完整显示而不被局部截取。
- **全局 Click-Away 点击收起**：在 `CustomDropdown` 中引入 `useEffect` 监听全局 `mousedown` 事件，实现点击下拉框外部区域时自动收回菜单。
- **保持 Modal dropdown 安全性**：由于 Notion 连接弹窗 (Connect a Notion account Modal) 处于弹窗内部，不存在与表格行的气泡冒泡冲突，因此该部分仍安全地复用 Ant Design 原生 `<Dropdown>`。

## 验证

- [x] 本地生产环境打包顺利通过 (`npm run build` 编译零错误)
- [x] 本地单元测试全部通过 (82 个测试用例无 regression)
- [x] 页面交互测试顺利：下拉框多开冲突解决 (一次仅能打开一个)，外侧点击自动收起正常，表格展开正常且互不干涉。