### PR TITLE
[codex] Fix staging transcription provider selection

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -97,6 +97,8 @@ jobs:
           NANOBOT_CONFIG_B64: ${{ secrets.STAGING_NANOBOT_CONFIG_B64 }}
           NANOBOT_ENV_B64: ${{ secrets.STAGING_NANOBOT_ENV_B64 }}
           CRM_UPLOAD_URL: http://${{ secrets.STAGING_TAILSCALE_IP }}:8889
+          CRM_TRANSCRIPTION_PROVIDER_LOCKED: "true"
+          CRM_BACKEND_PUBLIC_BASE_URL: https://staging.olatech.ai
         run: |
           set -euo pipefail
           install -d -m 700 rendered/crm/backend rendered/nanobot-state

--- a/backend/src/jobs/transcriptionWorker.js
+++ b/backend/src/jobs/transcriptionWorker.js
@@ -1,8 +1,8 @@
 // Transcription dispatcher (#257). Resolves STT provider per upload then
-// hands off to the matching provider module. Per-admin selection beats
-// process-wide env which beats hardcoded 'openai' fallback.
+// hands off to the matching provider module. Per-admin selection normally
+// beats process-wide env, unless the deployment explicitly locks the provider.
 //
-//   admin.transcribeProvider > process.env.TRANSCRIPTION_PROVIDER > 'openai'
+//   locked env > admin.transcribeProvider > env > 'openai'
 //
 // Shared helpers (needsCompression / compressToMp3) live here because they
 // apply to OpenAI's push-multipart path (size budget); paraformer's pull
@@ -39,16 +39,26 @@ async function compressToMp3(srcPath) {
 }
 
 async function resolveProvider(fileDoc) {
+  const providerLocked = /^(1|true|yes)$/i.test(
+    process.env.TRANSCRIPTION_PROVIDER_LOCKED || ''
+  );
   let adminProvider = null;
-  try {
-    const Admin = mongoose.model('Admin');
-    const admin = await Admin.findById(fileDoc.createdBy).select('transcribeProvider').lean();
-    if (admin && admin.transcribeProvider) adminProvider = admin.transcribeProvider;
-  } catch (e) {
-    // Admin lookup failure shouldn't block transcription — fall through to env/default.
-    console.warn(`[transcribe.dispatch] admin lookup failed: ${e.message}`);
+  if (!providerLocked) {
+    try {
+      const Admin = mongoose.model('Admin');
+      const admin = await Admin.findById(fileDoc.createdBy).select('transcribeProvider').lean();
+      if (admin && admin.transcribeProvider) adminProvider = admin.transcribeProvider;
+    } catch (e) {
+      // Admin lookup failure shouldn't block transcription — fall through to env/default.
+      console.warn(`[transcribe.dispatch] admin lookup failed: ${e.message}`);
+    }
   }
-  const provider = adminProvider || process.env.TRANSCRIPTION_PROVIDER || 'openai';
+  const provider = providerLocked
+    ? process.env.TRANSCRIPTION_PROVIDER
+    : adminProvider || process.env.TRANSCRIPTION_PROVIDER || 'openai';
+  if (providerLocked && !provider) {
+    throw new Error('TRANSCRIPTION_PROVIDER is required when provider locking is enabled');
+  }
   if (!VALID_PROVIDERS.has(provider)) {
     throw new Error(`Unknown transcription provider: ${provider}`);
   }

--- a/backend/test/transcriptionWorker.dispatch.test.js
+++ b/backend/test/transcriptionWorker.dispatch.test.js
@@ -63,6 +63,7 @@ beforeEach(async () => {
   await Job.deleteMany({});
   jest.clearAllMocks();
   delete process.env.TRANSCRIPTION_PROVIDER;
+  delete process.env.TRANSCRIPTION_PROVIDER_LOCKED;
 });
 
 async function makeAdmin({ provider = null, email = 'x@y.com' } = {}) {
@@ -101,6 +102,24 @@ test('resolveProvider: admin field "paraformer" wins over env', async () => {
   const fileDoc = { createdBy: admin._id };
   const out = await resolveProvider(fileDoc);
   expect(out).toBe('paraformer');
+});
+
+test('resolveProvider: locked env wins over admin field', async () => {
+  process.env.TRANSCRIPTION_PROVIDER = 'paraformer';
+  process.env.TRANSCRIPTION_PROVIDER_LOCKED = 'true';
+  const admin = await makeAdmin({ provider: 'openai' });
+  const fileDoc = { createdBy: admin._id };
+  const out = await resolveProvider(fileDoc);
+  expect(out).toBe('paraformer');
+});
+
+test('resolveProvider: locked deployment requires an explicit provider', async () => {
+  process.env.TRANSCRIPTION_PROVIDER_LOCKED = 'true';
+  const admin = await makeAdmin({ provider: 'openai' });
+  const fileDoc = { createdBy: admin._id };
+  await expect(resolveProvider(fileDoc)).rejects.toThrow(
+    /TRANSCRIPTION_PROVIDER is required/
+  );
 });
 
 test('resolveProvider: env wins when admin field is null', async () => {

--- a/deploy/render-crm-env.js
+++ b/deploy/render-crm-env.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 
 const REQUIRED_KEYS = ['DASHSCOPE_API_KEY', 'BACKEND_PUBLIC_BASE_URL'];
-const TRANSCRIPTION_SETTING = 'TRANSCRIPTION_PROVIDER=paraformer';
 
 function upsertSetting(lines, key, value) {
   const setting = `${key}=${value}`;

--- a/deploy/render-crm-env.js
+++ b/deploy/render-crm-env.js
@@ -5,22 +5,33 @@ const fs = require('fs');
 const REQUIRED_KEYS = ['DASHSCOPE_API_KEY', 'BACKEND_PUBLIC_BASE_URL'];
 const TRANSCRIPTION_SETTING = 'TRANSCRIPTION_PROVIDER=paraformer';
 
-function renderCrmEnv(source) {
-  const lines = source.split(/\r?\n/);
-  let foundProvider = false;
-  const rendered = lines.map((line) => {
-    if (!line.startsWith('TRANSCRIPTION_PROVIDER=')) return line;
-    foundProvider = true;
-    return TRANSCRIPTION_SETTING;
-  });
+function upsertSetting(lines, key, value) {
+  const setting = `${key}=${value}`;
+  const index = lines.findIndex((line) => line.startsWith(`${key}=`));
+  if (index >= 0) {
+    lines[index] = setting;
+    return;
+  }
+  while (lines.at(-1) === '') lines.pop();
+  lines.push(setting);
+}
 
-  if (!foundProvider) {
-    while (rendered.at(-1) === '') rendered.pop();
-    rendered.push(TRANSCRIPTION_SETTING);
+function renderCrmEnv(source, overrides = {}) {
+  const lines = source.split(/\r?\n/);
+  upsertSetting(lines, 'TRANSCRIPTION_PROVIDER', 'paraformer');
+  if (overrides.transcriptionProviderLocked !== undefined) {
+    upsertSetting(
+      lines,
+      'TRANSCRIPTION_PROVIDER_LOCKED',
+      String(overrides.transcriptionProviderLocked)
+    );
+  }
+  if (overrides.backendPublicBaseUrl) {
+    upsertSetting(lines, 'BACKEND_PUBLIC_BASE_URL', overrides.backendPublicBaseUrl);
   }
 
   const values = new Map(
-    rendered
+    lines
       .filter((line) => line && !line.startsWith('#') && line.includes('='))
       .map((line) => {
         const index = line.indexOf('=');
@@ -34,7 +45,7 @@ function renderCrmEnv(source) {
     }
   }
 
-  return rendered.join('\n').replace(/\n*$/, '\n');
+  return lines.join('\n').replace(/\n*$/, '\n');
 }
 
 function main(envPath = process.argv[2]) {
@@ -43,7 +54,10 @@ function main(envPath = process.argv[2]) {
   }
 
   const source = fs.readFileSync(envPath, 'utf8');
-  fs.writeFileSync(envPath, renderCrmEnv(source));
+  fs.writeFileSync(envPath, renderCrmEnv(source, {
+    transcriptionProviderLocked: process.env.CRM_TRANSCRIPTION_PROVIDER_LOCKED,
+    backendPublicBaseUrl: process.env.CRM_BACKEND_PUBLIC_BASE_URL,
+  }));
 }
 
 if (require.main === module) {

--- a/deploy/render-crm-env.test.js
+++ b/deploy/render-crm-env.test.js
@@ -33,6 +33,23 @@ test('adds the provider when it is missing', () => {
   );
 });
 
+test('applies deployment-specific provider lock and public callback URL', () => {
+  const source = `${required.join('\n')}\n`;
+  assert.equal(
+    renderCrmEnv(source, {
+      transcriptionProviderLocked: 'true',
+      backendPublicBaseUrl: 'https://staging.olatech.ai',
+    }),
+    [
+      'DASHSCOPE_API_KEY=dashscope-key',
+      'BACKEND_PUBLIC_BASE_URL=https://staging.olatech.ai',
+      'TRANSCRIPTION_PROVIDER=paraformer',
+      'TRANSCRIPTION_PROVIDER_LOCKED=true',
+      '',
+    ].join('\n')
+  );
+});
+
 for (const key of ['DASHSCOPE_API_KEY', 'BACKEND_PUBLIC_BASE_URL']) {
   test(`rejects a missing ${key}`, () => {
     const source = required.filter((line) => !line.startsWith(`${key}=`)).join('\n');


### PR DESCRIPTION
## What changed
- Added an opt-in transcription provider lock so deployment configuration can override per-admin preferences.
- Enabled the lock only for staging and pinned `BACKEND_PUBLIC_BASE_URL` to `https://staging.olatech.ai`.
- Extended the CRM environment renderer and tests for deployment-specific overrides.

## Root cause
Staging currently shares the development database. A user-level `transcribeProvider` value from that database took precedence over `TRANSCRIPTION_PROVIDER=paraformer`, so staging could route transcription through the wrong provider. The callback URL also depended on the stored secret value instead of the known staging origin.

## Validation
- `node --test deploy/render-crm-env.test.js` (5 passed)
- `npm test -- --runInBand test/transcriptionWorker.dispatch.test.js` (10 passed)
- `npm test -- --runInBand test/paraformerProvider.test.js` (24 passed)
- ESLint and syntax checks passed
