### PR TITLE
feat(erp): add AntD column sorting to Quote/Invoice/PO lists

### DIFF
--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -151,13 +151,33 @@ export default function DataTable({ config, extra = [] }) {
     },
   ];
 
-  const handelDataTableLoad = (pagination) => {
-    const options = { page: pagination.current || 1, items: pagination.pageSize || 10 };
+  const buildSortOptions = (sorter) => {
+    if (!sorter?.order) return {};
+    const field = Array.isArray(sorter.field) ? sorter.field.join('.') : sorter.field;
+    return { sortBy: field, sortValue: sorter.order === 'ascend' ? 1 : -1 };
+  };
+
+  const handelDataTableLoad = (pagination, _filters, sorter = {}) => {
+    const options = {
+      page: pagination?.current || 1,
+      items: pagination?.pageSize || 10,
+      ...buildSortOptions(sorter),
+    };
     dispatch(erp.list({ entity, options }));
   };
 
+  const defaultSortCol = dataTableColumns.find((c) => c.defaultSortOrder);
+
   const dispatcher = () => {
-    dispatch(erp.list({ entity }));
+    const options = {};
+    if (defaultSortCol) {
+      const field = Array.isArray(defaultSortCol.dataIndex)
+        ? defaultSortCol.dataIndex.join('.')
+        : defaultSortCol.dataIndex;
+      options.sortBy = field;
+      options.sortValue = defaultSortCol.defaultSortOrder === 'ascend' ? 1 : -1;
+    }
+    dispatch(erp.list({ entity, options }));
   };
 
   useEffect(() => {

--- a/frontend/src/pages/Invoice/index.jsx
+++ b/frontend/src/pages/Invoice/index.jsx
@@ -22,14 +22,18 @@ export default function Invoice() {
     {
       title: translate('Number'),
       dataIndex: 'number',
+      sorter: true,
     },
     {
       title: translate('Client'),
       dataIndex: ['client', 'name'],
+      sorter: true,
     },
     {
       title: translate('Date'),
       dataIndex: 'date',
+      sorter: true,
+      defaultSortOrder: 'descend',
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -37,6 +41,7 @@ export default function Invoice() {
     {
       title: translate('expired Date'),
       dataIndex: 'expiredDate',
+      sorter: true,
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -44,6 +49,7 @@ export default function Invoice() {
     {
       title: translate('Total'),
       dataIndex: 'total',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -74,6 +80,7 @@ export default function Invoice() {
     {
       title: translate('Status'),
       dataIndex: 'status',
+      sorter: true,
       render: (status) => {
         let tagStatus = tagColor(status);
 

--- a/frontend/src/pages/PurchaseOrder/index.jsx
+++ b/frontend/src/pages/PurchaseOrder/index.jsx
@@ -21,15 +21,19 @@ export default function PurchaseOrder() {
     {
       title: translate('Number'),
       dataIndex: 'number',
+      sorter: true,
     },
     {
       title: translate('Factory'),
       dataIndex: ['factory', 'factory_name'],
+      sorter: true,
       render: (_, record) => `${record.factory?.factory_code} - ${record.factory?.factory_name}`,
     },
     {
       title: translate('Date'),
       dataIndex: 'date',
+      sorter: true,
+      defaultSortOrder: 'descend',
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -37,6 +41,7 @@ export default function PurchaseOrder() {
     {
       title: translate('expired Date'),
       dataIndex: 'expiredDate',
+      sorter: true,
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -44,6 +49,7 @@ export default function PurchaseOrder() {
     {
       title: translate('Sub Total'),
       dataIndex: 'subTotal',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -58,6 +64,7 @@ export default function PurchaseOrder() {
     {
       title: translate('Total'),
       dataIndex: 'total',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -72,6 +79,7 @@ export default function PurchaseOrder() {
     {
       title: translate('Status'),
       dataIndex: 'status',
+      sorter: true,
       render: (status) => {
         let tagStatus = tagColor(status);
         return (

--- a/frontend/src/pages/Quote/index.jsx
+++ b/frontend/src/pages/Quote/index.jsx
@@ -21,14 +21,18 @@ export default function Quote() {
     {
       title: translate('Number'),
       dataIndex: 'number',
+      sorter: true,
     },
     {
       title: translate('Client'),
       dataIndex: ['client', 'name'],
+      sorter: true,
     },
     {
       title: translate('Date'),
       dataIndex: 'date',
+      sorter: true,
+      defaultSortOrder: 'descend',
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -36,6 +40,7 @@ export default function Quote() {
     {
       title: translate('expired Date'),
       dataIndex: 'expiredDate',
+      sorter: true,
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -43,6 +48,7 @@ export default function Quote() {
     {
       title: translate('Sub Total'),
       dataIndex: 'subTotal',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -57,6 +63,7 @@ export default function Quote() {
     {
       title: translate('Total'),
       dataIndex: 'total',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -72,6 +79,7 @@ export default function Quote() {
     {
       title: translate('Status'),
       dataIndex: 'status',
+      sorter: true,
       render: (status) => {
         let tagStatus = tagColor(status);
 


### PR DESCRIPTION
## 改动内容

Refs #164 — 给 Quote / Invoice / PurchaseOrder 三个列表页加列级排序。

- **`ErpPanelModule/DataTable.jsx`**(三页共用的核心 wiring)
  - `Table.onChange` 接 AntD sorter → 映射成 `sortBy` / `sortValue` query params(`ascend`→1、`descend`→-1;取消排序则不带 → 后端回落默认 `created desc`)
  - 嵌套 dataIndex 数组(如 `['client','name']`)`join('.')`
  - 首屏从带 `defaultSortOrder` 的列派生初始排序并发出 → 表头箭头与实际数据顺序一致(避免 #163 那类前后端默认不一致)
- **Quote / Invoice / PO `index.jsx`**:原生列加 `sorter: true`,`date` 列加 `defaultSortOrder: 'descend'`
- 后端 `paginatedList` 已支持 `sortBy`/`sortValue`(#163),`request.list` 自动序列化任意 option key,故 `actions.js`/`request.js`/后端均无需改动

## 已知限制(后续 issue)

- 关联列 `client.name` / `factory.factory_name` / `createdBy.name` 是 populate 字段,后端 `.sort()` 在 populate 前对原始 doc 执行,点击有请求但顺序不变。真正可排序需后端 `$lookup` 聚合,留作 backend 后续。

## 验证

- [x] `npx eslint` 改动文件无新增问题
- [x] `npm run build` 通过
- [x] 本地 `start-dev.sh` 起全栈,Quote/Invoice/PO 列头排序点击正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)