### PR TITLE
promote: dev → main (CD fix — resolve job environment scoping)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 5
     env:
       INPUT_CRM_SHA: ${{ inputs.crm_sha }}


### PR DESCRIPTION
## Summary
Follow-up promote to #396. Carries exactly one new commit: the fix for the `resolve` job in `deploy-production.yml` that blocked the first auto-triggered production promotion (missing `environment: production`, so `STAGING_HOST`/`STAGING_USER` resolved empty — see #397 for the full root-cause writeup and run 28672482143 for the failure).

Merging this will push to `main` and auto-trigger Promote Production again. Expected this time: `resolve` successfully SSHes to staging, resolves the CRM/nanobot SHA pair, and `promote` pauses at the `production` environment's required-reviewer approval — same single gate as before.

## Test plan
- [x] CI / Smoke E2E / Build & Push green on `dev` tip (3951f5b)
- [ ] Confirm the auto-triggered run reaches the production approval gate (not another resolve failure)
- [ ] Yuandong approves → Box1+Box2 deploy → verify per the original persona-fix acceptance checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)