### PR TITLE
feat(erp): AntD column sorting for Quote/Invoice/PO lists (native fields)

### DIFF
--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   EyeOutlined,
   EditOutlined,
@@ -21,6 +21,14 @@ import { generate as uniqueId } from 'shortid';
 import { useNavigate } from 'react-router-dom';
 
 import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
+
+// Normalize an AntD dataIndex / sorter.field (string or array) to a dot-path ('client.name').
+const toFieldPath = (field) => (Array.isArray(field) ? field.join('.') : field);
+
+// Build backend sort query params from a { field, order } descriptor.
+// No order → empty, so the backend falls back to its default `created` desc.
+const buildSortOptions = (sort) =>
+  sort?.order ? { sortBy: sort.field, sortValue: sort.order === 'ascend' ? 1 : -1 } : {};
 
 function AddNewItem({ config }) {
   const navigate = useNavigate();
@@ -150,47 +158,41 @@ export default function DataTable({ config, extra = [] }) {
     },
   ];
 
-  const buildSortOptions = (sorter) => {
-    if (!sorter?.order) return {}; // 取消排序 → 回退后端默认 created desc
-    const field = Array.isArray(sorter.field) ? sorter.field.join('.') : sorter.field;
-    return { sortBy: field, sortValue: sorter.order === 'ascend' ? 1 : -1 };
+  // Sort is React-controlled so the header arrow and the data order can never diverge.
+  // Seed from the column flagged with defaultSortOrder (e.g. date desc).
+  const defaultSortCol = dataTableColumns.find((c) => c.defaultSortOrder);
+  const [sortState, setSortState] = useState(
+    defaultSortCol
+      ? { field: toFieldPath(defaultSortCol.dataIndex), order: defaultSortCol.defaultSortOrder }
+      : null
+  );
+
+  // Single load path: every fetch carries the current sort, so Refresh / filter / paging stay consistent.
+  const fetchList = (sort, extra = {}) => {
+    dispatch(erp.list({ entity, options: { ...buildSortOptions(sort), ...extra } }));
   };
 
   const handelDataTableLoad = (pagination, _filters, sorter = {}) => {
-    const options = {
-      page: pagination?.current || 1,
-      items: pagination?.pageSize || 10,
-      ...buildSortOptions(sorter),
-    };
-    dispatch(erp.list({ entity, options }));
-  };
-
-  const defaultSortCol = dataTableColumns.find((c) => c.defaultSortOrder);
-
-  const dispatcher = () => {
-    const options = {};
-    if (defaultSortCol) {
-      const field = Array.isArray(defaultSortCol.dataIndex)
-        ? defaultSortCol.dataIndex.join('.')
-        : defaultSortCol.dataIndex;
-      options.sortBy = field;
-      options.sortValue = defaultSortCol.defaultSortOrder === 'ascend' ? 1 : -1;
-    }
-    dispatch(erp.list({ entity, options }));
+    const next = sorter?.order ? { field: toFieldPath(sorter.field), order: sorter.order } : null;
+    setSortState(next);
+    fetchList(next, { page: pagination?.current || 1, items: pagination?.pageSize || 10 });
   };
 
   useEffect(() => {
-    const controller = new AbortController();
-    dispatcher();
-    return () => {
-      controller.abort();
-    };
+    fetchList(sortState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const filterTable = (value) => {
-    const options = { equal: value, filter: searchConfig?.entity };
-    dispatch(erp.list({ entity, options }));
+    fetchList(sortState, { equal: value, filter: searchConfig?.entity });
   };
+
+  // Drive each sortable column's arrow from sortState (controlled).
+  const columnsWithSort = dataTableColumns.map((c) =>
+    c.sorter
+      ? { ...c, sortOrder: sortState?.field === toFieldPath(c.dataIndex) ? sortState.order : null }
+      : c
+  );
 
   return (
     <>
@@ -208,7 +210,7 @@ export default function DataTable({ config, extra = [] }) {
             // withRedirect
             // urlToRedirect={'/customer'}
           />,
-          <Button onClick={() => dispatcher()} key={`${uniqueId()}`} icon={<RedoOutlined />}>
+          <Button onClick={() => fetchList(sortState)} key={`${uniqueId()}`} icon={<RedoOutlined />}>
             {translate('Refresh')}
           </Button>,
 
@@ -220,7 +222,7 @@ export default function DataTable({ config, extra = [] }) {
       ></PageHeader>
 
       <Table
-        columns={dataTableColumns}
+        columns={columnsWithSort}
         rowKey={(item) => item._id}
         dataSource={dataSource}
         pagination={pagination}

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -173,7 +173,10 @@ export default function DataTable({ config, extra = [] }) {
   };
 
   const handelDataTableLoad = (pagination, _filters, sorter = {}) => {
-    const next = sorter?.order ? { field: toFieldPath(sorter.field), order: sorter.order } : null;
+    // AntD passes an array when multi-column sort is enabled; the backend supports a
+    // single sort key, so honor the highest-priority (first) column.
+    const active = Array.isArray(sorter) ? sorter[0] : sorter;
+    const next = active?.order ? { field: toFieldPath(active.field), order: active.order } : null;
     setSortState(next);
     fetchList(next, { page: pagination?.current || 1, items: pagination?.pageSize || 10 });
   };

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -7,7 +7,6 @@ import {
   RedoOutlined,
   PlusOutlined,
   EllipsisOutlined,
-  ArrowRightOutlined,
 } from '@ant-design/icons';
 import { Dropdown, Table, Button } from 'antd';
 import { PageHeader } from '@ant-design/pro-layout';
@@ -151,13 +150,33 @@ export default function DataTable({ config, extra = [] }) {
     },
   ];
 
-  const handelDataTableLoad = (pagination) => {
-    const options = { page: pagination.current || 1, items: pagination.pageSize || 10 };
+  const buildSortOptions = (sorter) => {
+    if (!sorter?.order) return {}; // 取消排序 → 回退后端默认 created desc
+    const field = Array.isArray(sorter.field) ? sorter.field.join('.') : sorter.field;
+    return { sortBy: field, sortValue: sorter.order === 'ascend' ? 1 : -1 };
+  };
+
+  const handelDataTableLoad = (pagination, _filters, sorter = {}) => {
+    const options = {
+      page: pagination?.current || 1,
+      items: pagination?.pageSize || 10,
+      ...buildSortOptions(sorter),
+    };
     dispatch(erp.list({ entity, options }));
   };
 
+  const defaultSortCol = dataTableColumns.find((c) => c.defaultSortOrder);
+
   const dispatcher = () => {
-    dispatch(erp.list({ entity }));
+    const options = {};
+    if (defaultSortCol) {
+      const field = Array.isArray(defaultSortCol.dataIndex)
+        ? defaultSortCol.dataIndex.join('.')
+        : defaultSortCol.dataIndex;
+      options.sortBy = field;
+      options.sortValue = defaultSortCol.defaultSortOrder === 'ascend' ? 1 : -1;
+    }
+    dispatch(erp.list({ entity, options }));
   };
 
   useEffect(() => {
@@ -189,7 +208,7 @@ export default function DataTable({ config, extra = [] }) {
             // withRedirect
             // urlToRedirect={'/customer'}
           />,
-          <Button onClick={handelDataTableLoad} key={`${uniqueId()}`} icon={<RedoOutlined />}>
+          <Button onClick={() => dispatcher()} key={`${uniqueId()}`} icon={<RedoOutlined />}>
             {translate('Refresh')}
           </Button>,
 

--- a/frontend/src/pages/Invoice/index.jsx
+++ b/frontend/src/pages/Invoice/index.jsx
@@ -22,6 +22,7 @@ export default function Invoice() {
     {
       title: translate('Number'),
       dataIndex: 'number',
+      sorter: true,
     },
     {
       title: translate('Client'),
@@ -30,6 +31,8 @@ export default function Invoice() {
     {
       title: translate('Date'),
       dataIndex: 'date',
+      sorter: true,
+      defaultSortOrder: 'descend',
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -37,6 +40,7 @@ export default function Invoice() {
     {
       title: translate('expired Date'),
       dataIndex: 'expiredDate',
+      sorter: true,
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -44,6 +48,7 @@ export default function Invoice() {
     {
       title: translate('Total'),
       dataIndex: 'total',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -74,6 +79,7 @@ export default function Invoice() {
     {
       title: translate('Status'),
       dataIndex: 'status',
+      sorter: true,
       render: (status) => {
         let tagStatus = tagColor(status);
 

--- a/frontend/src/pages/PurchaseOrder/index.jsx
+++ b/frontend/src/pages/PurchaseOrder/index.jsx
@@ -21,6 +21,7 @@ export default function PurchaseOrder() {
     {
       title: translate('Number'),
       dataIndex: 'number',
+      sorter: true,
     },
     {
       title: translate('Factory'),
@@ -30,6 +31,8 @@ export default function PurchaseOrder() {
     {
       title: translate('Date'),
       dataIndex: 'date',
+      sorter: true,
+      defaultSortOrder: 'descend',
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -37,6 +40,7 @@ export default function PurchaseOrder() {
     {
       title: translate('expired Date'),
       dataIndex: 'expiredDate',
+      sorter: true,
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -58,6 +62,7 @@ export default function PurchaseOrder() {
     {
       title: translate('Total'),
       dataIndex: 'total',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -72,6 +77,7 @@ export default function PurchaseOrder() {
     {
       title: translate('Status'),
       dataIndex: 'status',
+      sorter: true,
       render: (status) => {
         let tagStatus = tagColor(status);
         return (

--- a/frontend/src/pages/Quote/index.jsx
+++ b/frontend/src/pages/Quote/index.jsx
@@ -21,6 +21,7 @@ export default function Quote() {
     {
       title: translate('Number'),
       dataIndex: 'number',
+      sorter: true,
     },
     {
       title: translate('Client'),
@@ -29,6 +30,8 @@ export default function Quote() {
     {
       title: translate('Date'),
       dataIndex: 'date',
+      sorter: true,
+      defaultSortOrder: 'descend',
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -36,6 +39,7 @@ export default function Quote() {
     {
       title: translate('expired Date'),
       dataIndex: 'expiredDate',
+      sorter: true,
       render: (date) => {
         return dayjs(date).format(dateFormat);
       },
@@ -43,6 +47,7 @@ export default function Quote() {
     {
       title: translate('Sub Total'),
       dataIndex: 'subTotal',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -57,6 +62,7 @@ export default function Quote() {
     {
       title: translate('Total'),
       dataIndex: 'total',
+      sorter: true,
       onCell: () => {
         return {
           style: {
@@ -72,6 +78,7 @@ export default function Quote() {
     {
       title: translate('Status'),
       dataIndex: 'status',
+      sorter: true,
       render: (status) => {
         let tagStatus = tagColor(status);
 


### PR DESCRIPTION
## 改动内容

给 Quote / Invoice / PurchaseOrder 列表页加 AntD 列点击排序（升/降序）。**纯前端，零后端改动**——后端 `paginatedList.js` 已支持 `sortBy`/`sortValue`，`request.list` 已透传 `options`，唯一缺口是 `DataTable.jsx` 的 `onChange` 没接住 AntD 的 `sorter` 参数。

- **DataTable.jsx**：
  - `onChange` 接住 `sorter` → 转成 `sortBy`/`sortValue`（ascend→1, descend→-1；取消排序回退后端默认 `created desc`）
  - 首屏按列的 `defaultSortOrder` 播种排序，让表头箭头与实际数据一致（规避 #163 的"默认值不匹配"bug 类）
  - Refresh 按钮改为走 `dispatcher()`（原来误把 MouseEvent 当 pagination 传入）
  - 清掉死 import `ArrowRightOutlined`
- **Quote / Invoice / PO 页**：仅给**原生标量字段**加 `sorter: true`（`number`/`date`/`expiredDate`/`subTotal`/`total`/`status`），`date` 列默认降序

## 明确不做（避免"假箭头"）

- 关系列 `client.name`（Quote/Invoice）、`factory.factory_name`（PO）**不加排序** —— Mongo `.sort()` 排 populated 引用字段静默无效，需后端 `$lookup` 聚合（deferred）
- PO 的 `subTotal` **不加** —— `PurchaseOrder` 模型无此字段

> 这正是上一版（已撤回的 PR #339）"失效"的根因：给关系列和 PO subTotal 也加了 sorter，点了没反应。本次只排后端真能排的原生字段。

## 验证

- [x] 前端 `npm run build` 通过
- [x] 改动文件 ESLint 0 error（另清掉 1 个历史死 import error）
- [x] 浏览器 E2E：点 Date/Number/Total/Status 表头数据正确升降序，Network 请求带 `sortBy`/`sortValue`，Client/Factory 列无排序箭头

Refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)