### PR TITLE
fix(cd): verify gateway via bridge status, not container log scraping

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -187,7 +187,7 @@ jobs:
           wait_for_health bot "http://$BOX2_TAILSCALE_IP:8901/health"
           wait_for_health bot "http://$BOX2_TAILSCALE_IP:3001/health"
           wait_for_health crm "http://127.0.0.1:80/health"
-          "${SSH2[@]}" "MCP_SERVICE_TOKEN='$MCP_SERVICE_TOKEN' bash /opt/ola-production/verify-whatsapp.sh /opt/ola-production/nanobot-state http://'$BOX2_TAILSCALE_IP':3001 nanobot-gateway"
+          "${SSH2[@]}" "MCP_SERVICE_TOKEN='$MCP_SERVICE_TOKEN' bash /opt/ola-production/verify-whatsapp.sh /opt/ola-production/nanobot-state http://'$BOX2_TAILSCALE_IP':3001"
           "${SSH1[@]}" "cd /opt/ola-production/crm && DOMAINS='app.olajob.cn app.olatech.ai' TEST_EMAIL='$TEST_EMAIL' TEST_PASSWORD='$TEST_PASSWORD' MCP_HOST='$BOX1_TAILSCALE_IP' MCP_SERVICE_TOKEN='$MCP_SERVICE_TOKEN' bash /opt/ola-production/smoke-prod.sh"
 
           trap - ERR

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -185,7 +185,7 @@ jobs:
           wait_for_health "http://$STAGING_TAILSCALE_IP:8901/health"
           wait_for_health "http://$STAGING_TAILSCALE_IP:3001/health"
           wait_for_health "http://127.0.0.1:8080/health"
-          "${SSH[@]}" "MCP_SERVICE_TOKEN='$MCP_SERVICE_TOKEN' bash /opt/ola-staging/verify-whatsapp.sh /opt/ola-staging/nanobot-state http://'$STAGING_TAILSCALE_IP':3001 nanobot-gateway"
+          "${SSH[@]}" "MCP_SERVICE_TOKEN='$MCP_SERVICE_TOKEN' bash /opt/ola-staging/verify-whatsapp.sh /opt/ola-staging/nanobot-state http://'$STAGING_TAILSCALE_IP':3001"
 
           if ! "${SSH[@]}" "cd /opt/ola-staging/crm && DOMAINS=staging.olatech.ai TEST_EMAIL='$TEST_EMAIL' TEST_PASSWORD='$TEST_PASSWORD' MCP_HOST='$STAGING_TAILSCALE_IP' MCP_SERVICE_TOKEN='$MCP_SERVICE_TOKEN' bash /opt/ola-staging/smoke-prod.sh"; then
             if [[ "$previous_crm" =~ ^[0-9a-f]{40}$ && "$previous_bot" =~ ^[0-9a-f]{40}$ ]]; then

--- a/deploy/verify-whatsapp.sh
+++ b/deploy/verify-whatsapp.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-state_dir=${1:?usage: verify-whatsapp.sh STATE_DIR BRIDGE_URL GATEWAY_CONTAINER}
-bridge_url=${2:?usage: verify-whatsapp.sh STATE_DIR BRIDGE_URL GATEWAY_CONTAINER}
-gateway_container=${3:?usage: verify-whatsapp.sh STATE_DIR BRIDGE_URL GATEWAY_CONTAINER}
+state_dir=${1:?usage: verify-whatsapp.sh STATE_DIR BRIDGE_URL}
+bridge_url=${2:?usage: verify-whatsapp.sh STATE_DIR BRIDGE_URL}
 config="$state_dir/config.json"
 
 if ! jq -e '.channels.whatsapp.enabled == true' "$config" >/dev/null; then
@@ -49,19 +48,36 @@ for admin_id in "${admin_ids[@]}"; do
     exit 1
   fi
 
-  # The gateway reconnect log can lag the bridge status flip; poll briefly.
-  gateway_connected=false
+  # The gateway's WS re-subscription to the bridge can lag the bridge status
+  # flip; poll the live subscriber count the bridge reports. (Previously this
+  # grepped the gateway container logs for a "Connected" line, which only
+  # exists if the gateway restarted recently — deploys that leave the nanobot
+  # containers untouched failed spuriously once the line aged out of the
+  # docker-logs window.)
+  gateway_clients=0
   for attempt in $(seq 1 6); do
-    if docker logs --since 10m "$gateway_container" 2>&1 |
-      grep -F "[$admin_id] Connected to WhatsApp bridge" >/dev/null; then
-      gateway_connected=true
+    status=$(
+      curl --silent --max-time 10 \
+        -H "Authorization: Bearer $token" \
+        "$bridge_url/wa/$admin_id/status" 2>/dev/null || true
+    )
+    gateway_clients=$(
+      jq -r 'if has("gatewayClients") then (.gatewayClients | tostring) else "absent" end' \
+        <<<"$status" 2>/dev/null || true
+    )
+    gateway_clients=${gateway_clients:-0}
+    if [ "$gateway_clients" = absent ]; then
+      # Transitional: bridge image predates the gatewayClients field. Don't fail
+      # the deploy on it; the bridge status above already proved WhatsApp is up.
+      echo "Warning: bridge status has no gatewayClients field (old bridge image); skipping gateway check for $admin_id" >&2
       break
     fi
-    echo "Gateway not connected for $admin_id yet (attempt $attempt/6)" >&2
+    [ "$gateway_clients" -ge 1 ] 2>/dev/null && break
+    echo "Gateway not subscribed for $admin_id yet (attempt $attempt/6, gatewayClients: $gateway_clients)" >&2
     sleep 5
   done
-  if [ "$gateway_connected" != true ]; then
-    echo "WhatsApp verification failed: gateway is not connected for an admin" >&2
+  if [ "$gateway_clients" != absent ] && ! [ "$gateway_clients" -ge 1 ] 2>/dev/null; then
+    echo "WhatsApp verification failed: no gateway subscriber on the bridge for an admin" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Why

Deploy Staging run [27338703799](https://github.com/SeekMi-Technologies/Ola/actions/runs/27338703799) failed on a healthy deployment, while run 27338469559 passed four minutes earlier on identical code.

Root cause: `deploy/verify-whatsapp.sh` grepped `docker logs --since 10m nanobot-gateway` for a "Connected to WhatsApp bridge" line. The gateway logs that exactly once, at (re)connect time. The 09:40 run had recreated the gateway (fresh log line at ~09:43); the 09:49 run still found that line inside the 10-minute window and passed; by the 09:53 run it had aged out and verification failed — and every re-run keeps failing until something restarts the gateway. The check passes or fails based on when the gateway last restarted, not on whether anything is wrong.

## What

- `deploy/verify-whatsapp.sh`: replace the docker-logs grep with polling the bridge's `GET /wa/<adminId>/status` for `gatewayClients >= 1` — the live gateway WS subscriber count added in SeekMi-Technologies/Ola_bot#13. Same 6×5s retry loop, same curl + HMAC token as the existing bridge-status check.
- Transition safety: if the deployed bridge image predates the field, the script warns and passes (the bridge `status: connected` check above it already proved WhatsApp is up), so this PR and the Ola_bot PR can merge/deploy in either order.
- The now-unused `GATEWAY_CONTAINER` arg is dropped from the script and from the invocations in `deploy-staging.yml` and `deploy-production.yml`.

## Verification

- `bash -n` clean; exercised end-to-end against a stub bridge HTTP server with a fake state dir:
  - `{"status":"connected","gatewayClients":1}` → passes
  - `{"status":"connected"}` (old bridge image) → warns, passes
  - `{"status":"connected","gatewayClients":0}` → 6 retries, exits 1
- After the Ola_bot bridge image ships, re-running Deploy Staging on main (which currently fails deterministically) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)