### PR TITLE
fix(askola): upload-on-send architecture + SOUL.md cleanup (#387)

### DIFF
--- a/frontend/src/components/AskOla/ChatInput.jsx
+++ b/frontend/src/components/AskOla/ChatInput.jsx
@@ -6,305 +6,25 @@ import {
   ArrowUpOutlined,
   PaperClipOutlined,
   CloseOutlined,
-  LoadingOutlined,
-  CheckCircleFilled,
-  ExclamationCircleFilled,
-  DownOutlined,
-  UpOutlined,
 } from '@ant-design/icons';
 import useLanguage from '@/locale/useLanguage';
 
-const POLL_INTERVAL_MS = 3000;
-const POLL_MAX_DURATION_MS = 10 * 60 * 1000;
-
 /**
- * Independent chat input component with audio upload + transcription chip
- * (Plan B v3 phase E).
+ * Chat input bar. File upload and transcription happen in AskOla.handleSend
+ * after the user clicks Send — not at attach time.
  *
- * @param {function} onSend
- *   Callback: onSend({ text, mentions, attachments }).
- *   `attachments` is an array of File._id strings (only emitted when chip
- *   is in `state: 'ready'`).
- * @param {function} [onTranscriptionComplete]
- *   Optional callback fired when an attached file finishes transcription.
- *   Receives { fileId, originalName, durationMs, deduped } — host page (AskOla)
- *   uses this to drop a system notification into the chat panel.
- * @param {boolean} [disabled]
- *   Disable input and send button while waiting for response.
- *
- * pendingFile state machine:
- *   null
- *     → 'uploading'   POST /api/file/create in flight
- *         → 'ready'    (deduped:true — reused existing transcription)
- *         → 'transcribing'  (deduped:false — worker spawned, polling /api/job/read/:id)
- *             → 'ready'    Job.status === 'done'
- *             → 'failed'   Job.status === 'failed'
- *         → 'failed'   upload HTTP error or rejected mime/size
+ * onSend({ text: string, file: File | null })
+ *   Called when the user submits. `file` is the raw File object (not yet
+ *   uploaded); AskOla is responsible for upload + transcription + chat.
  */
-export default function ChatInput({ onSend, onTranscriptionComplete, disabled = false }) {
+export default function ChatInput({ onSend, disabled = false }) {
   const translate = useLanguage();
   const [inputValue, setInputValue] = useState('');
   const [plusMenuOpen, setPlusMenuOpen] = useState(false);
-  const [pendingFile, setPendingFile] = useState(null);
-  const [transcriptPreview, setTranscriptPreview] = useState(null);
-  // { fileId, text, expanded:bool, loading:bool, error:string }
+  const [pendingFile, setPendingFile] = useState(null); // File | null
   const menuRef = useRef(null);
   const btnRef = useRef(null);
   const fileInputRef = useRef(null);
-  const pollTimerRef = useRef(null);
-  const completedFileIdsRef = useRef(new Set());
-  // Always holds the latest onTranscriptionComplete prop so the setInterval
-  // closure (captured at startPolling time) never reads a stale version.
-  // Pattern: https://react.dev/learn/separating-events-from-effects#reading-latest-props-and-state-with-effect-events
-  const onTranscriptionCompleteRef = useRef(onTranscriptionComplete);
-  useEffect(() => { onTranscriptionCompleteRef.current = onTranscriptionComplete; });
-
-  // ---- Polling ---------------------------------------------------------
-
-  const stopPolling = () => {
-    if (pollTimerRef.current) {
-      clearInterval(pollTimerRef.current);
-      pollTimerRef.current = null;
-    }
-  };
-
-  const startPolling = (transcriptionJobId, fileMeta) => {
-    stopPolling();
-    const pollStartTs = Date.now();
-    pollTimerRef.current = setInterval(async () => {
-      if (Date.now() - pollStartTs > POLL_MAX_DURATION_MS) {
-        stopPolling();
-        setPendingFile((prev) =>
-          prev && prev._id === fileMeta._id
-            ? {
-                ...prev,
-                state: 'failed',
-                jobStatus: 'failed',
-                error: 'Transcription timed out (over 10 min). Try uploading a shorter recording.',
-              }
-            : prev
-        );
-        return;
-      }
-      try {
-        const resp = await fetch(`/api/job/read/${transcriptionJobId}`, {
-          credentials: 'include',
-        });
-        const json = await resp.json();
-        if (!resp.ok || !json.success) {
-          return; // transient; keep polling
-        }
-        const job = json.result;
-        if (job.status === 'done') {
-          stopPolling();
-          setPendingFile((prev) =>
-            prev && prev._id === fileMeta._id
-              ? {
-                  ...prev,
-                  state: 'ready',
-                  jobStatus: 'done',
-                  durationMs: job.result?.durationMs ?? null,
-                  sidecarBytes: job.result?.sizeBytes ?? null,
-                }
-              : prev
-          );
-          if (
-            onTranscriptionCompleteRef.current &&
-            !completedFileIdsRef.current.has(fileMeta._id)
-          ) {
-            completedFileIdsRef.current.add(fileMeta._id);
-            onTranscriptionCompleteRef.current({
-              fileId: fileMeta._id,
-              originalName: fileMeta.originalName,
-              durationMs: job.result?.durationMs ?? null,
-              sidecarBytes: job.result?.sizeBytes ?? null,
-              deduped: false,
-            });
-          }
-        } else if (job.status === 'failed') {
-          stopPolling();
-          setPendingFile((prev) =>
-            prev && prev._id === fileMeta._id
-              ? {
-                  ...prev,
-                  state: 'failed',
-                  jobStatus: 'failed',
-                  error: job.error || 'Transcription failed',
-                }
-              : prev
-          );
-        }
-        // pending / running → keep polling
-      } catch (_err) {
-        // network blip; next tick retries
-      }
-    }, POLL_INTERVAL_MS);
-  };
-
-  // Stop polling on unmount
-  useEffect(() => () => stopPolling(), []);
-
-  // ---- Upload handler --------------------------------------------------
-
-  const handleFilePicked = async (e) => {
-    const file = e.target.files?.[0];
-    e.target.value = '';
-    if (!file) return;
-
-    // Picking a new file always cancels any in-flight poll for a previous
-    // file, even if the new upload subsequently fails before startPolling.
-    stopPolling();
-    setPlusMenuOpen(false);
-    setPendingFile({
-      state: 'uploading',
-      _id: null,
-      transcriptionJobId: null,
-      originalName: file.name,
-      sizeBytes: file.size,
-      mimeType: file.type,
-      deduped: false,
-      error: null,
-      jobStatus: null,
-      durationMs: null,
-      sidecarBytes: null,
-      contentHash: null,
-    });
-
-    try {
-      const formData = new FormData();
-      formData.append('file', file);
-      const resp = await fetch('/api/file/create', {
-        method: 'POST',
-        credentials: 'include',
-        body: formData,
-      });
-      const json = await resp.json();
-      if (!resp.ok || !json.success) {
-        setPendingFile({
-          state: 'failed',
-          _id: null,
-          transcriptionJobId: null,
-          originalName: file.name,
-          sizeBytes: file.size,
-          mimeType: file.type,
-          deduped: false,
-          error: (json && json.message) || `HTTP ${resp.status}`,
-          jobStatus: null,
-          durationMs: null,
-          sidecarBytes: null,
-          contentHash: null,
-        });
-        return;
-      }
-      const result = json.result;
-      const baseMeta = {
-        _id: result._id,
-        transcriptionJobId: result.transcriptionJobId,
-        originalName: result.originalName,
-        sizeBytes: result.sizeBytes,
-        mimeType: result.mimeType,
-        contentHash: result.contentHash,
-        deduped: !!result.deduped,
-        error: null,
-        jobStatus: null,
-        durationMs: null,
-        sidecarBytes: null,
-      };
-      if (result.deduped) {
-        // Dedup hit → File + Job already exist + transcription already done
-        setPendingFile({ ...baseMeta, state: 'ready' });
-        if (onTranscriptionCompleteRef.current && !completedFileIdsRef.current.has(result._id)) {
-          completedFileIdsRef.current.add(result._id);
-          onTranscriptionCompleteRef.current({
-            fileId: result._id,
-            originalName: result.originalName,
-            durationMs: null,
-            sidecarBytes: null,
-            deduped: true,
-          });
-        }
-        return;
-      }
-      // Fresh upload → start polling
-      setPendingFile({ ...baseMeta, state: 'transcribing', jobStatus: 'pending' });
-      startPolling(result.transcriptionJobId, baseMeta);
-    } catch (err) {
-      setPendingFile({
-        state: 'failed',
-        _id: null,
-        transcriptionJobId: null,
-        originalName: file.name,
-        sizeBytes: file.size,
-        mimeType: file.type,
-        deduped: false,
-        error: err.message || 'Upload failed',
-        jobStatus: null,
-        durationMs: null,
-        sidecarBytes: null,
-        contentHash: null,
-      });
-    }
-  };
-
-  // ---- Transcript preview ---------------------------------------------
-
-  const togglePreview = async () => {
-    if (!pendingFile || pendingFile.state !== 'ready' || !pendingFile._id) return;
-    // Already loaded → toggle expanded
-    if (transcriptPreview && transcriptPreview.fileId === pendingFile._id) {
-      setTranscriptPreview({ ...transcriptPreview, expanded: !transcriptPreview.expanded });
-      return;
-    }
-    // Fetch
-    setTranscriptPreview({
-      fileId: pendingFile._id,
-      text: '',
-      expanded: true,
-      loading: true,
-      error: null,
-    });
-    try {
-      const resp = await fetch(`/api/file/transcript/${pendingFile._id}`, {
-        credentials: 'include',
-      });
-      const json = await resp.json();
-      if (resp.ok && json.success) {
-        setTranscriptPreview({
-          fileId: pendingFile._id,
-          text: json.result.transcript || '',
-          expanded: true,
-          loading: false,
-          error: null,
-        });
-      } else {
-        setTranscriptPreview({
-          fileId: pendingFile._id,
-          text: '',
-          expanded: true,
-          loading: false,
-          error: (json && json.message) || `HTTP ${resp.status}`,
-        });
-      }
-    } catch (err) {
-      setTranscriptPreview({
-        fileId: pendingFile._id,
-        text: '',
-        expanded: true,
-        loading: false,
-        error: err.message || 'Preview failed',
-      });
-    }
-  };
-
-  // ---- Plus menu -------------------------------------------------------
-
-  const plusMenuItems = [
-    {
-      icon: <PaperClipOutlined />,
-      label: translate('Upload photos & files'),
-      onClick: () => fileInputRef.current?.click(),
-    },
-  ];
 
   useEffect(() => {
     function handleClick(e) {
@@ -322,26 +42,21 @@ export default function ChatInput({ onSend, onTranscriptionComplete, disabled = 
     return () => document.removeEventListener('mousedown', handleClick);
   }, [plusMenuOpen]);
 
-  // ---- Send gate -------------------------------------------------------
+  const handleFilePicked = (e) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    setPendingFile(file);
+    setPlusMenuOpen(false);
+  };
 
-  const sendDisabled =
-    disabled ||
-    pendingFile?.state === 'uploading' ||
-    pendingFile?.state === 'failed';
+  const sendDisabled = disabled || (!inputValue.trim() && !pendingFile);
 
   const handleSend = () => {
     if (sendDisabled) return;
-    const text = inputValue.trim();
-    if (!text) return;
-    const attachments =
-      pendingFile?._id &&
-      (pendingFile.state === 'ready' || pendingFile.state === 'transcribing')
-        ? [pendingFile._id]
-        : [];
-    onSend({ text, mentions: [], attachments });
+    onSend({ text: inputValue.trim(), file: pendingFile });
     setInputValue('');
-    // Keep chip attached so user can ask follow-up questions about same file
-    // Cleared only when user clicks the X button or picks a new file
+    setPendingFile(null);
   };
 
   const handleKeyDown = (e) => {
@@ -351,71 +66,13 @@ export default function ChatInput({ onSend, onTranscriptionComplete, disabled = 
     }
   };
 
-  const removePendingFile = () => {
-    stopPolling();
-    setTranscriptPreview(null);
-    setPendingFile(null);
-  };
-
-  // ---- Chip rendering --------------------------------------------------
-
-  const renderChipStatus = () => {
-    if (!pendingFile) return null;
-    const sizeMb = (pendingFile.sizeBytes / 1024 / 1024).toFixed(1);
-    switch (pendingFile.state) {
-      case 'uploading':
-        return (
-          <>
-            <LoadingOutlined spin />
-            <span className="askola-pending-file-status">{translate('Uploading...')}</span>
-          </>
-        );
-      case 'transcribing':
-        return (
-          <>
-            <LoadingOutlined spin />
-            <span className="askola-pending-file-status">
-              {translate('Transcribing...')} ({sizeMb} MB)
-            </span>
-          </>
-        );
-      case 'ready':
-        return (
-          <>
-            <CheckCircleFilled style={{ color: '#52c41a' }} />
-            <span className="askola-pending-file-status">
-              {pendingFile.deduped
-                ? translate('Already transcribed (reused)')
-                : `${sizeMb} MB · ${translate('Ready')}`}
-            </span>
-            <button
-              type="button"
-              className="askola-pending-file-preview-btn"
-              onClick={togglePreview}
-              aria-label={translate('View transcript')}
-            >
-              {transcriptPreview?.expanded && transcriptPreview.fileId === pendingFile._id ? (
-                <UpOutlined />
-              ) : (
-                <DownOutlined />
-              )}
-              <span>{translate('Transcript')}</span>
-            </button>
-          </>
-        );
-      case 'failed':
-        return (
-          <>
-            <ExclamationCircleFilled style={{ color: '#ff4d4f' }} />
-            <span className="askola-pending-file-status">
-              {translate('Failed')}: {pendingFile.error || translate('unknown error')}
-            </span>
-          </>
-        );
-      default:
-        return null;
-    }
-  };
+  const plusMenuItems = [
+    {
+      icon: <PaperClipOutlined />,
+      label: translate('Upload photos & files'),
+      onClick: () => fileInputRef.current?.click(),
+    },
+  ];
 
   return (
     <div className="askola-chat-input-bar">
@@ -427,36 +84,21 @@ export default function ChatInput({ onSend, onTranscriptionComplete, disabled = 
         onChange={handleFilePicked}
       />
       {pendingFile && (
-        <>
-          <div className={`askola-pending-file-chip askola-pending-file-chip--${pendingFile.state}`}>
-            <PaperClipOutlined className="askola-pending-file-icon" />
-            <span className="askola-pending-file-name">{pendingFile.originalName}</span>
-            {renderChipStatus()}
-            <button
-              type="button"
-              className="askola-pending-file-remove"
-              onClick={removePendingFile}
-              aria-label={translate('Remove file')}
-            >
-              <CloseOutlined />
-            </button>
-          </div>
-          {transcriptPreview &&
-            transcriptPreview.fileId === pendingFile._id &&
-            transcriptPreview.expanded && (
-              <div className="askola-pending-file-transcript-preview">
-                {transcriptPreview.loading ? (
-                  <span>{translate('Loading transcript...')}</span>
-                ) : transcriptPreview.error ? (
-                  <span style={{ color: '#ff4d4f' }}>
-                    {translate('Cannot load transcript')}: {transcriptPreview.error}
-                  </span>
-                ) : (
-                  <pre className="askola-transcript-pre">{transcriptPreview.text}</pre>
-                )}
-              </div>
-            )}
-        </>
+        <div className="askola-pending-file-chip">
+          <PaperClipOutlined className="askola-pending-file-icon" />
+          <span className="askola-pending-file-name">{pendingFile.name}</span>
+          <span className="askola-pending-file-status">
+            {(pendingFile.size / 1024 / 1024).toFixed(1)} MB
+          </span>
+          <button
+            type="button"
+            className="askola-pending-file-remove"
+            onClick={() => setPendingFile(null)}
+            aria-label={translate('Remove file')}
+          >
+            <CloseOutlined />
+          </button>
+        </div>
       )}
       <Input.TextArea
         className="askola-chat-input"

--- a/frontend/src/components/AskOla/__tests__/ChatInput.uploadOnSend.test.jsx
+++ b/frontend/src/components/AskOla/__tests__/ChatInput.uploadOnSend.test.jsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+//
+// ChatInput — Upload-on-Send architecture (Issue #387 patch 2)
+//
+// Guards the core invariant: attaching a file must NOT trigger any network
+// request. Upload + transcription happen only after the user clicks Send
+// (delegated to AskOla.handleSend).
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+vi.mock('@/locale/useLanguage', () => ({
+  default: () => (key) => key,
+}));
+
+// Replace antd Input.TextArea with a plain React textarea.
+// This isolates ChatInput's own logic from antd's internal event handling
+// (rc-textarea keeps its own value cache that defeats fireEvent in jsdom).
+vi.mock('antd', async () => {
+  const actual = await vi.importActual('antd');
+  const React = await import('react');
+  return {
+    ...actual,
+    Input: {
+      ...actual.Input,
+      TextArea: React.forwardRef(
+        ({ value, onChange, onKeyDown, disabled, placeholder, className }, ref) =>
+          React.createElement('textarea', {
+            ref,
+            value,
+            onChange,
+            onKeyDown,
+            disabled,
+            placeholder,
+            className,
+          }),
+      ),
+    },
+  };
+});
+
+import ChatInput from '../ChatInput';
+
+const makeFile = (name = 'call.mp3', type = 'audio/mpeg') =>
+  new File(['audio-data'], name, { type });
+
+const renderInput = (props = {}) =>
+  render(<ChatInput onSend={vi.fn()} {...props} />);
+
+const pickFile = (file) => {
+  const fileInput = document.querySelector('input[type="file"]');
+  Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
+  fireEvent.change(fileInput);
+};
+
+// With antd mocked to a plain <textarea>, fireEvent.change correctly updates
+// React controlled state via the standard onChange pathway.
+const typeIntoTextarea = (value) =>
+  fireEvent.change(document.querySelector('textarea'), { target: { value } });
+
+const getSendBtn = () => document.querySelector('.askola-chat-send-btn');
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ── Core invariant ─────────────────────────────────────────────────────────
+
+describe('ChatInput — file attach makes zero network requests', () => {
+  test('picking a file does NOT call fetch', () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    renderInput();
+    pickFile(makeFile());
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('chip appears with filename after pick', () => {
+    renderInput();
+    pickFile(makeFile('sales-call.mp3'));
+    expect(screen.getByText('sales-call.mp3')).toBeTruthy();
+  });
+
+  test('chip shows size in MB', () => {
+    renderInput();
+    const file = makeFile();
+    pickFile(file);
+    const sizeMb = (file.size / 1024 / 1024).toFixed(1);
+    expect(screen.getByText(`${sizeMb} MB`)).toBeTruthy();
+  });
+});
+
+// ── onSend payload ─────────────────────────────────────────────────────────
+
+describe('ChatInput — onSend payload shape', () => {
+  test('file-only send: onSend({ text: "", file })', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    const file = makeFile();
+    pickFile(file);
+    fireEvent.click(getSendBtn());
+    expect(onSend).toHaveBeenCalledOnce();
+    expect(onSend).toHaveBeenCalledWith({ text: '', file });
+  });
+
+  test('text-only send: onSend({ text: "hello", file: null })', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    typeIntoTextarea('hello');
+    fireEvent.click(getSendBtn());
+    expect(onSend).toHaveBeenCalledWith({ text: 'hello', file: null });
+  });
+
+  test('text + file send: onSend receives both', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    const file = makeFile();
+    pickFile(file);
+    typeIntoTextarea('analyze it');
+    fireEvent.click(getSendBtn());
+    expect(onSend).toHaveBeenCalledWith({ text: 'analyze it', file });
+  });
+
+  test('whitespace-only text is trimmed; sends empty string', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    const file = makeFile();
+    pickFile(file);
+    typeIntoTextarea('   ');
+    fireEvent.click(getSendBtn());
+    expect(onSend).toHaveBeenCalledWith({ text: '', file });
+  });
+});
+
+// ── sendDisabled guard ─────────────────────────────────────────────────────
+
+describe('ChatInput — send gate', () => {
+  test('no text + no file: send is blocked', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    fireEvent.click(getSendBtn());
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test('no text + no file: send button is disabled', () => {
+    renderInput();
+    expect(getSendBtn().disabled).toBe(true);
+  });
+
+  test('file attached + no text: send button is enabled', () => {
+    renderInput();
+    pickFile(makeFile());
+    expect(getSendBtn().disabled).toBe(false);
+  });
+
+  test('disabled=true blocks send even with text', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend, disabled: true });
+    typeIntoTextarea('hello');
+    fireEvent.click(getSendBtn());
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test('Shift+Enter does NOT send', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    typeIntoTextarea('hello');
+    fireEvent.keyDown(document.querySelector('textarea'), { key: 'Enter', shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+// ── State reset after send ─────────────────────────────────────────────────
+
+describe('ChatInput — state clears after send', () => {
+  test('file chip disappears after send', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    pickFile(makeFile('call.mp3'));
+    fireEvent.click(getSendBtn());
+    expect(screen.queryByText('call.mp3')).toBeNull();
+  });
+
+  test('textarea value cleared after send', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    const ta = document.querySelector('textarea');
+    typeIntoTextarea('hello');
+    fireEvent.click(getSendBtn());
+    expect(ta.value).toBe('');
+  });
+});
+
+// ── Remove button ──────────────────────────────────────────────────────────
+
+describe('ChatInput — remove file button', () => {
+  test('clicking X hides the chip', () => {
+    renderInput();
+    pickFile(makeFile('call.mp3'));
+    fireEvent.click(screen.getByLabelText('Remove file'));
+    expect(screen.queryByText('call.mp3')).toBeNull();
+  });
+
+  test('after removing, send with no text is blocked again', () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    pickFile(makeFile());
+    fireEvent.click(screen.getByLabelText('Remove file'));
+    fireEvent.click(getSendBtn());
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test('picking a second file replaces the first', () => {
+    renderInput();
+    pickFile(makeFile('first.mp3'));
+    expect(screen.getByText('first.mp3')).toBeTruthy();
+    pickFile(makeFile('second.mp3'));
+    expect(screen.queryByText('first.mp3')).toBeNull();
+    expect(screen.getByText('second.mp3')).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/AskOla.jsx
+++ b/frontend/src/pages/AskOla.jsx
@@ -218,37 +218,30 @@ export default function AskOla() {
   };
 
   // Poll /api/job/read/:id until the transcription job reaches a terminal state.
-  // Resolves on 'done', throws on 'failed', auth error, or 10-min timeout.
-  // Uses request.read so JWT-expiry redirects and error notifications are handled
-  // by the shared axios layer — no silent swallowing of non-transient failures.
-  //
-  // Every throw here sets err.alreadyNotified = true so handleSend's catch
-  // skips the generic "Cannot connect to Ola" second notification.
+  // Resolves on 'done'. Throws (with a specific notification already shown) on
+  // job failure or 10-min timeout. On request error, request.read's errorHandler
+  // has already shown a notification — this just throws to stop the loop.
+  // Caller must wrap this in its own try/catch and never re-notify on failure.
   const _pollUntilDone = async (jobId, signal) => {
-    const tagged = (msg) => {
-      const err = new Error(msg);
-      err.alreadyNotified = true;
-      return err;
-    };
     const startTs = Date.now();
     while (!signal.aborted) {
       if (Date.now() - startTs > 10 * 60 * 1000) {
         const msg = translate('Transcription timed out (10 min). Try a shorter recording.');
         notification.error({ message: translate('Transcription timed out'), description: msg });
-        throw tagged(msg);
+        throw new Error(msg);
       }
       const json = await request.read({ entity: 'job', id: jobId });
       if (signal.aborted) return;
       if (!json?.success) {
         // request.read already showed error notification via errorHandler.
-        throw tagged(json?.message || translate('Transcription status check failed'));
+        throw new Error(json?.message || translate('Transcription status check failed'));
       }
       const { status, error } = json.result ?? {};
       if (status === 'done') return;
       if (status === 'failed') {
         const msg = error || translate('Transcription failed');
         notification.error({ message: translate('Transcription failed'), description: msg });
-        throw tagged(msg);
+        throw new Error(msg);
       }
       await new Promise((r) => setTimeout(r, 3000));
     }
@@ -287,9 +280,15 @@ export default function AskOla() {
           return;
         }
         // Dedup hit: transcription already done. Fresh upload: poll until done.
+        // _pollUntilDone handles its own notifications — wrap in a dedicated
+        // catch so poll errors never reach the outer "Cannot connect to Ola" handler.
         if (!result.deduped && result.transcriptionJobId) {
           setLiveLabel(translate('Transcribing...'));
-          await _pollUntilDone(result.transcriptionJobId, ac.signal);
+          try {
+            await _pollUntilDone(result.transcriptionJobId, ac.signal);
+          } catch {
+            return;
+          }
           if (ac.signal.aborted) return;
         }
       }
@@ -317,7 +316,7 @@ export default function AskOla() {
       await _doChat(body);
 
     } catch (err) {
-      if (err.name === 'AbortError' || err.alreadyNotified) return;
+      if (err.name === 'AbortError') return;
       notification.error({
         message: translate('Cannot connect to Ola'),
         description: err.message || translate('Please verify backend and NanoBot are running'),

--- a/frontend/src/pages/AskOla.jsx
+++ b/frontend/src/pages/AskOla.jsx
@@ -108,41 +108,6 @@ export default function AskOla() {
     setMessages([]);
   };
 
-  // Fired by ChatInput when an attached file finishes transcription
-  // (or hits dedup — already-transcribed). If Ola is idle, silently
-  // auto-triggers agent analysis (no user bubble). If busy, falls back to
-  // a system notification so the user knows to ask again when Ola is free.
-  const handleTranscriptionComplete = ({ fileId, originalName, durationMs, sidecarBytes, deduped }) => {
-    if (!loading) {
-      // Auto-trigger: agent receives [auto-analyze] + fileId with status="done"
-      // and replies with the sugar. No user bubble shown (issue #387).
-      handleAutoAnalyze(fileId);
-      return;
-    }
-    // Fallback: Ola is busy — show notification so user knows transcript is ready.
-    const seconds = durationMs ? Math.round(durationMs / 1000) : null;
-    const sizeKb = sidecarBytes ? (sidecarBytes / 1024).toFixed(1) : null;
-    const detail = [
-      seconds !== null ? `${seconds}s` : null,
-      sizeKb !== null ? `${sizeKb}KB transcript` : null,
-    ].filter(Boolean).join(' · ');
-    const text = deduped
-      ? translate('Recording "{name}" already transcribed (reused from earlier upload). You can ask me about it now.')
-          .replace('{name}', originalName)
-      : translate('Recording "{name}" transcription complete{detail}. You can ask me about it now.')
-          .replace('{name}', originalName)
-          .replace('{detail}', detail ? ` (${detail})` : '');
-    setMessages((prev) => [
-      ...prev,
-      {
-        id: `msg_system_${fileId}_${Date.now()}`,
-        role: 'system',
-        timestamp: new Date().toISOString(),
-        blocks: [{ type: 'text', content: text }],
-      },
-    ]);
-  };
-
   // Shared SSE chat helper. Manages abort, loading state, streaming UI, and
   // assistant-message commit. Callers are responsible for adding any user
   // bubble to `messages` before calling — this function never touches the user
@@ -252,27 +217,114 @@ export default function AskOla() {
     }
   };
 
-  const handleSend = async (messageContent) => {
-    const text = messageContent.text;
-    const fileIds = Array.isArray(messageContent.attachments) ? messageContent.attachments : [];
-
-    const userMessage = {
-      id: `msg_user_${Date.now()}`,
-      role: 'user',
-      timestamp: new Date().toISOString(),
-      blocks: [{ type: 'text', content: text }],
-    };
-    setMessages((prev) => [...prev, userMessage]);
-
-    const body = { message: text };
-    if (fileIds.length > 0) body.fileIds = fileIds;
-    await _doChat(body);
+  // Poll /api/job/read/:id until the transcription job reaches a terminal state.
+  // Resolves on 'done', throws on 'failed' or 10-min timeout.
+  const _pollUntilDone = async (jobId, signal) => {
+    const startTs = Date.now();
+    while (!signal.aborted) {
+      if (Date.now() - startTs > 10 * 60 * 1000) {
+        throw new Error(translate('Transcription timed out (10 min). Try a shorter recording.'));
+      }
+      let json;
+      try {
+        const resp = await fetch(`/api/job/read/${jobId}`, { credentials: 'include' });
+        json = await resp.json();
+        if (!resp.ok || !json.success) {
+          await new Promise((r) => setTimeout(r, 3000));
+          continue;
+        }
+      } catch {
+        await new Promise((r) => setTimeout(r, 3000));
+        continue;
+      }
+      const { status, error } = json.result ?? {};
+      if (status === 'done') return;
+      if (status === 'failed') throw new Error(error || translate('Transcription failed'));
+      await new Promise((r) => setTimeout(r, 3000));
+    }
   };
 
-  // Silent auto-trigger fired when a file finishes transcription and Ola is
-  // idle. No user bubble — SOUL.md recognises '[auto-analyze]' and gives the
-  // sugar without surfacing the marker to the salesperson (issue #387).
-  const handleAutoAnalyze = (fileId) => _doChat({ message: '[auto-analyze]', fileIds: [fileId] });
+  // Handles text-only, text+file, and file-only (auto-analyze) sends.
+  // Upload + transcription happen here, after the user clicks Send — never at attach time.
+  const handleSend = async ({ text, file }) => {
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setLoading(true);
+    setStreamingText('');
+
+    try {
+      let fileId = null;
+
+      if (file) {
+        setLiveLabel(translate('Uploading file...'));
+        const formData = new FormData();
+        formData.append('file', file);
+        const uploadResp = await fetch('/api/file/create', {
+          method: 'POST',
+          credentials: 'include',
+          body: formData,
+          signal: ac.signal,
+        });
+        if (ac.signal.aborted) return;
+        const uploadJson = await uploadResp.json();
+        if (!uploadResp.ok || !uploadJson.success) {
+          notification.error({
+            message: translate('File upload failed'),
+            description: uploadJson?.message || `HTTP ${uploadResp.status}`,
+          });
+          return;
+        }
+        const result = uploadJson.result;
+        fileId = result._id;
+        // Dedup hit: transcription already done. Fresh upload: poll until done.
+        if (!result.deduped && result.transcriptionJobId) {
+          setLiveLabel(translate('Transcribing...'));
+          await _pollUntilDone(result.transcriptionJobId, ac.signal);
+          if (ac.signal.aborted) return;
+        }
+      }
+
+      // Add user bubble only when the salesperson typed a message.
+      // File-only send (auto-analyze) produces no user bubble by design.
+      if (text) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `msg_user_${Date.now()}`,
+            role: 'user',
+            timestamp: new Date().toISOString(),
+            blocks: [{ type: 'text', content: text }],
+          },
+        ]);
+      }
+
+      const body = text
+        ? { message: text, ...(fileId ? { fileIds: [fileId] } : {}) }
+        : { message: '[auto-analyze]', fileIds: [fileId] };
+
+      // _doChat aborts ac (upload/transcription already done) and creates its
+      // own AbortController for the SSE stream, taking over abortRef.current.
+      await _doChat(body);
+
+    } catch (err) {
+      if (err.name === 'AbortError' || ac.signal.aborted) return;
+      notification.error({
+        message: translate('Cannot connect to Ola'),
+        description: err.message || translate('Please verify backend and NanoBot are running'),
+      });
+    } finally {
+      // Clean up only if _doChat was never reached — it replaces abortRef.current
+      // with its own controller and handles its own finally cleanup.
+      if (abortRef.current === ac) {
+        abortRef.current = null;
+        setLoading(false);
+        setLiveLabel(null);
+        setStreamingText('');
+      }
+    }
+  };
 
   const isEmpty = messages.length === 0;
 
@@ -297,7 +349,6 @@ export default function AskOla() {
           <div className="askola-chat-input-wrapper">
             <ChatInput
               onSend={handleSend}
-              onTranscriptionComplete={handleTranscriptionComplete}
               disabled={loading}
             />
           </div>
@@ -326,7 +377,6 @@ export default function AskOla() {
           <div className="askola-chat-input-wrapper">
             <ChatInput
               onSend={handleSend}
-              onTranscriptionComplete={handleTranscriptionComplete}
               disabled={loading}
             />
           </div>

--- a/frontend/src/pages/AskOla.jsx
+++ b/frontend/src/pages/AskOla.jsx
@@ -221,22 +221,35 @@ export default function AskOla() {
   // Resolves on 'done', throws on 'failed', auth error, or 10-min timeout.
   // Uses request.read so JWT-expiry redirects and error notifications are handled
   // by the shared axios layer — no silent swallowing of non-transient failures.
+  //
+  // Every throw here sets err.alreadyNotified = true so handleSend's catch
+  // skips the generic "Cannot connect to Ola" second notification.
   const _pollUntilDone = async (jobId, signal) => {
+    const tagged = (msg) => {
+      const err = new Error(msg);
+      err.alreadyNotified = true;
+      return err;
+    };
     const startTs = Date.now();
     while (!signal.aborted) {
       if (Date.now() - startTs > 10 * 60 * 1000) {
-        throw new Error(translate('Transcription timed out (10 min). Try a shorter recording.'));
+        const msg = translate('Transcription timed out (10 min). Try a shorter recording.');
+        notification.error({ message: translate('Transcription timed out'), description: msg });
+        throw tagged(msg);
       }
       const json = await request.read({ entity: 'job', id: jobId });
       if (signal.aborted) return;
       if (!json?.success) {
-        // request.read already showed an error notification via errorHandler.
-        // Stop looping — a non-success response is not a transient blip.
-        throw new Error(json?.message || translate('Transcription status check failed'));
+        // request.read already showed error notification via errorHandler.
+        throw tagged(json?.message || translate('Transcription status check failed'));
       }
       const { status, error } = json.result ?? {};
       if (status === 'done') return;
-      if (status === 'failed') throw new Error(error || translate('Transcription failed'));
+      if (status === 'failed') {
+        const msg = error || translate('Transcription failed');
+        notification.error({ message: translate('Transcription failed'), description: msg });
+        throw tagged(msg);
+      }
       await new Promise((r) => setTimeout(r, 3000));
     }
   };
@@ -304,7 +317,7 @@ export default function AskOla() {
       await _doChat(body);
 
     } catch (err) {
-      if (err.name === 'AbortError') return;
+      if (err.name === 'AbortError' || err.alreadyNotified) return;
       notification.error({
         message: translate('Cannot connect to Ola'),
         description: err.message || translate('Please verify backend and NanoBot are running'),

--- a/frontend/src/pages/AskOla.jsx
+++ b/frontend/src/pages/AskOla.jsx
@@ -218,24 +218,21 @@ export default function AskOla() {
   };
 
   // Poll /api/job/read/:id until the transcription job reaches a terminal state.
-  // Resolves on 'done', throws on 'failed' or 10-min timeout.
+  // Resolves on 'done', throws on 'failed', auth error, or 10-min timeout.
+  // Uses request.read so JWT-expiry redirects and error notifications are handled
+  // by the shared axios layer — no silent swallowing of non-transient failures.
   const _pollUntilDone = async (jobId, signal) => {
     const startTs = Date.now();
     while (!signal.aborted) {
       if (Date.now() - startTs > 10 * 60 * 1000) {
         throw new Error(translate('Transcription timed out (10 min). Try a shorter recording.'));
       }
-      let json;
-      try {
-        const resp = await fetch(`/api/job/read/${jobId}`, { credentials: 'include' });
-        json = await resp.json();
-        if (!resp.ok || !json.success) {
-          await new Promise((r) => setTimeout(r, 3000));
-          continue;
-        }
-      } catch {
-        await new Promise((r) => setTimeout(r, 3000));
-        continue;
+      const json = await request.read({ entity: 'job', id: jobId });
+      if (signal.aborted) return;
+      if (!json?.success) {
+        // request.read already showed an error notification via errorHandler.
+        // Stop looping — a non-success response is not a transient blip.
+        throw new Error(json?.message || translate('Transcription status check failed'));
       }
       const { status, error } = json.result ?? {};
       if (status === 'done') return;
@@ -261,23 +258,21 @@ export default function AskOla() {
         setLiveLabel(translate('Uploading file...'));
         const formData = new FormData();
         formData.append('file', file);
-        const uploadResp = await fetch('/api/file/create', {
-          method: 'POST',
-          credentials: 'include',
-          body: formData,
-          signal: ac.signal,
-        });
+        const uploadJson = await request.createAndUpload({ entity: 'file', jsonData: formData });
         if (ac.signal.aborted) return;
-        const uploadJson = await uploadResp.json();
-        if (!uploadResp.ok || !uploadJson.success) {
-          notification.error({
-            message: translate('File upload failed'),
-            description: uploadJson?.message || `HTTP ${uploadResp.status}`,
-          });
+        if (!uploadJson?.success) {
+          // request.createAndUpload already showed error notification via errorHandler.
           return;
         }
         const result = uploadJson.result;
         fileId = result._id;
+        if (!fileId) {
+          notification.error({
+            message: translate('File upload failed'),
+            description: translate('Server response missing file ID'),
+          });
+          return;
+        }
         // Dedup hit: transcription already done. Fresh upload: poll until done.
         if (!result.deduped && result.transcriptionJobId) {
           setLiveLabel(translate('Transcribing...'));
@@ -302,14 +297,14 @@ export default function AskOla() {
 
       const body = text
         ? { message: text, ...(fileId ? { fileIds: [fileId] } : {}) }
-        : { message: '[auto-analyze]', fileIds: [fileId] };
+        : { message: '[auto-analyze]', ...(fileId ? { fileIds: [fileId] } : {}) };
 
       // _doChat aborts ac (upload/transcription already done) and creates its
       // own AbortController for the SSE stream, taking over abortRef.current.
       await _doChat(body);
 
     } catch (err) {
-      if (err.name === 'AbortError' || ac.signal.aborted) return;
+      if (err.name === 'AbortError') return;
       notification.error({
         message: translate('Cannot connect to Ola'),
         description: err.message || translate('Please verify backend and NanoBot are running'),

--- a/ola/nanobot-workspace/SOUL.md
+++ b/ola/nanobot-workspace/SOUL.md
@@ -228,13 +228,10 @@ For each `id=X` in the hint, my decision tree:
    waste a tool call). I tell the salesperson the file is still being
    transcribed (usually 1–2 minutes) and that the analysis will start
    automatically once it is ready. I don't loop-retry.
-1. If `status="done"` → **before** calling `file.get_transcript`, I
-   output one brief status line as the very first text of my reply:
-   `[zh]` "读取中，请稍候。" / `[en]` "Reading transcript, one moment."
-   This ensures the salesperson sees immediate confirmation rather than
-   a blank screen. Then I call `file.get_transcript({ fileId: X })`.
+1. If `status="done"` → call `file.get_transcript({ fileId: X })` directly.
    The returned `transcript` field is authoritative — it was written by
-   the backend's transcription microservice.
+   the backend's transcription microservice. (The UI already showed
+   progress while transcribing; I do not need to output a status line.)
    - If the user asked a specific question → answer it from the transcript.
    - If the user's message is vague or empty → give the **sugar**
      (see "Web UI file uploads — the sugar for recordings" below).


### PR DESCRIPTION
## 背景

PR #390 合并后在 staging 发现 3 个 bug，触发 revert PR #391。本 PR 是修复后的重新提交，合并后可关闭 #391。

## Bug 修复

| Bug | 根因 | 修复 |
|---|---|---|
| B1 (P0) attach 即刻 upload/transcribe | `handleFilePicked` 直接发 fetch | `pendingFile` 改为 raw `File\|null`，upload 推迟到 Send |
| B2 (P1) "Reading transcript" 出现两次 | SOUL.md 让 agent 在调 `file.get_transcript` 前先输出状态文字，然后 continuation 又输出一次 | 移除 SOUL.md 该指令 |
| B3 (P1) 状态文字和分析整段跳出 | nanobot 在 tool call 期间 buffer SSE tokens，B2 的文字和分析一起 flush | B2 修复后 agent 只生成分析文字，正常流式 |

## 改动内容

- **ChatInput.jsx** (517→104 行)：剥离全部 upload/transcription 逻辑；`onSend({ text, file: File|null })` 接口；chip 只显示 filename + size
- **AskOla.jsx**：`handleSend` 接管完整流程 — upload → `_pollUntilDone` 轮询 → `_doChat` SSE；ThinkingPanel 依次显示 "Uploading file…" → "Transcribing…" → "Ola is thinking…"
- **SOUL.md**：移除"先输出 Reading transcript"规则；确认 WhatsApp `[语音消息转写]` 规则完整无需改动

## 测试

- [x] `npx vitest run` — 99/99 passed（新增 17-case ChatInput.uploadOnSend 套件）
- [x] `cd frontend && npx vite build` — 0 error
- [x] ESLint 0 warning
- [x] Self-check grep — 无残留 `handleTranscriptionComplete` / `handleAutoAnalyze` / `onTranscriptionComplete`

## 验收标准（staging 测试）

1. attach 文件 → DevTools Network tab 无 `/api/file/create` 请求
2. 点 Send → ThinkingPanel 依次显示 Uploading… → Transcribing… → Ola is thinking…
3. 无文字 + 有文件 → 无 user bubble，agent 直接分析
4. 有文字 + 有文件 → user bubble 出现，agent 正常回复
5. agent 回复无 "Reading transcript" 前缀，正常流式

Closes #391
Refs #387 #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)