### PR TITLE
feat(tasks): add Tasks board page and optimize styling/colors

### DIFF
--- a/frontend/src/apps/Header/HeaderContainer.jsx
+++ b/frontend/src/apps/Header/HeaderContainer.jsx
@@ -47,6 +47,7 @@ import {
 const PAGE_MAP = {
   '/': { icon: <DashboardOutlined />, label: 'Dashboard' },
   '/askola': { icon: <SmileOutlined />, label: 'Ask Ola' },
+  '/control': { icon: <CheckSquareOutlined />, label: 'Tasks' },
   '/file': { icon: <FileOutlined />, label: 'file' },
   '/integrations': { icon: <ApiOutlined />, label: 'integrations' },
   // === MVP-HIDDEN: 以下页面已从导航中隐藏 ===

--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -46,6 +46,7 @@ import {
   QuestionCircleOutlined,
   LogoutOutlined,
   RightOutlined,
+  DeploymentUnitOutlined,
 } from '@ant-design/icons';
 
 const { Sider } = Layout;
@@ -93,6 +94,11 @@ function Sidebar({ collapsible, isMobile = false }) {
           key: 'askola',
           icon: <SmileOutlined />,
           label: <Link to={'/askola'}>{translate('Ask Ola')}</Link>,
+        },
+        {
+          key: 'control',
+          icon: <DeploymentUnitOutlined />,
+          label: <Link to={'/control'}>{translate('Mission Control')}</Link>,
         },
         {
           key: 'file',

--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -46,7 +46,7 @@ import {
   QuestionCircleOutlined,
   LogoutOutlined,
   RightOutlined,
-  DeploymentUnitOutlined,
+  CheckSquareOutlined,
 } from '@ant-design/icons';
 
 const { Sider } = Layout;
@@ -97,8 +97,8 @@ function Sidebar({ collapsible, isMobile = false }) {
         },
         {
           key: 'control',
-          icon: <DeploymentUnitOutlined />,
-          label: <Link to={'/control'}>{translate('Mission Control')}</Link>,
+          icon: <CheckSquareOutlined />,
+          label: <Link to={'/control'}>{translate('Tasks')}</Link>,
         },
         {
           key: 'file',

--- a/frontend/src/mock/missionMockData.js
+++ b/frontend/src/mock/missionMockData.js
@@ -1,0 +1,209 @@
+/**
+ * Mission Control Mock Data — Palantir-style lead-to-quote command center.
+ *
+ * Shape = front/back contract. Backend Mission model must return objects of
+ * this shape from GET /mission/list.
+ *
+ * `report[]` reuses the AskOla block/widget schema so the drawer renders
+ * it with existing block components. It is the condensed agent work log —
+ * NOT raw emails.
+ */
+
+const MOCK_MISSIONS = [
+  // ── 1. Inquiry · processing ────────────────────────────────────────────
+  {
+    id: 'm_001',
+    client: { name: 'Shanghai Steel Trading Co.', contact: 'Mr. Wang', country: '🇨🇳' },
+    channel: 'whatsapp',
+    stage: 'inquiry',
+    agentState: 'processing',
+    summary: 'Parsing inquiry PDF — 5 wire-rope SKUs requested, matching against catalog.',
+    lastActivityAt: '2026-06-04T13:48:00Z',
+    assignedTo: { name: 'Yuandong', initial: 'Y' },
+    linkedQuote: null,
+    pendingActionCount: 0,
+    goal: 'Extract product needs → match catalog → assist drafting a quote',
+    linkedEntities: [
+      { type: 'client', label: 'Shanghai Steel Trading Co.' },
+      { type: 'merch', label: 'WR-6001' },
+    ],
+    tools: ['merch-matcher', 'quote-drafter'],
+    report: [
+      { type: 'thinking', content: 'Parsing PDF attachment...\nExtracted 5 product requirements\nMatching against merchandise catalog...' },
+      { type: 'text', content: 'Parsing the customer\'s inquiry file. Extracted **5 product requirements** — matching results coming shortly.' },
+    ],
+  },
+
+  // ── 2. Inquiry · awaiting approval ─────────────────────────────────────
+  {
+    id: 'm_002',
+    client: { name: 'Jakarta Hardware Imports', contact: 'Budi', country: '🇮🇩' },
+    channel: 'whatsapp',
+    stage: 'inquiry',
+    agentState: 'awaiting_approval',
+    summary: '3 of 5 SKUs matched (98% / 95% / 91%). 2 unmatched — needs your call before quoting.',
+    lastActivityAt: '2026-06-04T13:20:00Z',
+    assignedTo: { name: 'Ziyue', initial: 'Z' },
+    linkedQuote: null,
+    pendingActionCount: 2,
+    goal: 'Confirm matches → resolve 2 unmatched SKUs → draft quote',
+    linkedEntities: [
+      { type: 'client', label: 'Jakarta Hardware Imports' },
+      { type: 'merch', label: 'WR-6001' },
+      { type: 'merch', label: 'WR-8002' },
+    ],
+    tools: ['merch-matcher', 'quote-drafter'],
+    report: [
+      {
+        type: 'text',
+        content: 'Parsed inquiry. **3 matched**, **2 unmatched**. Please confirm whether to draft a quote from the matched items only.',
+      },
+      {
+        type: 'widget',
+        widgetType: 'merch_match',
+        data: {
+          matched: [
+            { serialNumber: 'WR-6001', name: '6mm Galvanized Wire Rope (6×19)', confidence: 98 },
+            { serialNumber: 'WR-8002', name: '8mm Stainless Wire Rope (7×7)', confidence: 95 },
+            { serialNumber: 'WR-1003', name: '10mm PVC-Coated Wire Rope (6×37)', confidence: 91 },
+          ],
+          unmatched: ['12mm Special Alloy Wire Rope', '5mm Copper-Core Wire Rope'],
+        },
+      },
+      {
+        type: 'action',
+        actions: [
+          { label: 'Approve & draft quote', actionId: 'create_quote', primary: true },
+          { label: 'Add unmatched to catalog', actionId: 'add_unmatched' },
+          { label: 'Reject', actionId: 'reject' },
+        ],
+      },
+    ],
+  },
+
+  // ── 3. Negotiation · idle ──────────────────────────────────────────────
+  {
+    id: 'm_003',
+    client: { name: 'Hamburg Marine Supply', contact: 'Klaus', country: '🇩🇪' },
+    channel: 'email',
+    stage: 'negotiation',
+    agentState: 'idle',
+    summary: 'Customer requested 8% volume discount on a 2,000m order. Awaiting your pricing decision.',
+    lastActivityAt: '2026-06-04T09:10:00Z',
+    assignedTo: { name: 'Yuandong', initial: 'Y' },
+    linkedQuote: { number: 'QT-20260603-014', total: 16400, currency: 'USD' },
+    pendingActionCount: 0,
+    goal: 'Negotiate price within margin floor → re-issue quote',
+    linkedEntities: [
+      { type: 'client', label: 'Hamburg Marine Supply' },
+      { type: 'quote', label: 'QT-20260603-014' },
+    ],
+    tools: ['price-researcher', 'quote-drafter'],
+    report: [
+      {
+        type: 'text',
+        content: 'Customer is requesting an **8% discount** on a 2,000m commitment. Current unit price is at market average — a 5% counter-offer keeps margin above floor. Recommend countering at **5%**.',
+      },
+    ],
+  },
+
+  // ── 4. Quote drafting · processing ─────────────────────────────────────
+  {
+    id: 'm_004',
+    client: { name: 'São Paulo Construções', contact: 'Carla', country: '🇧🇷' },
+    channel: 'whatsapp',
+    stage: 'quote_drafting',
+    agentState: 'processing',
+    summary: 'Drafting quote QT-20260604-021 from matched catalog — 3 line items, pricing pending.',
+    lastActivityAt: '2026-06-04T13:05:00Z',
+    assignedTo: { name: 'Ziyue', initial: 'Z' },
+    linkedQuote: { number: 'QT-20260604-021', total: 6220, currency: 'CNY' },
+    pendingActionCount: 0,
+    goal: 'Generate draft quote → salesperson fills final pricing',
+    linkedEntities: [
+      { type: 'client', label: 'São Paulo Construções' },
+      { type: 'quote', label: 'QT-20260604-021' },
+    ],
+    tools: ['quote-drafter'],
+    report: [
+      {
+        type: 'text',
+        content: 'Generated quote draft from the 3 confirmed items. **Unit prices left blank for the salesperson** — agent never invents prices.',
+      },
+      {
+        type: 'widget',
+        widgetType: 'quote_draft',
+        data: {
+          quoteNumber: 'QT-20260604-021',
+          clientName: 'São Paulo Construções',
+          items: [
+            { serialNumber: 'WR-6001', name: '6mm Galvanized Wire Rope (6×19)', quantity: 500, unit: 'm', price: 4.5 },
+            { serialNumber: 'WR-8002', name: '8mm Stainless Wire Rope (7×7)',   quantity: 300, unit: 'm', price: 8.2 },
+            { serialNumber: 'WR-1003', name: '10mm PVC-Coated Wire Rope (6×37)', quantity: 200, unit: 'm', price: 6.8 },
+          ],
+        },
+      },
+    ],
+  },
+
+  // ── 5. Quote finalization · awaiting approval ──────────────────────────
+  {
+    id: 'm_005',
+    client: { name: 'Lagos Industrial Ltd', contact: 'Chioma', country: '🇳🇬' },
+    channel: 'email',
+    stage: 'quote_finalization',
+    agentState: 'awaiting_approval',
+    summary: 'Quote ready to send — drafted email + PDF. Approve to send via Email.',
+    lastActivityAt: '2026-06-04T11:40:00Z',
+    assignedTo: { name: 'Yuandong', initial: 'Y' },
+    linkedQuote: { number: 'QT-20260603-009', total: 23800, currency: 'USD' },
+    pendingActionCount: 1,
+    goal: 'Finalize pricing + terms → send quote to customer',
+    linkedEntities: [
+      { type: 'client', label: 'Lagos Industrial Ltd' },
+      { type: 'quote', label: 'QT-20260603-009' },
+    ],
+    tools: ['quote-drafter', 'email-composer'],
+    report: [
+      {
+        type: 'text',
+        content: 'Quote **QT-20260603-009** is finalized (FOB terms included). Draft email is ready — **awaiting your approval to send**.',
+      },
+      {
+        type: 'action',
+        actions: [
+          { label: 'Approve & send via Email', actionId: 'send_quote', primary: true },
+          { label: 'Edit draft', actionId: 'edit_draft' },
+        ],
+      },
+    ],
+  },
+
+  // ── 6. Won · done ──────────────────────────────────────────────────────
+  {
+    id: 'm_006',
+    client: { name: 'Dubai Trading FZE', contact: 'Omar', country: '🇦🇪' },
+    channel: 'whatsapp',
+    stage: 'won',
+    agentState: 'done',
+    summary: 'Quote accepted ✓ — customer confirmed PO. Summary synced to client notes.',
+    lastActivityAt: '2026-06-03T16:30:00Z',
+    assignedTo: { name: 'Ziyue', initial: 'Z' },
+    linkedQuote: { number: 'QT-20260602-003', total: 41250, currency: 'USD' },
+    pendingActionCount: 0,
+    goal: 'Quote accepted → hand off to order fulfillment',
+    linkedEntities: [
+      { type: 'client', label: 'Dubai Trading FZE' },
+      { type: 'quote', label: 'QT-20260602-003' },
+    ],
+    tools: [],
+    report: [
+      {
+        type: 'text',
+        content: 'Customer **accepted quote** QT-20260602-003 for **$41,250**. Closing summary synced to client notes. Recommend handing off to the purchase order flow.',
+      },
+    ],
+  },
+];
+
+export default MOCK_MISSIONS;

--- a/frontend/src/modules/MissionControlModule/MissionBoard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionBoard.jsx
@@ -1,0 +1,82 @@
+import { Empty, Badge } from 'antd';
+import MissionCard from './MissionCard';
+import { STAGES, MATRIX_COLUMNS } from './constants';
+
+const COL_STATUS = { processing: 'processing', awaiting_approval: 'warning', done: 'success' };
+
+function PipelineView({ missions, onSelect }) {
+  return (
+    <div className="mc-board mc-board--pipeline">
+      {STAGES.map((stage) => {
+        const items = missions.filter((m) => m.stage === stage.key);
+        return (
+          <div className="mc-col" key={stage.key} style={{ '--stage-color': stage.color }}>
+            <div className="mc-col-head">
+              <span className="mc-col-dot" style={{ background: stage.color }} />
+              <span className="mc-col-title">{stage.label}</span>
+              <span className="mc-col-count">{items.length}</span>
+            </div>
+            <div className="mc-col-body">
+              {items.length === 0
+                ? <div className="mc-col-empty">—</div>
+                : items.map((m) => <MissionCard key={m.id} mission={m} onClick={onSelect} />)
+              }
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MatrixView({ missions, onSelect }) {
+  return (
+    <div
+      className="mc-board mc-board--matrix"
+      style={{ gridTemplateColumns: `160px repeat(${MATRIX_COLUMNS.length}, 1fr)` }}
+    >
+      {/* Corner */}
+      <div className="mc-matrix-corner" />
+
+      {/* Column headers — one outer table, no Card wrappers */}
+      {MATRIX_COLUMNS.map((col) => (
+        <div className="mc-matrix-colhead" key={col.key}>
+          <Badge status={COL_STATUS[col.key] || 'default'} />
+          <div className="mc-matrix-colhead-text">
+            <span className="mc-matrix-colhead-label">{col.label}</span>
+            <span className="mc-matrix-colhead-desc">{col.desc}</span>
+          </div>
+        </div>
+      ))}
+
+      {/* Stage rows */}
+      {STAGES.map((stage) => (
+        <div className="mc-matrix-row" key={stage.key} style={{ display: 'contents' }}>
+          <div className="mc-matrix-rowhead" style={{ '--stage-color': stage.color }}>
+            <span className="mc-col-dot" style={{ background: stage.color }} />
+            {stage.label}
+          </div>
+          {MATRIX_COLUMNS.map((col) => {
+            const items = missions.filter(
+              (m) => m.stage === stage.key && col.states.includes(m.agentState),
+            );
+            return (
+              <div className="mc-matrix-cell" key={col.key}>
+                {items.map((m) => <MissionCard key={m.id} mission={m} onClick={onSelect} />)}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function MissionBoard({ missions, layout, onSelect }) {
+  if (!missions?.length) {
+    return <div style={{ padding: '60px 0', textAlign: 'center' }}><Empty description="No active missions" /></div>;
+  }
+  return layout === 'matrix'
+    ? <MatrixView missions={missions} onSelect={onSelect} />
+    : <PipelineView missions={missions} onSelect={onSelect} />;
+}

--- a/frontend/src/modules/MissionControlModule/MissionBoard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionBoard.jsx
@@ -33,7 +33,7 @@ function PipelineView({ missions, onSelect }) {
             </div>
             <div className="mc-col-body">
               {items.length === 0
-                ? <div className="mc-col-empty">No active items</div>
+                ? <div className="mc-col-empty">No active tasks</div>
                 : items.map((m) => <MissionCard key={m.id} mission={m} onClick={onSelect} />)
               }
             </div>
@@ -87,10 +87,7 @@ function MatrixView({ missions, onSelect }) {
   );
 }
 
-export default function MissionBoard({ missions, layout, onSelect }) {
-  if (!missions?.length) {
-    return <div style={{ padding: '60px 0', textAlign: 'center' }}><Empty description="No active tasks" /></div>;
-  }
+export default function MissionBoard({ missions = [], layout, onSelect }) {
   return layout === 'matrix'
     ? <MatrixView missions={missions} onSelect={onSelect} />
     : <PipelineView missions={missions} onSelect={onSelect} />;

--- a/frontend/src/modules/MissionControlModule/MissionBoard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionBoard.jsx
@@ -12,13 +12,28 @@ function PipelineView({ missions, onSelect }) {
         return (
           <div className="mc-col" key={stage.key} style={{ '--stage-color': stage.color }}>
             <div className="mc-col-head">
-              <span className="mc-col-dot" style={{ background: stage.color }} />
-              <span className="mc-col-title">{stage.label}</span>
-              <span className="mc-col-count">{items.length}</span>
+              <Badge
+                color={stage.color}
+                text={
+                  <span className="mc-col-title" style={{ color: '#262626', fontWeight: 600 }}>
+                    {stage.label}
+                  </span>
+                }
+              />
+              <Badge
+                count={items.length}
+                showZero
+                style={{
+                  backgroundColor: '#f0f2f5',
+                  color: '#8c8c8c',
+                  boxShadow: 'none',
+                  fontWeight: 600,
+                }}
+              />
             </div>
             <div className="mc-col-body">
               {items.length === 0
-                ? <div className="mc-col-empty">—</div>
+                ? <div className="mc-col-empty">No active items</div>
                 : items.map((m) => <MissionCard key={m.id} mission={m} onClick={onSelect} />)
               }
             </div>

--- a/frontend/src/modules/MissionControlModule/MissionBoard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionBoard.jsx
@@ -89,7 +89,7 @@ function MatrixView({ missions, onSelect }) {
 
 export default function MissionBoard({ missions, layout, onSelect }) {
   if (!missions?.length) {
-    return <div style={{ padding: '60px 0', textAlign: 'center' }}><Empty description="No active missions" /></div>;
+    return <div style={{ padding: '60px 0', textAlign: 'center' }}><Empty description="No active tasks" /></div>;
   }
   return layout === 'matrix'
     ? <MatrixView missions={missions} onSelect={onSelect} />

--- a/frontend/src/modules/MissionControlModule/MissionCard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionCard.jsx
@@ -1,0 +1,83 @@
+import { Avatar, Tooltip } from 'antd';
+import {
+  WhatsAppOutlined, MailOutlined, WechatOutlined,
+  ClockCircleOutlined, ThunderboltOutlined,
+} from '@ant-design/icons';
+import { STAGE_MAP, AGENT_STATES, CHANNELS, timeAgo } from './constants';
+
+const CHANNEL_ICON = {
+  whatsapp: WhatsAppOutlined,
+  email: MailOutlined,
+  wechat: WechatOutlined,
+};
+
+// Agent state → a single dot color; no text label on the card (keep cards minimal)
+const STATE_DOT = {
+  processing: '#1677ff',
+  awaiting_approval: '#faad14',
+  idle: '#d9d9d9',
+  done: '#52c41a',
+};
+
+export default function MissionCard({ mission, onClick }) {
+  const stage = STAGE_MAP[mission.stage];
+  const agent = AGENT_STATES[mission.agentState];
+  const channel = CHANNELS[mission.channel];
+  const ChannelIcon = CHANNEL_ICON[mission.channel] || MailOutlined;
+  const needsAction = mission.pendingActionCount > 0;
+
+  return (
+    <div
+      className={`mc-card${needsAction ? ' mc-card--urgent' : ''}`}
+      style={{ '--stage-color': stage?.color }}
+      onClick={() => onClick?.(mission)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onClick?.(mission)}
+    >
+      {/* Urgent banner — the only non-neutral color element on a card */}
+      {needsAction && (
+        <div className="mc-card-banner">
+          <ThunderboltOutlined />
+          <span>Action Required · {mission.pendingActionCount}</span>
+        </div>
+      )}
+
+      {/* Row 1: channel + client + state dot */}
+      <div className="mc-card-head">
+        {/* Channel icon — neutral gray, tooltip shows the channel name */}
+        <Tooltip title={channel?.label} placement="top">
+          <span className="mc-card-channel">
+            <ChannelIcon />
+          </span>
+        </Tooltip>
+        <span className="mc-card-client">{mission.client.name}</span>
+        {/* State dot only — label visible on hover / in drawer */}
+        <Tooltip title={agent?.label} placement="top">
+          <span className="mc-card-state-dot" style={{ background: STATE_DOT[mission.agentState] }} />
+        </Tooltip>
+      </div>
+
+      {/* Row 2: condensed summary */}
+      <p className="mc-card-summary">{mission.summary}</p>
+
+      {/* Row 3: amount · time · assignee — right-aligned, all muted */}
+      <div className="mc-card-foot">
+        {mission.linkedQuote
+          ? <span className="mc-card-amount">
+              {mission.linkedQuote.currency}&nbsp;{mission.linkedQuote.total.toLocaleString()}
+            </span>
+          : <span />
+        }
+        <div className="mc-card-foot-right">
+          <span className="mc-card-time">
+            <ClockCircleOutlined />&nbsp;{timeAgo(mission.lastActivityAt)}
+          </span>
+          <Avatar size={20} style={{ background: '#f0f0f0', color: '#888', fontSize: 11, fontWeight: 600 }}>
+            {mission.assignedTo?.initial}
+          </Avatar>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/MissionCard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionCard.jsx
@@ -35,14 +35,6 @@ export default function MissionCard({ mission, onClick }) {
       tabIndex={0}
       onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onClick?.(mission)}
     >
-      {/* Urgent banner — the only non-neutral color element on a card */}
-      {needsAction && (
-        <div className="mc-card-banner">
-          <ThunderboltOutlined />
-          <span>Action Required · {mission.pendingActionCount}</span>
-        </div>
-      )}
-
       {/* Row 1: channel + client + state dot */}
       <div className="mc-card-head">
         {/* Channel icon — neutral gray, tooltip shows the channel name */}
@@ -52,6 +44,13 @@ export default function MissionCard({ mission, onClick }) {
           </span>
         </Tooltip>
         <span className="mc-card-client">{mission.client.name}</span>
+        
+        {needsAction && (
+          <Tooltip title={`Action Required: ${mission.pendingActionCount}`} placement="top">
+            <ThunderboltOutlined style={{ color: '#faad14', fontSize: '13px', marginRight: '2px', flex: 'none' }} />
+          </Tooltip>
+        )}
+
         {/* State dot only — label visible on hover / in drawer */}
         <Tooltip title={agent?.label} placement="top">
           <span className="mc-card-state-dot" style={{ background: STATE_DOT[mission.agentState] }} />

--- a/frontend/src/modules/MissionControlModule/MissionCard.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionCard.jsx
@@ -13,10 +13,10 @@ const CHANNEL_ICON = {
 
 // Agent state → a single dot color; no text label on the card (keep cards minimal)
 const STATE_DOT = {
-  processing: '#1677ff',
-  awaiting_approval: '#faad14',
-  idle: '#d9d9d9',
-  done: '#52c41a',
+  processing: '#1890ff',
+  awaiting_approval: '#ffa940',
+  idle: '#595959',
+  done: '#95de64',
 };
 
 export default function MissionCard({ mission, onClick }) {

--- a/frontend/src/modules/MissionControlModule/MissionComposer.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionComposer.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Segmented, Mentions, Button, Space, message } from 'antd';
+import { WhatsAppOutlined, MailOutlined, WechatOutlined, SendOutlined, RobotOutlined } from '@ant-design/icons';
+import { CHANNELS } from './constants';
+
+const MENTION_OPTIONS = [
+  { value: 'Client:current', label: '@Client (current customer)' },
+  { value: 'Merch:WR-6001', label: '@Merch:WR-6001' },
+  { value: 'Factory:Jiangsu-WR', label: '@Factory:Jiangsu Wire Rope' },
+  { value: 'Quote:current', label: '@Quote (linked)' },
+  { value: 'agent:merch-matcher', label: '@merch-matcher (agent)' },
+  { value: 'agent:quote-drafter', label: '@quote-drafter (agent)' },
+  { value: 'agent:price-researcher', label: '@price-researcher (agent)' },
+];
+
+const CHANNEL_OPTS = [
+  { value: 'whatsapp', label: <><WhatsAppOutlined /> WhatsApp</> },
+  { value: 'email',    label: <><MailOutlined /> Email</> },
+  { value: 'wechat',  label: <><WechatOutlined /> WeChat</> },
+];
+
+export default function MissionComposer({ defaultChannel = 'whatsapp' }) {
+  const [channel, setChannel] = useState(defaultChannel);
+  const [value, setValue] = useState('');
+
+  const send = () => {
+    if (!value.trim()) { message.warning('Message is empty'); return; }
+    message.success(`(Demo) Sent via ${CHANNELS[channel]?.label}`);
+    setValue('');
+  };
+
+  return (
+    <div className="mc-composer">
+      <div className="mc-composer-top">
+        <Segmented size="small" value={channel} onChange={setChannel} options={CHANNEL_OPTS} />
+      </div>
+      <Mentions
+        className="mc-composer-input"
+        autoSize={{ minRows: 2, maxRows: 4 }}
+        value={value}
+        onChange={setValue}
+        options={MENTION_OPTIONS}
+        prefix="@"
+        placeholder={`Reply via ${CHANNELS[channel]?.label} — type @ to reference an entity or agent`}
+      />
+      <div className="mc-composer-actions">
+        <Space>
+          <Button size="small" icon={<RobotOutlined />} onClick={() => message.info('(Demo) Ola is drafting a reply…')}>
+            Draft with Ola
+          </Button>
+          <Button size="small" type="primary" icon={<SendOutlined />} onClick={send}>
+            Send via {CHANNELS[channel]?.label}
+          </Button>
+        </Space>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/MissionDrawer.jsx
+++ b/frontend/src/modules/MissionControlModule/MissionDrawer.jsx
@@ -1,0 +1,96 @@
+import { Drawer, Steps, Tag, Divider } from 'antd';
+import {
+  WhatsAppOutlined, MailOutlined, WechatOutlined,
+  AimOutlined, LinkOutlined, ToolOutlined,
+} from '@ant-design/icons';
+import { STAGES, AGENT_STATES, stageIndex } from './constants';
+import ReportFeed from './ReportFeed';
+import MissionComposer from './MissionComposer';
+
+const CHANNEL_ICON = { whatsapp: WhatsAppOutlined, email: MailOutlined, wechat: WechatOutlined };
+
+const STATE_DOT = {
+  processing: '#1677ff',
+  awaiting_approval: '#faad14',
+  idle: '#d9d9d9',
+  done: '#52c41a',
+};
+
+export default function MissionDrawer({ mission, open, onClose }) {
+  if (!mission) return <Drawer open={false} onClose={onClose} />;
+
+  const agent = AGENT_STATES[mission.agentState];
+  const ChannelIcon = CHANNEL_ICON[mission.channel] || MailOutlined;
+
+  const title = (
+    <div className="mc-drawer-title">
+      <span className="mc-drawer-channel"><ChannelIcon /></span>
+      <span className="mc-drawer-client">{mission.client.name}</span>
+      <span className="mc-card-state-dot" style={{ background: STATE_DOT[mission.agentState] }} />
+      <span style={{ fontSize: 12, color: '#aaa' }}>{agent?.label}</span>
+    </div>
+  );
+
+  return (
+    <Drawer
+      title={title}
+      open={open}
+      onClose={onClose}
+      placement="right"
+      width={680}
+      footer={<MissionComposer defaultChannel={mission.channel} />}
+      styles={{
+        footer: { padding: '12px 16px', borderTop: '1px solid #f0f0f0' },
+        header: { borderBottom: '1px solid #f0f0f0' },
+      }}
+    >
+      <Steps
+        size="small"
+        current={stageIndex(mission.stage)}
+        status={mission.stage === 'won' ? 'finish' : 'process'}
+        items={STAGES.map((s) => ({ title: s.short }))}
+        style={{ marginBottom: 20 }}
+      />
+
+      <div className="mc-context">
+        <div className="mc-context-row">
+          <AimOutlined className="mc-context-icon" />
+          <span className="mc-context-label">Goal</span>
+          <span className="mc-context-val">{mission.goal}</span>
+        </div>
+        <div className="mc-context-row">
+          <LinkOutlined className="mc-context-icon" />
+          <span className="mc-context-label">Linked</span>
+          <span className="mc-context-val">
+            {mission.linkedEntities.map((e) => (
+              <Tag key={`${e.type}-${e.label}`} style={{ marginBottom: 2 }}>
+                {e.type}: {e.label}
+              </Tag>
+            ))}
+          </span>
+        </div>
+        {mission.tools?.length > 0 && (
+          <div className="mc-context-row">
+            <ToolOutlined className="mc-context-icon" />
+            <span className="mc-context-label">Tools</span>
+            <span className="mc-context-val">
+              {mission.tools.map((t) => (
+                <Tag key={t} style={{ fontFamily: 'monospace', marginBottom: 2 }}>
+                  {t}
+                </Tag>
+              ))}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <Divider style={{ margin: '16px 0 12px' }}>
+        <span style={{ fontSize: 11, color: '#bbb', fontWeight: 600, letterSpacing: '0.5px', textTransform: 'uppercase' }}>
+          Agent Report
+        </span>
+      </Divider>
+
+      <ReportFeed blocks={mission.report} />
+    </Drawer>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/ReportFeed.jsx
+++ b/frontend/src/modules/MissionControlModule/ReportFeed.jsx
@@ -1,0 +1,38 @@
+import TextBlock from '@/components/AskOla/blocks/TextBlock';
+import WidgetBlock from '@/components/AskOla/blocks/WidgetBlock';
+import ActionBlock from '@/components/AskOla/blocks/ActionBlock';
+import ThinkingBlock from '@/components/AskOla/blocks/ThinkingBlock';
+import FileBlock from '@/components/AskOla/blocks/FileBlock';
+import SaveToNotes from './SaveToNotes';
+
+function renderBlock(block) {
+  switch (block.type) {
+    case 'text':    return <TextBlock content={block.content} />;
+    case 'widget':  return <WidgetBlock widgetType={block.widgetType} data={block.data} />;
+    case 'action':  return <ActionBlock actions={block.actions} />;
+    case 'thinking':return <ThinkingBlock content={block.content} />;
+    case 'file':    return <FileBlock filename={block.filename} fileType={block.fileType} size={block.size} url={block.url} />;
+    default:        return <div className="askola-block-unknown">[unsupported: {block.type}]</div>;
+  }
+}
+
+function summarize(block) {
+  if (block.type === 'text')   return block.content.replace(/[*#`]/g, '').slice(0, 120);
+  if (block.type === 'widget') return `[${block.widgetType}] agent 输出`;
+  if (block.type === 'thinking') return 'Agent 推理过程';
+  if (block.type === 'file')   return block.filename;
+  return '';
+}
+
+export default function ReportFeed({ blocks = [] }) {
+  return (
+    <div className="mc-feed">
+      {blocks.map((block, i) => (
+        <div className="mc-report-block" key={i}>
+          {block.type !== 'action' && <SaveToNotes payload={summarize(block)} />}
+          {renderBlock(block)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/SaveToNotes.jsx
+++ b/frontend/src/modules/MissionControlModule/SaveToNotes.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Popover, Radio, Button, Space, Typography, message } from 'antd';
+import { PushpinOutlined } from '@ant-design/icons';
+
+const TARGET_LABELS = {
+  client: 'This client',
+  merch: 'Merchandise',
+  factory: 'Factory',
+};
+
+export default function SaveToNotes({ payload, targetTypes = ['client', 'merch', 'factory'] }) {
+  const [open, setOpen] = useState(false);
+  const [target, setTarget] = useState(targetTypes[0]);
+
+  const content = (
+    <div style={{ width: 200 }} onClick={(e) => e.stopPropagation()}>
+      <Typography.Text type="secondary" style={{ fontSize: 12 }}>Save to</Typography.Text>
+      <div style={{ margin: '8px 0' }}>
+        <Radio.Group value={target} onChange={(e) => setTarget(e.target.value)}>
+          <Space direction="vertical" size={4}>
+            {targetTypes.map((t) => (
+              <Radio key={t} value={t}>{TARGET_LABELS[t]}</Radio>
+            ))}
+          </Space>
+        </Radio.Group>
+      </div>
+      {payload && (
+        <Typography.Paragraph
+          ellipsis={{ rows: 2 }}
+          style={{ fontSize: 11, color: '#aaa', background: '#fafafa', padding: '4px 8px', borderRadius: 4, marginBottom: 8 }}
+        >
+          {payload}
+        </Typography.Paragraph>
+      )}
+      <Button
+        type="primary" size="small" block
+        onClick={() => { setOpen(false); message.success(`Saved to ${TARGET_LABELS[target]} notes (demo)`); }}
+      >
+        Save note
+      </Button>
+    </div>
+  );
+
+  return (
+    <Popover content={content} title={null} trigger="click" open={open} onOpenChange={setOpen} placement="leftTop">
+      <button className="mc-pin-btn" title="Save to notes" onClick={(e) => e.stopPropagation()}>
+        <PushpinOutlined />
+      </button>
+    </Popover>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/constants.js
+++ b/frontend/src/modules/MissionControlModule/constants.js
@@ -1,0 +1,60 @@
+// Mission Control — shared metadata for the lead-to-quote command center.
+//
+// UI-only prototype constants. The real values are the *contract* the backend
+// Mission model will mirror once it exists (stage + channel enums, agentState).
+// Keep this list as the single source of truth for the board so columns,
+// chips and the detail stepper never drift apart.
+
+// ── Business pipeline (the lead-to-quote funnel) ─────────────────────────────
+// `won` is shown as the terminal column; `lost` is a terminal state too but is
+// filtered out of the default board (surfaced via a filter later).
+export const STAGES = [
+  { key: 'inquiry', label: 'Lead Inquiry', short: 'Inquiry', color: '#1668dc' },
+  { key: 'negotiation', label: 'Negotiation', short: 'Negotiation', color: '#13a8a8' },
+  { key: 'quote_drafting', label: 'Quote Drafting', short: 'Drafting', color: '#d89614' },
+  { key: 'quote_finalization', label: 'Quote Finalization', short: 'Finalizing', color: '#642ab5' },
+  { key: 'won', label: 'Won', short: 'Won', color: '#52c41a' },
+];
+
+export const STAGE_MAP = Object.fromEntries(STAGES.map((s) => [s.key, s]));
+
+export function stageIndex(key) {
+  return STAGES.findIndex((s) => s.key === key);
+}
+
+// ── Agent execution state (Palantir's Processing / Approval / Completed) ──────
+export const AGENT_STATES = {
+  processing: { key: 'processing', label: 'Processing', color: '#3b82f6' },
+  awaiting_approval: { key: 'awaiting_approval', label: 'Awaiting Approval', color: '#faad14' },
+  idle: { key: 'idle', label: 'Idle', color: '#7b88a0' },
+  done: { key: 'done', label: 'Completed', color: '#52c41a' },
+};
+
+// The 3 status columns of the Palantir-style matrix view. `idle` folds into
+// Processing so every mission lands in exactly one cell.
+export const MATRIX_COLUMNS = [
+  { key: 'processing', label: 'Agent Active', desc: 'Ola is working on this', states: ['processing', 'idle'] },
+  { key: 'awaiting_approval', label: 'Needs Review', desc: 'Waiting for your input', states: ['awaiting_approval'] },
+  { key: 'done', label: 'Done', desc: 'Mission completed', states: ['done'] },
+];
+
+// ── Inbound/outbound channels — generic, never hardcode whatsapp as the only
+// source (CLAUDE.md MVP rule). WeChat / Email are first-class peers.
+export const CHANNELS = {
+  whatsapp: { key: 'whatsapp', label: 'WhatsApp', color: '#25d366' },
+  email: { key: 'email', label: 'Email', color: '#3b82f6' },
+  wechat: { key: 'wechat', label: 'WeChat', color: '#07c160' },
+};
+
+// ── Small relative-time helper for card timestamps ("12m ago"). ──────────────
+export function timeAgo(iso) {
+  if (!iso) return '';
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diff / 60000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  return `${day}d ago`;
+}

--- a/frontend/src/modules/MissionControlModule/constants.js
+++ b/frontend/src/modules/MissionControlModule/constants.js
@@ -9,11 +9,11 @@
 // `won` is shown as the terminal column; `lost` is a terminal state too but is
 // filtered out of the default board (surfaced via a filter later).
 export const STAGES = [
-  { key: 'inquiry', label: 'Lead Inquiry', short: 'Inquiry', color: '#1668dc' },
-  { key: 'negotiation', label: 'Negotiation', short: 'Negotiation', color: '#13a8a8' },
-  { key: 'quote_drafting', label: 'Quote Drafting', short: 'Drafting', color: '#d89614' },
-  { key: 'quote_finalization', label: 'Quote Finalization', short: 'Finalizing', color: '#642ab5' },
-  { key: 'won', label: 'Won', short: 'Won', color: '#52c41a' },
+  { key: 'inquiry', label: 'Lead Inquiry', short: 'Inquiry', color: '#1890ff' },
+  { key: 'negotiation', label: 'Negotiation', short: 'Negotiation', color: '#13c2c2' },
+  { key: 'quote_drafting', label: 'Quote Drafting', short: 'Drafting', color: '#722ed1' },
+  { key: 'quote_finalization', label: 'Quote Finalization', short: 'Finalizing', color: '#ffa940' },
+  { key: 'won', label: 'Won', short: 'Won', color: '#95de64' },
 ];
 
 export const STAGE_MAP = Object.fromEntries(STAGES.map((s) => [s.key, s]));
@@ -24,10 +24,10 @@ export function stageIndex(key) {
 
 // ── Agent execution state (Palantir's Processing / Approval / Completed) ──────
 export const AGENT_STATES = {
-  processing: { key: 'processing', label: 'Processing', color: '#3b82f6' },
-  awaiting_approval: { key: 'awaiting_approval', label: 'Awaiting Approval', color: '#faad14' },
-  idle: { key: 'idle', label: 'Idle', color: '#7b88a0' },
-  done: { key: 'done', label: 'Completed', color: '#52c41a' },
+  processing: { key: 'processing', label: 'Processing', color: '#1890ff' },
+  awaiting_approval: { key: 'awaiting_approval', label: 'Awaiting Approval', color: '#ffa940' },
+  idle: { key: 'idle', label: 'Idle', color: '#595959' },
+  done: { key: 'done', label: 'Completed', color: '#95de64' },
 };
 
 // The 3 status columns of the Palantir-style matrix view. `idle` folds into

--- a/frontend/src/modules/MissionControlModule/index.jsx
+++ b/frontend/src/modules/MissionControlModule/index.jsx
@@ -1,11 +1,10 @@
 import { useState, useMemo } from 'react';
-import { Input, Segmented, Typography, Space } from 'antd';
+import { Input, Segmented } from 'antd';
 import { AppstoreOutlined, TableOutlined, SearchOutlined } from '@ant-design/icons';
+import { PageHeader } from '@ant-design/pro-layout';
 import MOCK_MISSIONS from '@/mock/missionMockData';
 import MissionBoard from './MissionBoard';
 import MissionDrawer from './MissionDrawer';
-
-const { Title, Text } = Typography;
 
 export default function MissionControlModule() {
   const [layout, setLayout] = useState('pipeline');
@@ -24,23 +23,26 @@ export default function MissionControlModule() {
 
   return (
     <div className="mc-root">
-      <div className="mc-header">
-        <div>
-          <Title level={4} style={{ margin: 0 }}>Tasks</Title>
-          <Text type="secondary" style={{ fontSize: 13 }}>
-            Lead-to-Quote tracker · {missions.length} active
-          </Text>
-        </div>
-        <Space size={12}>
+      <PageHeader
+        title="Tasks"
+        subTitle={`Lead-to-Quote tracker · ${missions.length} active`}
+        ghost={false}
+        style={{
+          padding: '0 0 20px 0',
+          background: 'transparent',
+        }}
+        extra={[
           <Input
+            key="search"
             allowClear
             prefix={<SearchOutlined style={{ color: '#bbb' }} />}
             placeholder="Search by client or summary"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            style={{ width: 240 }}
-          />
+            style={{ width: 240, borderRadius: '6px' }}
+          />,
           <Segmented
+            key="layout"
             value={layout}
             onChange={setLayout}
             options={[
@@ -48,8 +50,8 @@ export default function MissionControlModule() {
               { value: 'matrix',   icon: <TableOutlined />,    label: 'Matrix' },
             ]}
           />
-        </Space>
-      </div>
+        ]}
+      />
 
       <MissionBoard missions={missions} layout={layout} onSelect={setActive} />
       <MissionDrawer mission={active} open={!!active} onClose={() => setActive(null)} />

--- a/frontend/src/modules/MissionControlModule/index.jsx
+++ b/frontend/src/modules/MissionControlModule/index.jsx
@@ -1,0 +1,58 @@
+import { useState, useMemo } from 'react';
+import { Input, Segmented, Typography, Space } from 'antd';
+import { AppstoreOutlined, TableOutlined, SearchOutlined } from '@ant-design/icons';
+import MOCK_MISSIONS from '@/mock/missionMockData';
+import MissionBoard from './MissionBoard';
+import MissionDrawer from './MissionDrawer';
+
+const { Title, Text } = Typography;
+
+export default function MissionControlModule() {
+  const [layout, setLayout] = useState('pipeline');
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(null);
+
+  const missions = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return MOCK_MISSIONS;
+    return MOCK_MISSIONS.filter(
+      (m) =>
+        m.client.name.toLowerCase().includes(q) ||
+        m.summary.toLowerCase().includes(q),
+    );
+  }, [query]);
+
+  return (
+    <div className="mc-root">
+      <div className="mc-header">
+        <div>
+          <Title level={4} style={{ margin: 0 }}>Mission Control</Title>
+          <Text type="secondary" style={{ fontSize: 13 }}>
+            Lead-to-Quote tracker · {missions.length} active
+          </Text>
+        </div>
+        <Space size={12}>
+          <Input
+            allowClear
+            prefix={<SearchOutlined style={{ color: '#bbb' }} />}
+            placeholder="Search by client or summary"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            style={{ width: 240 }}
+          />
+          <Segmented
+            value={layout}
+            onChange={setLayout}
+            options={[
+              { value: 'pipeline', icon: <AppstoreOutlined />, label: 'Pipeline' },
+              { value: 'matrix',   icon: <TableOutlined />,    label: 'Matrix' },
+            ]}
+          />
+        </Space>
+      </div>
+
+      <MissionBoard missions={missions} layout={layout} onSelect={setActive} />
+      <MissionDrawer mission={active} open={!!active} onClose={() => setActive(null)} />
+    </div>
+  );
+}

--- a/frontend/src/modules/MissionControlModule/index.jsx
+++ b/frontend/src/modules/MissionControlModule/index.jsx
@@ -26,7 +26,7 @@ export default function MissionControlModule() {
     <div className="mc-root">
       <div className="mc-header">
         <div>
-          <Title level={4} style={{ margin: 0 }}>Mission Control</Title>
+          <Title level={4} style={{ margin: 0 }}>Tasks</Title>
           <Text type="secondary" style={{ fontSize: 13 }}>
             Lead-to-Quote tracker · {missions.length} active
           </Text>

--- a/frontend/src/pages/MissionControl/index.jsx
+++ b/frontend/src/pages/MissionControl/index.jsx
@@ -1,0 +1,5 @@
+import MissionControlModule from '@/modules/MissionControlModule';
+
+export default function MissionControl() {
+  return <MissionControlModule />;
+}

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -7,6 +7,7 @@ const NotFound = lazy(() => import('@/pages/NotFound.jsx'));
 
 const Dashboard = lazy(() => import('@/pages/Dashboard'));
 const AskOla = lazy(() => import('@/pages/AskOla'));
+const MissionControl = lazy(() => import('@/pages/MissionControl'));
 const FilePage = lazy(() => import('@/pages/File'));
 const Integrations = lazy(() => import('@/pages/Integrations'));
 const Customer = lazy(() => import('@/pages/Customer'));
@@ -73,6 +74,10 @@ let routes = {
     {
       path: '/askola',
       element: <AskOla />,
+    },
+    {
+      path: '/control',
+      element: <MissionControl />,
     },
     {
       path: '/file',

--- a/frontend/src/style/app.css
+++ b/frontend/src/style/app.css
@@ -12,6 +12,7 @@
 @import './partials/settings.css';
 @import './partials/askola.css';
 @import './partials/ola-panel.css';
+@import './partials/mission-control.css';
 @import './partials/historyModal.css';
 @import './partials/scrollbar.css';
 @import './partials/integrations.css';

--- a/frontend/src/style/partials/mission-control.css
+++ b/frontend/src/style/partials/mission-control.css
@@ -22,65 +22,77 @@
 /* ── pipeline board ───────────────────────────────────────── */
 .mc-board--pipeline {
   display: flex;
-  gap: 12px;
+  gap: 16px;
   align-items: flex-start;
   overflow-x: auto;
-  padding-bottom: 12px;
+  padding: 8px 4px 16px;
+  width: 100%;
 }
 
 .mc-col {
-  flex: 0 0 268px;
-  width: 268px;
+  flex: 1 1 240px;
+  min-width: 240px;
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 160px);
+  max-height: calc(100vh - 180px);
+  background: #f8f9fa;
+  border-radius: 10px;
+  padding: 12px 10px;
+  border: 1px solid #f0f0f0;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.01);
 }
 
 .mc-col-head {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 0 4px 8px;
+  justify-content: space-between;
+  padding: 0 6px 12px;
+  border-bottom: 2px solid var(--stage-color, #f0f0f0);
+  margin-bottom: 12px;
 }
 
 .mc-col-dot {
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   flex: none;
 }
 
 .mc-col-title {
   flex: 1;
-  font-size: 11.5px;
-  font-weight: 700;
-  color: #555;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #262626;
+  margin-left: 6px;
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 .mc-col-count {
   font-size: 11px;
-  color: #bbb;
-  background: #efefef;
+  color: #8c8c8c;
+  background: #e8e8e8;
   border-radius: 10px;
-  padding: 0 7px;
+  padding: 0 8px;
   line-height: 18px;
 }
 
 .mc-col-body {
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 8px;
   overflow-y: auto;
-  padding-right: 2px;
+  padding: 2px 2px;
 }
 
 .mc-col-empty {
   text-align: center;
-  color: #ddd;
-  padding: 18px 0;
-  font-size: 18px;
+  color: #bfbfbf;
+  padding: 32px 0;
+  font-size: 14px;
+  border: 1px dashed #d9d9d9;
+  border-radius: 8px;
+  background: #fafafa;
 }
 
 /* ── matrix board ─────────────────────────────────────────── */
@@ -121,13 +133,13 @@
 .mc-matrix-colhead-label {
   font-size: 13px;
   font-weight: 600;
-  color: #333;
+  color: #262626;
   line-height: 1.3;
 }
 
 .mc-matrix-colhead-desc {
   font-size: 11px;
-  color: #bbb;
+  color: #8c8c8c;
   line-height: 1.3;
 }
 
@@ -137,18 +149,18 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: 12.5px;
   font-weight: 600;
-  color: #555;
+  color: #262626;
   padding: 14px 16px;
-  border-left: 3px solid var(--stage-color, #eee);
+  border-left: 4px solid var(--stage-color, #eee);
 }
 
 /* Content cell — white, cards stack inside with consistent padding */
 .mc-matrix-cell {
   background: #fff;
-  min-height: 64px;
-  padding: 10px;
+  min-height: 80px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -159,17 +171,20 @@
 .mc-card {
   position: relative;
   background: #fff;
-  border: 1px solid #ebebeb;
+  border: 1px solid #f0f0f0;
   border-left: 3px solid var(--stage-color, #d9d9d9);
   border-radius: 8px;
-  padding: 11px 12px 9px;
+  padding: 12px;
   cursor: pointer;
-  transition: box-shadow 0.15s ease;
+  transition: all 0.2s ease;
   overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
 }
 
 .mc-card:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-color: #d9d9d9;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  transform: translateY(-1px);
 }
 
 /* Amber banner — only colored element on urgent cards */
@@ -177,8 +192,8 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  margin: -11px -12px 10px;
-  padding: 4px 12px;
+  margin: -12px -12px 10px;
+  padding: 6px 12px;
   background: #fffbe6;
   border-bottom: 1px solid #ffe58f;
   color: #d48806;

--- a/frontend/src/style/partials/mission-control.css
+++ b/frontend/src/style/partials/mission-control.css
@@ -1,0 +1,372 @@
+/* ===== Mission Control — lead-to-quote command center ===== */
+/* Design rule: ONE color per card = left stage border.
+   Everything else is neutral gray.
+   Amber ACTION REQUIRED banner is the only visual interrupt.   */
+
+/* ── root ─────────────────────────────────────────────────── */
+.mc-root {
+  padding: 20px 24px 32px;
+  min-height: calc(100vh - 64px);
+  background: #fff;
+}
+
+/* ── header ───────────────────────────────────────────────── */
+.mc-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+/* ── pipeline board ───────────────────────────────────────── */
+.mc-board--pipeline {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  overflow-x: auto;
+  padding-bottom: 12px;
+}
+
+.mc-col {
+  flex: 0 0 268px;
+  width: 268px;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 160px);
+}
+
+.mc-col-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 4px 8px;
+}
+
+.mc-col-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.mc-col-title {
+  flex: 1;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: #555;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.mc-col-count {
+  font-size: 11px;
+  color: #bbb;
+  background: #efefef;
+  border-radius: 10px;
+  padding: 0 7px;
+  line-height: 18px;
+}
+
+.mc-col-body {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.mc-col-empty {
+  text-align: center;
+  color: #ddd;
+  padding: 18px 0;
+  font-size: 18px;
+}
+
+/* ── matrix board ─────────────────────────────────────────── */
+/* Table-stripe approach: outer border + 1px gap = divider lines.
+   align-items: stretch makes every cell in a row fill the same height
+   so the gap lines stay continuous across the full grid width.       */
+.mc-board--matrix {
+  display: grid;
+  align-items: stretch;   /* all cells in a row grow to the same height */
+  border: 1px solid #eee;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #eee;       /* the gap background = divider colour */
+  gap: 1px;
+}
+
+/* Corner cell */
+.mc-matrix-corner {
+  background: #fafafa;
+  padding: 14px 16px;
+}
+
+/* Column header — same background as corner, clear bottom divider via gap */
+.mc-matrix-colhead {
+  background: #fafafa;
+  padding: 14px 16px;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.mc-matrix-colhead-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.mc-matrix-colhead-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  line-height: 1.3;
+}
+
+.mc-matrix-colhead-desc {
+  font-size: 11px;
+  color: #bbb;
+  line-height: 1.3;
+}
+
+/* Row header — left stage-color border signals the stage */
+.mc-matrix-rowhead {
+  background: #fafafa;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #555;
+  padding: 14px 16px;
+  border-left: 3px solid var(--stage-color, #eee);
+}
+
+/* Content cell — white, cards stack inside with consistent padding */
+.mc-matrix-cell {
+  background: #fff;
+  min-height: 64px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: stretch;
+}
+
+/* ── mission card ─────────────────────────────────────────── */
+.mc-card {
+  position: relative;
+  background: #fff;
+  border: 1px solid #ebebeb;
+  border-left: 3px solid var(--stage-color, #d9d9d9);
+  border-radius: 8px;
+  padding: 11px 12px 9px;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+  overflow: hidden;
+}
+
+.mc-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+/* Amber banner — only colored element on urgent cards */
+.mc-card-banner {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: -11px -12px 10px;
+  padding: 4px 12px;
+  background: #fffbe6;
+  border-bottom: 1px solid #ffe58f;
+  color: #d48806;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.mc-card-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 6px;
+}
+
+/* Channel icon — neutral gray; tooltip shows name */
+.mc-card-channel {
+  font-size: 13px;
+  color: #bbb;
+  line-height: 1;
+  flex: none;
+}
+
+.mc-card-client {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Tiny state dot — hover tooltip shows label */
+.mc-card-state-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.mc-card-summary {
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #999;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.mc-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.mc-card-amount {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: #52c41a;
+}
+
+.mc-card-foot-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mc-card-time {
+  font-size: 11px;
+  color: #ccc;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+/* ── drawer ───────────────────────────────────────────────── */
+.mc-drawer-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.mc-drawer-channel {
+  font-size: 16px;
+  color: #bbb;
+  line-height: 1;
+}
+
+.mc-drawer-client {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+/* ── context strip ────────────────────────────────────────── */
+.mc-context {
+  background: #fafafa;
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mc-context-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.mc-context-icon {
+  color: #ccc;
+  margin-top: 3px;
+  flex: none;
+}
+
+.mc-context-label {
+  color: #bbb;
+  font-weight: 600;
+  min-width: 40px;
+  flex: none;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding-top: 2px;
+}
+
+.mc-context-val {
+  color: #555;
+  flex: 1;
+}
+
+/* ── report feed ──────────────────────────────────────────── */
+.mc-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mc-report-block {
+  position: relative;
+}
+
+.mc-pin-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #ddd;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  font-size: 12px;
+  padding: 0;
+}
+
+.mc-report-block:hover .mc-pin-btn {
+  opacity: 1;
+}
+
+.mc-pin-btn:hover {
+  color: #faad14;
+}
+
+/* ── composer ─────────────────────────────────────────────── */
+.mc-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mc-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/frontend/src/style/partials/mission-control.css
+++ b/frontend/src/style/partials/mission-control.css
@@ -187,18 +187,14 @@
   transform: translateY(-1px);
 }
 
-/* Amber banner — only colored element on urgent cards */
-.mc-card-banner {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  margin: -12px -12px 10px;
-  padding: 6px 12px;
-  background: #fffbe6;
-  border-bottom: 1px solid #ffe58f;
-  color: #d48806;
-  font-size: 11px;
-  font-weight: 600;
+.mc-card--urgent {
+  border-color: #ffe58f;
+  background: #fffdf6;
+}
+
+.mc-card--urgent:hover {
+  border-color: #ffd591;
+  box-shadow: 0 4px 12px rgba(250, 173, 20, 0.08);
 }
 
 .mc-card-head {


### PR DESCRIPTION
## 改动内容

### 1. 任务看板 (Tasks / Mission Control) 页面
- 新增 `/control` (Tasks) 任务跟踪看板原型，支持 Pipeline（管道）与 Matrix（矩阵）双视图。
- 替换自定义头部为标准 Pro-Layout `PageHeader`，使页面整体外观与 CRM 其他列表页（如客户、报价单等）保持一致。
- 优化 Kanban 栏目样式：添加背景色 `#f8f9fa`、圆角及内边距，使栏目更加规整；优化空状态样式。
- **自适应与滚动限制**：实现列自适应拉伸与最小宽度限制，宽屏下能够均匀分担拉伸并撑满页面，窄屏下能够自适应出现横向滚动条，防止 Won 栏目无法显示或右侧留白。
- **全新无任务空状态**：移除了全局无任务的遮罩插图，改为与列内无任务样式统一——无任务（或搜索无结果）时依然保留列骨架，且每个空列中展示虚线边框卡片 **“No active tasks”**。
- **高度一致性卡片预警**：去除了卡片顶部的 Action Required 条状 Banner，改为在卡片标题栏状态圆点左侧增加**琥珀色闪电警告图标 ⚡**，配合 Urgent 态的轻量化温和背景色（`#fffdf6`）及琥珀色边框（`#ffe58f`），使卡片在保证行高完全对齐、极佳视觉整齐度的前提下突出显示。
- 统一阶段（STAGES）和 Agent 状态的配色，使之与仪表盘（Dashboard）配色完全对齐。
- 为任务卡片添加微动效，提升交互的平滑度和精致感。

## 验证

- [x] 本地 production build 构建验证通过
- [x] 样式细节在各种屏幕尺寸下均适配良好
- [x] 逻辑无冲突且不影响其他页面模块