### PR TITLE
feat(whatsapp): QR connect on Integrations + REST proxy + Integration model (#325 #326 #327)

### DIFF
--- a/backend/src/controllers/appControllers/whatsappController/callBridge.js
+++ b/backend/src/controllers/appControllers/whatsappController/callBridge.js
@@ -1,0 +1,96 @@
+const http = require('http');
+const crypto = require('crypto');
+const { readBridge } = require('@/utils/bridgePort');
+
+// Per-admin bridge token: HMAC-SHA256(MCP_SERVICE_TOKEN, adminId). Same secret
+// and algorithm as the bridge (Node) and nanobot (Python), so all three derive
+// identical tokens with no shared table.
+function tokenFor(adminId) {
+  const secret = process.env.MCP_SERVICE_TOKEN;
+  if (!secret) {
+    // Misconfig — surface as "unavailable" to the user, log on the server.
+    console.error('[whatsapp] MCP_SERVICE_TOKEN is missing');
+    const err = new Error('WhatsApp bridge not running');
+    err.code = 'BRIDGE_UNREACHABLE';
+    throw err;
+  }
+  return crypto.createHmac('sha256', secret).update(adminId).digest('hex');
+}
+
+// Proxy one request to the bridge. Resolves the parsed JSON body on 2xx.
+// Rejects with code BRIDGE_UNREACHABLE (network/no-portfile) or
+// BRIDGE_BAD_STATUS (non-2xx, .upstreamStatus carries the code).
+function callBridge(method, pathSuffix, adminId) {
+  return new Promise((resolve, reject) => {
+    let host, port, token;
+    try {
+      ({ host, port } = readBridge());
+      token = tokenFor(adminId);
+    } catch (err) {
+      return reject(err);
+    }
+
+    const req = http.request(
+      {
+        host,
+        port,
+        path: `/wa/${adminId}${pathSuffix}`,
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+        timeout: 8000,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            let body = {};
+            try {
+              body = data ? JSON.parse(data) : {};
+            } catch {
+              body = {};
+            }
+            resolve(body);
+          } else {
+            const err = new Error(`bridge responded ${res.statusCode}`);
+            err.code = 'BRIDGE_BAD_STATUS';
+            err.upstreamStatus = res.statusCode;
+            reject(err);
+          }
+        });
+      }
+    );
+
+    req.on('timeout', () => {
+      req.destroy();
+      const err = new Error('WhatsApp bridge not running');
+      err.code = 'BRIDGE_UNREACHABLE';
+      reject(err);
+    });
+    req.on('error', () => {
+      const err = new Error('WhatsApp bridge not running');
+      err.code = 'BRIDGE_UNREACHABLE';
+      reject(err);
+    });
+    req.end();
+  });
+}
+
+// Translate a bridge error into an HTTP response. Returns true if it handled
+// the error; false means the caller should rethrow (→ catchErrors → 500).
+function sendBridgeError(res, err) {
+  if (err.code === 'BRIDGE_UNREACHABLE') {
+    res.status(503).json({ success: false, result: null, message: 'WhatsApp bridge not running' });
+    return true;
+  }
+  if (err.code === 'BRIDGE_BAD_STATUS') {
+    console.error(`[whatsapp] bridge bad status: ${err.upstreamStatus}`);
+    res.status(502).json({ success: false, result: null, message: 'WhatsApp bridge error' });
+    return true;
+  }
+  return false;
+}
+
+module.exports = { callBridge, sendBridgeError, tokenFor };

--- a/backend/src/controllers/appControllers/whatsappController/callBridge.js
+++ b/backend/src/controllers/appControllers/whatsappController/callBridge.js
@@ -46,13 +46,17 @@ function callBridge(method, pathSuffix, adminId) {
         });
         res.on('end', () => {
           if (res.statusCode >= 200 && res.statusCode < 300) {
-            let body = {};
             try {
-              body = data ? JSON.parse(data) : {};
-            } catch {
-              body = {};
+              resolve(data ? JSON.parse(data) : {});
+            } catch (parseErr) {
+              // A 2xx with non-JSON (proxy/nginx error page) is a fault, not a
+              // success — surface it as 502 instead of silently returning {}.
+              console.error('[whatsapp] bridge returned non-JSON on 2xx:', parseErr.message);
+              const err = new Error('bridge returned non-JSON');
+              err.code = 'BRIDGE_BAD_STATUS';
+              err.upstreamStatus = res.statusCode;
+              reject(err);
             }
-            resolve(body);
           } else {
             const err = new Error(`bridge responded ${res.statusCode}`);
             err.code = 'BRIDGE_BAD_STATUS';

--- a/backend/src/controllers/appControllers/whatsappController/index.js
+++ b/backend/src/controllers/appControllers/whatsappController/index.js
@@ -1,0 +1,5 @@
+const login = require('./login');
+const status = require('./status');
+const logout = require('./logout');
+
+module.exports = { login, status, logout };

--- a/backend/src/controllers/appControllers/whatsappController/login.js
+++ b/backend/src/controllers/appControllers/whatsappController/login.js
@@ -1,0 +1,33 @@
+const Integration = require('@/models/coreModels/Integration');
+const { callBridge, sendBridgeError } = require('./callBridge');
+
+const PROVIDER = 'whatsapp';
+
+// POST /api/whatsapp/login — trigger the bridge to start a Baileys client for
+// this admin (QR is fetched by the subsequent /status polls), and record intent.
+const login = async (req, res) => {
+  const adminId = req.admin._id; // identity from the auth token only — never body/param
+
+  let bridge;
+  try {
+    bridge = await callBridge('POST', '/login', adminId.toString());
+  } catch (err) {
+    if (sendBridgeError(res, err)) return;
+    throw err;
+  }
+
+  const status = bridge.status || 'qr_pending';
+  await Integration.findOneAndUpdate(
+    { createdBy: adminId, provider: PROVIDER },
+    { enabled: true, status, updated: Date.now() },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+  return res.status(200).json({
+    success: true,
+    result: { status },
+    message: 'WhatsApp login initiated',
+  });
+};
+
+module.exports = login;

--- a/backend/src/controllers/appControllers/whatsappController/logout.js
+++ b/backend/src/controllers/appControllers/whatsappController/logout.js
@@ -1,0 +1,31 @@
+const Integration = require('@/models/coreModels/Integration');
+const { callBridge, sendBridgeError } = require('./callBridge');
+
+const PROVIDER = 'whatsapp';
+
+// DELETE /api/whatsapp — tell the bridge to disconnect + wipe authDir, and
+// record that this admin turned WhatsApp off.
+const logout = async (req, res) => {
+  const adminId = req.admin._id;
+
+  try {
+    await callBridge('DELETE', '', adminId.toString());
+  } catch (err) {
+    if (sendBridgeError(res, err)) return;
+    throw err;
+  }
+
+  await Integration.findOneAndUpdate(
+    { createdBy: adminId, provider: PROVIDER },
+    { enabled: false, status: 'logged_out', updated: Date.now() },
+    { upsert: true, setDefaultsOnInsert: true }
+  );
+
+  return res.status(200).json({
+    success: true,
+    result: { status: 'logged_out' },
+    message: 'WhatsApp disconnected',
+  });
+};
+
+module.exports = logout;

--- a/backend/src/controllers/appControllers/whatsappController/status.js
+++ b/backend/src/controllers/appControllers/whatsappController/status.js
@@ -1,0 +1,32 @@
+const Integration = require('@/models/coreModels/Integration');
+const { callBridge, sendBridgeError } = require('./callBridge');
+
+const PROVIDER = 'whatsapp';
+
+// GET /api/whatsapp/status — pass through the bridge's live snapshot ({status, qr?})
+// and refresh the cached row only when the observed status actually changed.
+const status = async (req, res) => {
+  const adminId = req.admin._id;
+
+  let bridge;
+  try {
+    bridge = await callBridge('GET', '/status', adminId.toString());
+  } catch (err) {
+    if (sendBridgeError(res, err)) return;
+    throw err;
+  }
+
+  const result = { status: bridge.status || 'disconnected' };
+  if (bridge.qr) result.qr = bridge.qr;
+
+  // Cache refresh: write only on change, and never create a row here — login
+  // owns row creation (intent). $ne makes a no-op when status is unchanged.
+  await Integration.updateOne(
+    { createdBy: adminId, provider: PROVIDER, status: { $ne: result.status } },
+    { status: result.status, updated: Date.now() }
+  );
+
+  return res.status(200).json({ success: true, result, message: 'WhatsApp status' });
+};
+
+module.exports = status;

--- a/backend/src/models/coreModels/Integration.js
+++ b/backend/src/models/coreModels/Integration.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+
+// Per-admin × per-provider integration state. Row-per-integration so new
+// channels (email/wechat/...) extend the `provider` enum, not the Admin schema.
+const integrationSchema = new Schema({
+  removed: { type: Boolean, default: false },
+  // intent: did this admin turn the integration on (distinct from observed `status`)
+  enabled: { type: Boolean, default: false },
+
+  createdBy: { type: Schema.ObjectId, ref: 'Admin', required: true },
+
+  provider: { type: String, required: true, enum: ['whatsapp'] },
+
+  // observed connection snapshot, pulled from the bridge (the live source of truth).
+  // String, not enum: keeps this table provider-neutral — the value set is
+  // validated per-provider in the controller.
+  status: { type: String, default: 'disconnected' },
+
+  // provider-specific data, e.g. whatsapp → { phoneNumber }
+  meta: { type: Schema.Types.Mixed, default: {} },
+
+  created: { type: Date, default: Date.now },
+  updated: { type: Date, default: Date.now },
+});
+
+// One integration row per (admin, provider)
+integrationSchema.index({ createdBy: 1, provider: 1 }, { unique: true });
+
+module.exports = mongoose.model('Integration', integrationSchema);

--- a/backend/src/routes/appRoutes/appApi.js
+++ b/backend/src/routes/appRoutes/appApi.js
@@ -67,4 +67,11 @@ router.route('/ola/session/delete/:id').delete(catchErrors(olaController['sessio
 router.route('/ola/session/rename/:id').patch(catchErrors(olaController['sessionRename']));
 router.route('/ola/session/messages/:id').get(catchErrors(olaController['sessionMessages']));
 
+// WhatsApp — CRM proxy to the local Baileys bridge (#326). Not an appModel, so
+// registered here like ola/*; adminAuth + trackActivity already applied at mount.
+const whatsappController = require('@/controllers/appControllers/whatsappController');
+router.route('/whatsapp/login').post(catchErrors(whatsappController['login']));
+router.route('/whatsapp/status').get(catchErrors(whatsappController['status']));
+router.route('/whatsapp').delete(catchErrors(whatsappController['logout']));
+
 module.exports = router;

--- a/backend/src/utils/bridgePort.js
+++ b/backend/src/utils/bridgePort.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function unreachable() {
+  const err = new Error('WhatsApp bridge not running');
+  err.code = 'BRIDGE_UNREACHABLE';
+  return err;
+}
+
+// Locate the local WhatsApp bridge. Env wins for cross-host prod (Box1 CRM →
+// Box2 bridge); dev falls back to the portfile the bridge writes on startup.
+function readBridge() {
+  const host = process.env.WA_BRIDGE_HOST || '127.0.0.1';
+
+  if (process.env.WA_BRIDGE_PORT) {
+    const port = parseInt(process.env.WA_BRIDGE_PORT, 10);
+    if (!port) throw unreachable();
+    return { host, port };
+  }
+
+  const portFile = path.join(os.homedir(), '.nanobot', 'wa', 'bridge.port');
+  if (!fs.existsSync(portFile)) throw unreachable();
+  const port = parseInt(fs.readFileSync(portFile, 'utf8').trim(), 10);
+  if (!port) throw unreachable();
+  return { host, port };
+}
+
+module.exports = { readBridge };

--- a/backend/test/integration.model.test.js
+++ b/backend/test/integration.model.test.js
@@ -1,0 +1,110 @@
+/**
+ * Tests for the Integration model (#325 / H1).
+ *
+ * Covers:
+ *  - Defaults: enabled=false, status='disconnected', removed=false, meta={}
+ *  - provider enum accepts 'whatsapp', rejects unknown
+ *  - createdBy is required
+ *  - unique (createdBy, provider) index enforced
+ *  - upsert by (createdBy, provider) is idempotent (no duplicate rows)
+ *  - cross-admin: same provider for two admins coexists
+ */
+
+const path = require('path');
+const mongoose = require('mongoose');
+const { globSync } = require('glob');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+
+let mongo;
+let Integration;
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  Integration = mongoose.model('Integration');
+  // Build the unique index in the in-memory server before exercising it.
+  await Integration.init();
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => setTimeout(r, 200));
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  if (Integration) await Integration.deleteMany({});
+});
+
+function fixture(extra = {}) {
+  return {
+    createdBy: new mongoose.Types.ObjectId(),
+    provider: 'whatsapp',
+    ...extra,
+  };
+}
+
+test('1. Defaults: enabled=false, status=disconnected, removed=false, meta={}', async () => {
+  const doc = await Integration.create(fixture());
+  expect(doc.enabled).toBe(false);
+  expect(doc.status).toBe('disconnected');
+  expect(doc.removed).toBe(false);
+  expect(doc.meta).toEqual({});
+  expect(doc.created).toBeInstanceOf(Date);
+});
+
+test('2. provider enum accepts "whatsapp"', async () => {
+  const doc = await Integration.create(fixture({ provider: 'whatsapp' }));
+  expect(doc.provider).toBe('whatsapp');
+});
+
+test('3. provider enum rejects unknown value', async () => {
+  await expect(Integration.create(fixture({ provider: 'telegram' }))).rejects.toThrow(
+    /provider/
+  );
+});
+
+test('4. createdBy is required', async () => {
+  await expect(Integration.create({ provider: 'whatsapp' })).rejects.toThrow(/createdBy/);
+});
+
+test('5. unique (createdBy, provider) rejects a second row for same admin+provider', async () => {
+  const adminId = new mongoose.Types.ObjectId();
+  await Integration.create(fixture({ createdBy: adminId }));
+  await expect(Integration.create(fixture({ createdBy: adminId }))).rejects.toThrow(
+    /E11000|duplicate key/
+  );
+});
+
+test('6. upsert by (createdBy, provider) is idempotent — no duplicate rows', async () => {
+  const adminId = new mongoose.Types.ObjectId();
+  const filter = { createdBy: adminId, provider: 'whatsapp' };
+
+  await Integration.findOneAndUpdate(
+    filter,
+    { enabled: true, status: 'qr_pending' },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+  await Integration.findOneAndUpdate(
+    filter,
+    { status: 'connected', meta: { phoneNumber: '+8613800138000' } },
+    { upsert: true, new: true }
+  );
+
+  const rows = await Integration.find(filter);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].status).toBe('connected');
+  expect(rows[0].enabled).toBe(true);
+  expect(rows[0].meta.phoneNumber).toBe('+8613800138000');
+});
+
+test('7. cross-admin: same provider for two different admins coexists', async () => {
+  await Integration.create(fixture({ createdBy: new mongoose.Types.ObjectId() }));
+  await Integration.create(fixture({ createdBy: new mongoose.Types.ObjectId() }));
+  expect(await Integration.countDocuments({ provider: 'whatsapp' })).toBe(2);
+});

--- a/backend/test/whatsapp.proxy.test.js
+++ b/backend/test/whatsapp.proxy.test.js
@@ -181,3 +181,14 @@ test('7. bridge non-2xx → 502', async () => {
   expect(res.status).toBe(502);
   expect(res.body.message).toBe('WhatsApp bridge error');
 });
+
+test('8. bridge 2xx with non-JSON body → 502 (not a silent success)', async () => {
+  bridgeRespond = (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' }).end('<html>proxy error</html>');
+  };
+  const res = await request(app).post('/api/whatsapp/login');
+  expect(res.status).toBe(502);
+  expect(res.body.message).toBe('WhatsApp bridge error');
+  // and no Integration row was written for a non-success
+  expect(await Integration.countDocuments({ createdBy: ADMIN_ID })).toBe(0);
+});

--- a/backend/test/whatsapp.proxy.test.js
+++ b/backend/test/whatsapp.proxy.test.js
@@ -1,0 +1,183 @@
+/**
+ * Tests for the WhatsApp CRM proxy controller (#326 / T2).
+ *
+ * Strategy: mount the 3 controllers behind a fake adminAuth (injects req.admin)
+ * on a throwaway express app, back them with a fake bridge HTTP server and an
+ * in-memory Mongo. No real WhatsApp/Baileys involved.
+ *
+ * Covers:
+ *  - login → 200 {status:qr_pending} + Integration row {enabled:true}
+ *  - status → 200 passes through {status, qr}; refreshes cache only on change
+ *  - logout → 200 {status:logged_out} + Integration {enabled:false}
+ *  - bridge unreachable → 503 'WhatsApp bridge not running'
+ *  - bridge non-2xx → 502 'WhatsApp bridge error'
+ *  - HMAC Bearer is what the bridge receives
+ */
+
+const http = require('http');
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+const { globSync } = require('glob');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const SECRET = 'test-mcp-service-token-0123456789';
+process.env.MCP_SERVICE_TOKEN = SECRET;
+
+const BACKEND_ROOT = path.join(__dirname, '..');
+const ADMIN_ID = new mongoose.Types.ObjectId();
+
+let mongo;
+let Integration;
+let app;
+let fakeBridge;
+let bridgeRespond; // (req, res) => void — overridable per test
+let lastBridgeReq; // { method, url, auth }
+
+beforeAll(async () => {
+  globSync('src/models/**/*.js', { cwd: BACKEND_ROOT }).forEach((f) =>
+    require(path.join(BACKEND_ROOT, f))
+  );
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  Integration = mongoose.model('Integration');
+  await Integration.init();
+
+  // Fake bridge: capture the request, then defer to the per-test responder.
+  fakeBridge = http.createServer((req, res) => {
+    lastBridgeReq = { method: req.method, url: req.url, auth: req.headers.authorization };
+    bridgeRespond(req, res);
+  });
+  await new Promise((r) => fakeBridge.listen(0, '127.0.0.1', r));
+  process.env.WA_BRIDGE_HOST = '127.0.0.1';
+  process.env.WA_BRIDGE_PORT = String(fakeBridge.address().port);
+
+  const { catchErrors } = require('@/handlers/errorHandlers');
+  const wa = require('@/controllers/appControllers/whatsappController');
+  app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.admin = { _id: ADMIN_ID };
+    next();
+  });
+  app.post('/api/whatsapp/login', catchErrors(wa.login));
+  app.get('/api/whatsapp/status', catchErrors(wa.status));
+  app.delete('/api/whatsapp', catchErrors(wa.logout));
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => setTimeout(r, 200));
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+  if (fakeBridge) await new Promise((r) => fakeBridge.close(r));
+});
+
+beforeEach(async () => {
+  await Integration.deleteMany({});
+  // Default responder mirrors the bridge contract by method/action.
+  bridgeRespond = (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    if (req.method === 'POST' && req.url.endsWith('/login')) {
+      res.end(JSON.stringify({ status: 'qr_pending' }));
+    } else if (req.method === 'GET' && req.url.endsWith('/status')) {
+      res.end(JSON.stringify({ status: 'qr_pending', qr: 'QR-DATA-123' }));
+    } else if (req.method === 'DELETE') {
+      res.end(JSON.stringify({ status: 'logged_out' }));
+    } else {
+      res.writeHead(404).end();
+    }
+  };
+});
+
+const expectedToken = () => crypto.createHmac('sha256', SECRET).update(ADMIN_ID.toString()).digest('hex');
+
+test('1. login → 200 qr_pending + Integration row enabled=true', async () => {
+  const res = await request(app).post('/api/whatsapp/login');
+  expect(res.status).toBe(200);
+  expect(res.body).toMatchObject({ success: true, result: { status: 'qr_pending' } });
+
+  const row = await Integration.findOne({ createdBy: ADMIN_ID, provider: 'whatsapp' });
+  expect(row).not.toBeNull();
+  expect(row.enabled).toBe(true);
+  expect(row.status).toBe('qr_pending');
+
+  // bridge saw POST /wa/<id>/login with the HMAC Bearer
+  expect(lastBridgeReq.method).toBe('POST');
+  expect(lastBridgeReq.url).toBe(`/wa/${ADMIN_ID}/login`);
+  expect(lastBridgeReq.auth).toBe(`Bearer ${expectedToken()}`);
+});
+
+test('2. status → 200 passes through {status, qr}', async () => {
+  const res = await request(app).get('/api/whatsapp/status');
+  expect(res.status).toBe(200);
+  expect(res.body.success).toBe(true);
+  expect(res.body.result).toEqual({ status: 'qr_pending', qr: 'QR-DATA-123' });
+});
+
+test('3. status refreshes cache only on change (no redundant write)', async () => {
+  // seed connected row
+  await Integration.create({ createdBy: ADMIN_ID, provider: 'whatsapp', enabled: true, status: 'connected' });
+  const before = await Integration.findOne({ createdBy: ADMIN_ID, provider: 'whatsapp' });
+
+  // bridge still reports connected → status unchanged → no write (updated stays)
+  bridgeRespond = (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify({ status: 'connected' }));
+  };
+  await request(app).get('/api/whatsapp/status');
+  const afterSame = await Integration.findOne({ createdBy: ADMIN_ID, provider: 'whatsapp' });
+  expect(afterSame.updated.getTime()).toBe(before.updated.getTime());
+
+  // bridge now reports disconnected → status changed → row updated
+  bridgeRespond = (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify({ status: 'disconnected' }));
+  };
+  await request(app).get('/api/whatsapp/status');
+  const afterChange = await Integration.findOne({ createdBy: ADMIN_ID, provider: 'whatsapp' });
+  expect(afterChange.status).toBe('disconnected');
+});
+
+test('4. status does NOT create a row when none exists (login owns creation)', async () => {
+  await request(app).get('/api/whatsapp/status');
+  expect(await Integration.countDocuments({ createdBy: ADMIN_ID })).toBe(0);
+});
+
+test('5. logout → 200 logged_out + Integration enabled=false', async () => {
+  await Integration.create({ createdBy: ADMIN_ID, provider: 'whatsapp', enabled: true, status: 'connected' });
+  const res = await request(app).delete('/api/whatsapp');
+  expect(res.status).toBe(200);
+  expect(res.body.result.status).toBe('logged_out');
+
+  const row = await Integration.findOne({ createdBy: ADMIN_ID, provider: 'whatsapp' });
+  expect(row.enabled).toBe(false);
+  expect(row.status).toBe('logged_out');
+  expect(lastBridgeReq.method).toBe('DELETE');
+  expect(lastBridgeReq.url).toBe(`/wa/${ADMIN_ID}`);
+});
+
+test('6. bridge unreachable → 503 plain message', async () => {
+  const saved = process.env.WA_BRIDGE_PORT;
+  // point at a closed port → ECONNREFUSED
+  const probe = http.createServer();
+  await new Promise((r) => probe.listen(0, '127.0.0.1', r));
+  const deadPort = probe.address().port;
+  await new Promise((r) => probe.close(r));
+  process.env.WA_BRIDGE_PORT = String(deadPort);
+  try {
+    const res = await request(app).get('/api/whatsapp/status');
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ success: false, result: null, message: 'WhatsApp bridge not running' });
+  } finally {
+    process.env.WA_BRIDGE_PORT = saved;
+  }
+});
+
+test('7. bridge non-2xx → 502', async () => {
+  bridgeRespond = (_req, res) => {
+    res.writeHead(500).end('boom');
+  };
+  const res = await request(app).post('/api/whatsapp/login');
+  expect(res.status).toBe(502);
+  expect(res.body.message).toBe('WhatsApp bridge error');
+});

--- a/frontend/src/locale/translation/en.js
+++ b/frontend/src/locale/translation/en.js
@@ -837,6 +837,11 @@ const lang = {
   whatsapp_disconnect_confirm: 'Disconnect WhatsApp?',
   whatsapp_disconnect: 'Disconnect',
   whatsapp_generating_qr: 'Generating QR code…',
+  whatsapp_modal_title: 'Connect a WhatsApp account',
+  whatsapp_step_1: 'Open WhatsApp on your phone',
+  whatsapp_step_2: 'Tap "Settings", then select "Linked Devices"',
+  whatsapp_step_3: 'Tap "Link a new device"',
+  whatsapp_step_4: 'Point your phone at this screen to scan the QR code',
 };
 
 export default lang;

--- a/frontend/src/locale/translation/en.js
+++ b/frontend/src/locale/translation/en.js
@@ -828,6 +828,15 @@ const lang = {
   integration_desc_sentry: 'Track frontend and backend errors.',
   integration_desc_vercel: 'Deploy previews and production builds.',
   integration_desc_whatsapp: 'Chat with customers via WhatsApp Business.',
+  whatsapp_status_disconnected: 'Not connected',
+  whatsapp_status_connecting: 'Connecting…',
+  whatsapp_status_connected: 'Connected',
+  whatsapp_status_logged_out: 'Device logged out, please scan again',
+  whatsapp_gateway_unavailable: 'WhatsApp gateway is temporarily unavailable. Please contact your administrator.',
+  whatsapp_connect_failed: 'Failed to connect WhatsApp. Please try again later.',
+  whatsapp_disconnect_confirm: 'Disconnect WhatsApp?',
+  whatsapp_disconnect: 'Disconnect',
+  whatsapp_generating_qr: 'Generating QR code…',
 };
 
 export default lang;

--- a/frontend/src/locale/translation/zh.js
+++ b/frontend/src/locale/translation/zh.js
@@ -828,6 +828,15 @@ const lang = {
   integration_desc_sentry: '监控前后端错误与异常。',
   integration_desc_vercel: '部署预览版本与生产构建。',
   integration_desc_whatsapp: '通过 WhatsApp 商业账户与客户沟通。',
+  whatsapp_status_disconnected: '未接入',
+  whatsapp_status_connecting: '连接中…',
+  whatsapp_status_connected: '已接入',
+  whatsapp_status_logged_out: '设备已退出，请重新扫码',
+  whatsapp_gateway_unavailable: 'WhatsApp 网关暂不可用，请联系管理员',
+  whatsapp_connect_failed: 'WhatsApp 连接失败，请稍后重试',
+  whatsapp_disconnect_confirm: '确定取消接入？',
+  whatsapp_disconnect: '取消接入',
+  whatsapp_generating_qr: '正在生成二维码…',
 };
 
 export default lang;

--- a/frontend/src/locale/translation/zh.js
+++ b/frontend/src/locale/translation/zh.js
@@ -837,6 +837,11 @@ const lang = {
   whatsapp_disconnect_confirm: '确定取消接入？',
   whatsapp_disconnect: '取消接入',
   whatsapp_generating_qr: '正在生成二维码…',
+  whatsapp_modal_title: '关联 WhatsApp 账号',
+  whatsapp_step_1: '在手机上打开 WhatsApp',
+  whatsapp_step_2: '点击「设置」，然后选择「已关联的设备」',
+  whatsapp_step_3: '点击「关联新设备」',
+  whatsapp_step_4: '用手机对准本屏幕扫描二维码',
 };
 
 export default lang;

--- a/frontend/src/pages/Integrations/index.jsx
+++ b/frontend/src/pages/Integrations/index.jsx
@@ -1,10 +1,10 @@
-import { useState, useMemo } from 'react';
-import { Button, Input, Switch, Row, Col, Tag, Segmented, message, Modal } from 'antd';
+import { useState, useMemo, useEffect, useRef } from 'react';
+import { Button, Input, Switch, Row, Col, message, Modal, QRCode, Spin } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { PageHeader } from '@ant-design/pro-layout';
 import useLanguage from '@/locale/useLanguage';
 import whatsappLogo from '@/style/images/whatsapp.png';
-import whatsappQr from '@/style/images/whatsapp_qr.png';
+import { waLogin, waStatus, waLogout } from '@/request/whatsapp';
 
 // Data lives outside the component so it is never recreated on render.
 // Descriptions are looked up by key at render time so language switches work.
@@ -12,7 +12,6 @@ const INTEGRATIONS_DATA = [
   {
     id: 'whatsapp',
     name: 'WhatsApp',
-    connected: false,
     popular: true,
     descriptionKey: 'integration_desc_whatsapp',
     logo: (
@@ -25,49 +24,138 @@ const INTEGRATIONS_DATA = [
   },
 ];
 
+// Observed bridge status → i18n label key + accent color.
+const STATUS_LABEL_KEY = {
+  disconnected: 'whatsapp_status_disconnected',
+  qr_pending: 'whatsapp_status_connecting',
+  connected: 'whatsapp_status_connected',
+  logged_out: 'whatsapp_status_logged_out',
+};
+const STATUS_COLOR = {
+  disconnected: '#8c8c8c',
+  qr_pending: '#1677ff',
+  connected: '#52c41a',
+  logged_out: '#fa8c16',
+};
+const POLL_MS = 2500;
+
 export default function IntegrationsPage() {
   const translate = useLanguage();
 
-  // Track only the mutable connection state; static data stays in INTEGRATIONS_DATA.
-  const [connectedIds, setConnectedIds] = useState(
-    () => new Set(INTEGRATIONS_DATA.filter((i) => i.connected).map((i) => i.id))
-  );
   const [searchQuery, setSearchQuery] = useState('');
-  const [activeTab, setActiveTab] = useState('all');
-  const [showConnectedOnly, setShowConnectedOnly] = useState(false);
+  // Tabs / "connected only" bar is commented out below; these stay constant until it returns.
+  const activeTab = 'all';
+  const showConnectedOnly = false;
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // TODO: replace with Redux dispatch + real backend endpoint when integration backend is wired
-  const handleToggleConnection = (id, name) => {
-    if (id === 'whatsapp' && !connectedIds.has('whatsapp')) {
-      setIsModalOpen(true);
-      return;
-    }
-    const wasConnected = connectedIds.has(id);
-    setConnectedIds((prev) => {
-      const next = new Set(prev);
-      if (wasConnected) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-    if (wasConnected) {
-      message.info(`${name} ${translate('integration_disconnected')}`);
-    } else {
-      message.success(`${name} ${translate('integration_connected')}`);
+  // WhatsApp live state, pulled from the bridge via the CRM proxy.
+  const [waStatusValue, setWaStatusValue] = useState('disconnected');
+  const [waQr, setWaQr] = useState(null);
+  const pollRef = useRef(null);
+
+  const stopPolling = () => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
     }
   };
+
+  const isItemConnected = (item) => item.id === 'whatsapp' && waStatusValue === 'connected';
+
+  // Map an error to the right localized toast (503 = gateway down).
+  const toastError = (err) =>
+    message.error(
+      translate(err?.response?.status === 503 ? 'whatsapp_gateway_unavailable' : 'whatsapp_connect_failed')
+    );
+
+  const applyStatus = (result) => {
+    const next = result?.status || 'disconnected';
+    setWaStatusValue(next);
+    setWaQr(result?.qr || null);
+    if (next === 'connected') {
+      stopPolling();
+      setIsModalOpen(false);
+      message.success(`WhatsApp ${translate('integration_connected')}`);
+    }
+  };
+
+  const startPolling = () => {
+    stopPolling();
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await waStatus();
+        applyStatus(res.result);
+      } catch (err) {
+        stopPolling();
+        setIsModalOpen(false);
+        setWaStatusValue('disconnected');
+        toastError(err);
+      }
+    }, POLL_MS);
+  };
+
+  const handleConnect = async () => {
+    setWaQr(null);
+    setIsModalOpen(true);
+    try {
+      const res = await waLogin();
+      setWaStatusValue(res.result?.status || 'qr_pending');
+      startPolling();
+    } catch (err) {
+      setIsModalOpen(false);
+      setWaStatusValue('disconnected');
+      toastError(err);
+    }
+  };
+
+  const confirmDisconnect = () => {
+    Modal.confirm({
+      title: translate('whatsapp_disconnect_confirm'),
+      okText: translate('whatsapp_disconnect'),
+      cancelText: translate('cancel'),
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        try {
+          await waLogout();
+          stopPolling();
+          setWaStatusValue('logged_out');
+          setWaQr(null);
+          message.info(`WhatsApp ${translate('integration_disconnected')}`);
+        } catch (err) {
+          toastError(err);
+        }
+      },
+    });
+  };
+
+  const handleSwitch = (checked) => {
+    if (checked) handleConnect();
+    else confirmDisconnect();
+  };
+
+  // Pull current status once on open (self-heals a stale UI); stop polling on unmount.
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await waStatus();
+        setWaStatusValue(res.result?.status || 'disconnected');
+        setWaQr(res.result?.qr || null);
+      } catch {
+        // Silent on initial load — don't error-toast just for opening the page.
+      }
+    })();
+    return () => stopPolling();
+  }, []);
 
   const filteredIntegrations = useMemo(() => {
     return INTEGRATIONS_DATA.filter((item) => {
       const matchesSearch = item.name.toLowerCase().includes(searchQuery.toLowerCase());
       const matchesTab = activeTab === 'all' ? true : item.popular;
-      const matchesConnected = showConnectedOnly ? connectedIds.has(item.id) : true;
+      const matchesConnected = showConnectedOnly ? isItemConnected(item) : true;
       return matchesSearch && matchesTab && matchesConnected;
     });
-  }, [connectedIds, searchQuery, activeTab, showConnectedOnly]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery, activeTab, showConnectedOnly, waStatusValue]);
 
   return (
     <div
@@ -120,7 +208,7 @@ export default function IntegrationsPage() {
       </PageHeader>
 
       {/* Tabs and Show Connected Switch Bar commented out as currently not needed */}
-      {/* 
+      {/*
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
         <Segmented
           options={[
@@ -146,13 +234,13 @@ export default function IntegrationsPage() {
       {/* Grid of integration cards */}
       <Row gutter={[24, 24]}>
         {filteredIntegrations.map((item) => {
-          const isConnected = connectedIds.has(item.id);
+          const isConnected = isItemConnected(item);
+          const statusValue = item.id === 'whatsapp' ? waStatusValue : 'disconnected';
           return (
             <Col xs={24} sm={12} md={8} key={item.id}>
               <div
                 className={`whiteBox shadow integration-card${isConnected ? ' integration-card--connected' : ''}`}
-                onClick={() => handleToggleConnection(item.id, item.name)}
-                style={{ cursor: 'pointer' }}
+                style={{ cursor: 'default' }}
               >
                 {/* Logo — always visible, no animation */}
                 <div className="integration-card__logo">
@@ -161,7 +249,7 @@ export default function IntegrationsPage() {
 
                 {/* Text area — clips the two sliding layers */}
                 <div className="integration-card__text-area">
-                  {/* Name + tag: slides up and out on hover */}
+                  {/* Name + status/switch */}
                   <div className="integration-card__name-row">
                     <span
                       style={{
@@ -175,22 +263,15 @@ export default function IntegrationsPage() {
                     >
                       {item.name}
                     </span>
-                    <div>
-                      {isConnected ? (
-                        <Tag
-                          color="success"
-                          style={{ borderRadius: '12px', border: 'none', padding: '2px 10px', fontSize: '12px', fontWeight: '500', margin: 0 }}
-                        >
-                          {translate('connected')}
-                        </Tag>
-                      ) : (
-                        <Tag
-                          color="default"
-                          style={{ borderRadius: '12px', border: '1px solid #d9d9d9', background: '#ffffff', color: '#8c8c8c', padding: '2px 10px', fontSize: '12px', fontWeight: '500', margin: 0 }}
-                        >
-                          {translate('connect')}
-                        </Tag>
-                      )}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexShrink: 0 }}>
+                      <span style={{ fontSize: '12px', fontWeight: 500, color: STATUS_COLOR[statusValue] }}>
+                        {translate(STATUS_LABEL_KEY[statusValue])}
+                      </span>
+                      <Switch
+                        checked={isConnected}
+                        loading={statusValue === 'qr_pending'}
+                        onChange={handleSwitch}
+                      />
                     </div>
                   </div>
                 </div>
@@ -218,7 +299,7 @@ export default function IntegrationsPage() {
         </div>
       )}
 
-      {/* Premium WhatsApp Connection Modal (Image 1 Style + Image 2 Content Refined) */}
+      {/* WhatsApp Connection Modal — live QR from the bridge */}
       <Modal
         title={
           <div style={{ fontSize: '20px', fontWeight: '600', color: '#1f1f1f', fontFamily: 'Inter, system-ui, sans-serif', paddingBottom: '16px', borderBottom: '1px solid #f0f0f0' }}>
@@ -248,14 +329,17 @@ export default function IntegrationsPage() {
             </ol>
           </div>
 
-          {/* Right Column: QR Code (More compact and elegant) */}
+          {/* Right Column: live QR (or a spinner while the bridge generates it) */}
           <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flexShrink: 0 }}>
             <div style={{ border: '1px solid #e8e8e8', borderRadius: '12px', padding: '12px', background: '#ffffff', boxShadow: '0 2px 8px rgba(0,0,0,0.02)' }}>
-              <img
-                src={whatsappQr}
-                alt="Scan to Login"
-                style={{ width: '160px', height: '160px', display: 'block', objectFit: 'contain' }}
-              />
+              {waQr ? (
+                <QRCode value={waQr} size={160} bordered={false} />
+              ) : (
+                <div style={{ width: 184, height: 184, display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'center', justifyContent: 'center', color: '#8c8c8c', fontSize: 13 }}>
+                  <Spin />
+                  <span>{translate('whatsapp_generating_qr')}</span>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Integrations/index.jsx
+++ b/frontend/src/pages/Integrations/index.jsx
@@ -29,14 +29,15 @@ const STATUS_LABEL_KEY = {
   disconnected: 'whatsapp_status_disconnected',
   qr_pending: 'whatsapp_status_connecting',
   connected: 'whatsapp_status_connected',
-  logged_out: 'whatsapp_status_logged_out',
 };
 const STATUS_COLOR = {
   disconnected: '#8c8c8c',
   qr_pending: '#1677ff',
   connected: '#52c41a',
-  logged_out: '#fa8c16',
 };
+// logged_out / unknown collapse to "not connected" in the UI — no separate display.
+const labelKeyFor = (s) => STATUS_LABEL_KEY[s] || STATUS_LABEL_KEY.disconnected;
+const colorFor = (s) => STATUS_COLOR[s] || STATUS_COLOR.disconnected;
 const POLL_MS = 2500;
 
 export default function IntegrationsPage() {
@@ -79,19 +80,22 @@ export default function IntegrationsPage() {
     }
   };
 
+  const pollOnce = async () => {
+    try {
+      const res = await waStatus();
+      applyStatus(res.result);
+    } catch (err) {
+      stopPolling();
+      setIsModalOpen(false);
+      setWaStatusValue('disconnected');
+      toastError(err);
+    }
+  };
+
   const startPolling = () => {
     stopPolling();
-    pollRef.current = setInterval(async () => {
-      try {
-        const res = await waStatus();
-        applyStatus(res.result);
-      } catch (err) {
-        stopPolling();
-        setIsModalOpen(false);
-        setWaStatusValue('disconnected');
-        toastError(err);
-      }
-    }, POLL_MS);
+    pollOnce(); // fire immediately so the QR shows without waiting a full interval
+    pollRef.current = setInterval(pollOnce, POLL_MS);
   };
 
   const handleConnect = async () => {
@@ -118,7 +122,7 @@ export default function IntegrationsPage() {
         try {
           await waLogout();
           stopPolling();
-          setWaStatusValue('logged_out');
+          setWaStatusValue('disconnected');
           setWaQr(null);
           message.info(`WhatsApp ${translate('integration_disconnected')}`);
         } catch (err) {
@@ -131,6 +135,19 @@ export default function IntegrationsPage() {
   const handleSwitch = (checked) => {
     if (checked) handleConnect();
     else confirmDisconnect();
+  };
+
+  // Closing the QR dialog before scanning cancels the attempt: stop polling,
+  // tear down the pending bridge client, and return to a clean "not connected"
+  // instead of a stuck "connecting".
+  const handleModalCancel = () => {
+    setIsModalOpen(false);
+    if (waStatusValue === 'qr_pending') {
+      stopPolling();
+      setWaQr(null);
+      setWaStatusValue('disconnected');
+      waLogout().catch((err) => console.warn('WhatsApp connect cancel teardown failed:', err?.message));
+    }
   };
 
   // Pull current status once on open (self-heals a stale UI); stop polling on unmount.
@@ -264,12 +281,11 @@ export default function IntegrationsPage() {
                       {item.name}
                     </span>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexShrink: 0 }}>
-                      <span style={{ fontSize: '12px', fontWeight: 500, color: STATUS_COLOR[statusValue] }}>
-                        {translate(STATUS_LABEL_KEY[statusValue])}
+                      <span style={{ fontSize: '12px', fontWeight: 500, color: colorFor(statusValue) }}>
+                        {translate(labelKeyFor(statusValue))}
                       </span>
                       <Switch
                         checked={isConnected}
-                        loading={statusValue === 'qr_pending'}
                         onChange={handleSwitch}
                       />
                     </div>
@@ -303,11 +319,11 @@ export default function IntegrationsPage() {
       <Modal
         title={
           <div style={{ fontSize: '20px', fontWeight: '600', color: '#1f1f1f', fontFamily: 'Inter, system-ui, sans-serif', paddingBottom: '16px', borderBottom: '1px solid #f0f0f0' }}>
-            Connect a WhatsApp account
+            {translate('whatsapp_modal_title')}
           </div>
         }
         open={isModalOpen}
-        onCancel={() => setIsModalOpen(false)}
+        onCancel={handleModalCancel}
         footer={null}
         width={640}
         centered
@@ -322,10 +338,10 @@ export default function IntegrationsPage() {
           {/* Left Column: Instructions */}
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '16px' }}>
             <ol style={{ paddingLeft: '20px', margin: 0, display: 'flex', flexDirection: 'column', gap: '14px', color: '#595959', fontSize: '14px', lineHeight: '1.6' }}>
-              <li>Open WhatsApp on your phone</li>
-              <li>Tap <strong style={{ color: '#262626' }}>"You"</strong>, then under <strong style={{ color: '#262626' }}>"Settings"</strong> select <strong style={{ color: '#262626' }}>"Linked Devices"</strong></li>
-              <li>Tap on <strong style={{ color: '#262626' }}>Link a device</strong></li>
-              <li>Point your phone to this screen to capture the QR code</li>
+              <li>{translate('whatsapp_step_1')}</li>
+              <li>{translate('whatsapp_step_2')}</li>
+              <li>{translate('whatsapp_step_3')}</li>
+              <li>{translate('whatsapp_step_4')}</li>
             </ol>
           </div>
 

--- a/frontend/src/pages/Integrations/index.jsx
+++ b/frontend/src/pages/Integrations/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { Button, Input, Switch, Row, Col, message, Modal, QRCode, Spin } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { PageHeader } from '@ant-design/pro-layout';
@@ -61,7 +61,10 @@ export default function IntegrationsPage() {
     }
   };
 
-  const isItemConnected = (item) => item.id === 'whatsapp' && waStatusValue === 'connected';
+  const isItemConnected = useCallback(
+    (item) => item.id === 'whatsapp' && waStatusValue === 'connected',
+    [waStatusValue]
+  );
 
   // Map an error to the right localized toast (503 = gateway down).
   const toastError = (err) =>
@@ -157,8 +160,9 @@ export default function IntegrationsPage() {
         const res = await waStatus();
         setWaStatusValue(res.result?.status || 'disconnected');
         setWaQr(res.result?.qr || null);
-      } catch {
-        // Silent on initial load — don't error-toast just for opening the page.
+      } catch (err) {
+        // Don't error-toast just for opening the page, but log for debugging.
+        console.warn('[whatsapp] initial status fetch failed:', err?.message);
       }
     })();
     return () => stopPolling();
@@ -171,8 +175,7 @@ export default function IntegrationsPage() {
       const matchesConnected = showConnectedOnly ? isItemConnected(item) : true;
       return matchesSearch && matchesTab && matchesConnected;
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, activeTab, showConnectedOnly, waStatusValue]);
+  }, [searchQuery, activeTab, showConnectedOnly, isItemConnected]);
 
   return (
     <div

--- a/frontend/src/request/request.js
+++ b/frontend/src/request/request.js
@@ -310,5 +310,15 @@ const request = {
       return errorHandler(error);
     }
   },
+
+  // Raw passthrough for endpoints that own their success/error UI (e.g. WhatsApp
+  // connect needs the raw HTTP status to tell 503 apart from other failures).
+  // Same configured axios instance as the rest of this module — deliberately
+  // skips success/errorHandler so the caller sees the untouched response/error.
+  raw: {
+    post: (url, data) => axios.post(url, data).then((res) => res.data),
+    get: (url) => axios.get(url).then((res) => res.data),
+    delete: (url) => axios.delete(url).then((res) => res.data),
+  },
 };
 export default request;

--- a/frontend/src/request/whatsapp.js
+++ b/frontend/src/request/whatsapp.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+// Reuses the global axios instance configured in request/request.js (baseURL
+// ends with /api/, withCredentials). Raw calls — the caller maps success/error
+// to localized UI so it can distinguish 503 (gateway) from other failures.
+export const waLogin = () => axios.post('whatsapp/login').then((res) => res.data);
+export const waStatus = () => axios.get('whatsapp/status').then((res) => res.data);
+export const waLogout = () => axios.delete('whatsapp').then((res) => res.data);

--- a/frontend/src/request/whatsapp.js
+++ b/frontend/src/request/whatsapp.js
@@ -1,8 +1,8 @@
-import axios from 'axios';
+import request from '@/request/request';
 
-// Reuses the global axios instance configured in request/request.js (baseURL
-// ends with /api/, withCredentials). Raw calls — the caller maps success/error
-// to localized UI so it can distinguish 503 (gateway) from other failures.
-export const waLogin = () => axios.post('whatsapp/login').then((res) => res.data);
-export const waStatus = () => axios.get('whatsapp/status').then((res) => res.data);
-export const waLogout = () => axios.delete('whatsapp').then((res) => res.data);
+// Goes through the src/request/ layer (request.raw = shared axios, no toast
+// handlers) so the caller can map HTTP status to localized UI — 503 (gateway)
+// vs other failures.
+export const waLogin = () => request.raw.post('whatsapp/login');
+export const waStatus = () => request.raw.get('whatsapp/status');
+export const waLogout = () => request.raw.delete('whatsapp');


### PR DESCRIPTION
## What
Web-based WhatsApp QR connect/disconnect on the Integrations page, backed by a CRM REST proxy to the local Baileys bridge and a new per-admin `Integration` collection. This is the **H1–H4** handoff from the WhatsApp multi-tenant plan (terminal QR → web QR + persisted state).

**Companion bridge PR: SeekMi-Technologies/Ola_bot#8** — must land together to work end-to-end.

## Commits
- `feat(model)` — `Integration` collection: row-per-(admin, provider), keeps `Admin` pure (#325)
- `feat(api)` — REST proxy `/api/whatsapp/{login,status,logout}` → per-admin HMAC to the bridge (#326)
- `feat(frontend)` — per-capsule Switch + live QR modal + 2.5s poll (#327)
- `fix(frontend)` — E2E UX fixes: switch spinner removed, modal-cancel = abort, immediate poll, modal i18n

## Design
- adminId always from `req.admin._id` (never body/param); bridge unreachable → **503**, bridge error → **502**
- `Integration`: `enabled` = intent (login/logout), `status`/`meta` = observed cache (pull-only; bridge→CRM push is a documented follow-up)
- no phone number surfaced (WhatsApp LID, not a trustworthy MSISDN)
- QR rendered via antd's built-in `<QRCode>` — **no new dependency**
- routes registered in `appApi.js` alongside `ola/*` (not an appModel; no app.js/auto-CRUD changes)

## Tests
- jest: `integration.model.test.js` 7/7 (defaults/enum/unique/upsert), `whatsapp.proxy.test.js` 7/7 (fake bridge + in-memory Mongo: login/status/logout/503/502/HMAC)
- `vite build` clean; manual E2E: connect → scan → connected → disconnect → reconnect verified

## Heads-up (CI)
Full `npm test` has **pre-existing flaky failures** from a hardcoded test port (`18901`) colliding under parallel jest (`EADDRINUSE`) — unrelated to this PR, reproducible on `dev`, passes serially. Logged as a separate test-infra backlog item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)