### PR TITLE
fix(cd): normalize production gateway bind and auth verification

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -94,6 +94,9 @@ jobs:
             const fs = require("fs");
             const path = "rendered/nanobot-state/config.json";
             const config = JSON.parse(fs.readFileSync(path, "utf8"));
+            config.gateway ??= {};
+            config.gateway.host = "0.0.0.0";
+            config.gateway.port = 8901;
             config.channels ??= {};
             config.channels.whatsapp ??= {};
             config.channels.whatsapp.enabled = true;

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -107,6 +107,9 @@ jobs:
             const fs = require("fs");
             const path = "rendered/nanobot-state/config.json";
             const config = JSON.parse(fs.readFileSync(path, "utf8"));
+            config.gateway ??= {};
+            config.gateway.host = "0.0.0.0";
+            config.gateway.port = 8901;
             config.channels ??= {};
             config.channels.whatsapp ??= {};
             config.channels.whatsapp.enabled = true;

--- a/deploy/verify-whatsapp.sh
+++ b/deploy/verify-whatsapp.sh
@@ -11,8 +11,11 @@ if ! jq -e '.channels.whatsapp.enabled == true' "$config" >/dev/null; then
 fi
 
 mapfile -t admin_ids < <(
-  find "$state_dir/wa" -mindepth 2 -maxdepth 2 -type d -name auth -printf '%h\n' |
-    sed 's#.*/##' |
+  while IFS= read -r auth_dir; do
+    if find "$auth_dir" -type f -print -quit | grep -q .; then
+      basename "$(dirname "$auth_dir")"
+    fi
+  done < <(find "$state_dir/wa" -mindepth 2 -maxdepth 2 -type d -name auth) |
     grep -E '^[a-f0-9]{24}$' |
     sort -u
 )


### PR DESCRIPTION
## Summary
- normalize nanobot gateway internal bind to `0.0.0.0:8901`
- ignore empty WhatsApp auth placeholders during deployment verification

## Production findings
- the legacy Tailscale bind address cannot bind inside Docker
- after correcting the live bind, the full production smoke suite passed 15/15
- one real persisted WhatsApp session is connected; two empty placeholders caused a false failure
- rollback restored the legacy Box 2 services

After merge, allow the new CRM SHA to pass staging before promoting it.