### PR TITLE
fix(cd): resolve job needs environment:production for STAGING_HOST/USER + BOX1 secrets

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 5
     env:
       INPUT_CRM_SHA: ${{ inputs.crm_sha }}


### PR DESCRIPTION
## Summary
The auto-resolve-from-staging-last-green `resolve` job (added alongside the `push: [main]` trigger on `deploy-production.yml`) references `secrets.STAGING_HOST`/`secrets.STAGING_USER` (to SSH into Box 6) and `secrets.PRODUCTION_BOX1_HOST`/`secrets.PRODUCTION_BOX1_USER` (to check whether the pair is already live) — all GitHub Environment secrets. A job with no `environment:` declaration can't read environment-scoped secrets, so both resolved to empty strings and the SSH call failed immediately (`ssh -i ~/.ssh/deploy_key "@"`, exit 255).

`production` already has `STAGING_HOST`/`STAGING_USER` duplicated into it alongside `PRODUCTION_SSH_KEY`/`DEPLOY_SSH_KNOWN_HOSTS`/`PRODUCTION_BOX1_HOST`/`USER` — everything this job's existing SSH step needs (it already uses the production deploy key for both the Box6 read and the Box1 read). One line: `environment: production` on the `resolve` job.

Discovered live: the first push-to-main promotion after this workflow version merged (PR #396, run [28672482143](https://github.com/SeekMi-Technologies/Ola/actions/runs/28672482143)) failed at `resolve` with blank `STAGING_HOST`/`STAGING_USER`. `promote` never ran — no production impact.

## Test plan
- [ ] Merge to `dev`, then promote to `main`
- [ ] Confirm the next push-to-main run's `resolve` job successfully SSHes to Box 6, resolves the SHA pair, and pauses at the `production` environment approval gate (not a second one — `resolve` and `promote` share the `production` environment in the same run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)